### PR TITLE
Rename class -> struct for few declarations

### DIFF
--- a/src/dict.h
+++ b/src/dict.h
@@ -15,10 +15,10 @@ namespace CSymPy {
 class Basic;
 class Number;
 class Integer;
-class RCPBasicHash;
-class RCPBasicKeyEq;
-class RCPBasicKeyLess;
-class RCPIntegerKeyLess;
+struct RCPBasicHash;
+struct RCPBasicKeyEq;
+struct RCPBasicKeyLess;
+struct RCPIntegerKeyLess;
 
 typedef std::unordered_map<RCP<const Basic>, RCP<const Number>,
         RCPBasicHash, RCPBasicKeyEq> umap_basic_int;


### PR DESCRIPTION
These are defined in basic.h as "struct", so we need to forward declare them as
"struct" too. This was triggered by clang warnings (gcc compiles without
warning).
