### PR TITLE
adding missing include to fix build using clang

### DIFF
--- a/src/csympy_rcp.h
+++ b/src/csympy_rcp.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <stdexcept>
+#include <string>
 
 #include "csympy_config.h"
 #include "csympy_assert.h"


### PR DESCRIPTION
It still does not work, because my system does not have link.h, but at least the rest compiles.
