### PR TITLE
[WIP] Cache the ordered dict_ in Add

### DIFF
--- a/src/add.cpp
+++ b/src/add.cpp
@@ -63,8 +63,7 @@ std::size_t Add::__hash__() const
 {
     std::size_t seed = 0;
     hash_combine<Basic>(seed, *coef_);
-    map_basic_int ordered(dict_.begin(), dict_.end());
-    for (auto &p: ordered) {
+    for (auto &p: get_ordered_dict()) {
         hash_combine<Basic>(seed, *(p.first));
         hash_combine<Basic>(seed, *(p.second));
     }
@@ -95,11 +94,7 @@ int Add::compare(const Basic &o) const
         return cmp;
 
     // Compare dictionaries:
-    // NOTE: This is slow. Add should cache this map_basic_int representation
-    // once it is computed.
-    map_basic_int adict(dict_.begin(), dict_.end());
-    map_basic_int bdict(s.dict_.begin(), s.dict_.end());
-    return map_basic_int_compare(adict, bdict);
+    return map_basic_int_compare(get_ordered_dict(), s.get_ordered_dict());
 }
 
 std::string Add::__str__() const

--- a/src/add.h
+++ b/src/add.h
@@ -11,6 +11,9 @@ public: // TODO: make this private
     Teuchos::RCP<Number> coef_; // The coefficient (e.g. "2" in 2+x+y)
     umap_basic_int dict_; // the dictionary of the rest (e.g. "x+y" in 2+x+y)
 
+    // This is calculated from dict_ only when needed:
+    mutable map_basic_int ordered_dict_;
+
 public:
     // Constructs Add from a dictionary by copying the contents of the
     // dictionary:
@@ -28,6 +31,12 @@ public:
             const umap_basic_int& dict);
 
     virtual Teuchos::RCP<Basic> diff(const Teuchos::RCP<Symbol> &x) const;
+
+    inline const map_basic_int& get_ordered_dict() const {
+        if (ordered_dict_.size() == 0)
+            ordered_dict_ = map_basic_int(dict_.begin(), dict_.end());
+        return ordered_dict_;
+    }
 };
 
 Teuchos::RCP<Basic> add(const Teuchos::RCP<Basic> &a,


### PR DESCRIPTION
This would seem like the right improvement, but it actually gets things slower.
Before:

```
$ ./expand2
Expanding: ((y + x + z + w)^15 + w)*(y + x + z + w)^15
1518ms
```

After:

```
$ ./expand2 
Expanding: ((y + x + z + w)^15 + w)*(y + x + z + w)^15
1548ms
number of terms: 6272
```

Not sure why.
