### PR TITLE
Travis: Install cmake with apt-get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - BUILD_TYPE="Release" TEST_IN_TREE="yes" WITH_PYTHON="yes" WITH_CSYMPY_RCP="yes" WITH_ECM="yes"
 before_install:
   - sudo apt-get update
-  - sudo apt-get install libgmp-dev
+  - sudo apt-get install cmake libgmp-dev
   - if [[ "${WITH_BFD}" == "yes" ]]; then
         sudo apt-get install binutils-dev;
     fi


### PR DESCRIPTION
This is not needed for Travis, but it is needed for Shippable.
