### PR TITLE
Fix failing test in test_arit.

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -232,12 +232,7 @@ RCP<Basic> pow_expand(const RCP<Pow> &self)
                                 rcp_static_cast<Number>(
                                 rcp_static_cast<Integer>(base)->powint(*exp)));
                         } else if (is_a<Symbol>(*base)) {
-                            // If this ever fails:
-                            CSYMPY_ASSERT(d.find(base) == d.end())
-                            // Then we need to use
-                            //Mul::dict_add_term(d, exp, base);
-                            // Instead of:
-                            insert(d, base, exp);
+                            Mul::dict_add_term(d, exp, base);
                         } else {
                             RCP<Basic> exp2, t, tmp;
                             tmp = pow(base, exp);


### PR DESCRIPTION
Before this change:

```
$ ctest
Test project /home/jrioux/git/csympy
    Start 1: test_rcp
1/6 Test #1: test_rcp .........................   Passed    0.01 sec
    Start 2: test_basic
2/6 Test #2: test_basic .......................   Passed    0.02 sec
    Start 3: test_arit
3/6 Test #3: test_arit ........................***Exception: Other  0.48 sec
    Start 4: test_poly
4/6 Test #4: test_poly ........................   Passed    0.01 sec
    Start 5: test_functions
5/6 Test #5: test_functions ...................   Passed    0.02 sec
    Start 6: test_subs
6/6 Test #6: test_subs ........................   Passed    0.01 sec

83% tests passed, 1 tests failed out of 6

Total Test time (real) =   0.58 sec

The following tests FAILED:
      3 - test_arit (OTHER_FAULT)
Errors while running CTest
```

The log gave the failing test in test_arit:

```
3x^2 + 2x^3 + x^4 + 2x^5 + x^6
x^2 + 2x^3 + 3x^4 + 2x^5 + x^6
test_arit: /home/jrioux/git/csympy/src/tests/basic/test_arit.cpp:421: void test_expand2(): Assertion `eq(r1, r2)' failed.
```

Benchmarks gave:

```
$ for f in benchmarks/expand{1,2,2b,3}; do ./$f; done
Expanding: (y + z + w + x)^60
170ms
number of terms: 39711
Expanding: (y + z + w + x)^15*((y + z + w + x)^15 + w)
1743ms
number of terms: 6272
poly_mul start
poly_mul stop
135ms
number of terms: 6272
Expanding: (z^x + x^y + y^x)^100
44ms
number of terms: 5151
```

After this change:

```
$ ctest
Test project /home/jrioux/git/csympy
    Start 1: test_rcp
1/6 Test #1: test_rcp .........................   Passed    0.00 sec
    Start 2: test_basic
2/6 Test #2: test_basic .......................   Passed    0.01 sec
    Start 3: test_arit
3/6 Test #3: test_arit ........................   Passed    0.02 sec
    Start 4: test_poly
4/6 Test #4: test_poly ........................   Passed    0.01 sec
    Start 5: test_functions
5/6 Test #5: test_functions ...................   Passed    0.00 sec
    Start 6: test_subs
6/6 Test #6: test_subs ........................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =   0.06 sec
```

Benchmarks give:

```
$ for f in benchmarks/expand{1,2,2b,3}; do ./$f; done
Expanding: (y + z + w + x)^60
169ms
number of terms: 39711
Expanding: (y + z + w + x)^15*((y + z + w + x)^15 + w)
1837ms
number of terms: 6272
poly_mul start
poly_mul stop
135ms
number of terms: 6272
Expanding: (z^x + x^y + y^x)^100
44ms
number of terms: 5151
```
