### PR TITLE
Fix a docs string

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -114,7 +114,7 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 };
 
-//! Canonicalize FunctionSymbol :
+//! Create a new FunctionSymbol instance:
 RCP<const Basic> function_symbol(std::string name,
         const RCP<const Basic> &arg);
 


### PR DESCRIPTION
@sushant-hiray, I think you added this description in 1d4994b0ba4d1ab12487e136a534510c5f96456e, let me know if you agree.

I looked at `sin` and `cos` in `functions.h`. Your comment is actually correct --- these functions do the canonicalization first, i.e. if you call `sin(0)` it returns 0 immediately, only creates an instance of `Sin` if it cannot be simplified. 

For FunctionSymbol, we just return FunctionSymbol, as there is not much that we can do.

Maybe we should leave your original comment.
