### PR TITLE
Add two more implementations of monomial_mul()

### DIFF
--- a/src/monomials.cpp
+++ b/src/monomials.cpp
@@ -13,6 +13,10 @@ void monomial_mul(const vec_int &A, const vec_int &B, vec_int &C)
     }
 }
 
+/*
+// Other implementation of monomial_mul() are below. Those are slightly slower,
+// so they are commented out.
+
 // This is slightly slower than monomial_mul
 void monomial_mul2(const vec_int &A, const vec_int &B, vec_int &C)
 {
@@ -25,6 +29,6 @@ void monomial_mul3(const vec_int &A, const vec_int &B, vec_int &C)
     std::transform(A.begin(), A.end(), B.begin(), C.begin(),
         [] (int a, int b) { return a + b; });
 }
-
+*/
 
 } // CSymPy


### PR DESCRIPTION
The new implementation gets faster from:

```
ondrej@kittiwake:~/repos/csympy/benchmarks(master)$ ./expand2b 
poly_mul start
poly_mul stop
98ms
number of terms: 6272
```

to:

```
ondrej@kittiwake:~/repos/csympy/benchmarks(mul)$ ./expand2b
poly_mul start
poly_mul stop
93ms
number of terms: 6272
```

and it is also simpler.
