### PR TITLE
Fix for #204: CSymPy printing error

### DIFF
--- a/src/tests/printing/test_printing.cpp
+++ b/src/tests/printing/test_printing.cpp
@@ -19,7 +19,7 @@ using CSymPy::add;
 
 void test_printing()
 {
-    RCP<const Basic> r;
+    RCP<const Basic> r, r1, r2;
 
     r = div(integer(12), pow(integer(196), div(integer(1), integer(2))));
     assert(r->__str__() == "3/49*196^(1/2)");


### PR DESCRIPTION
Fixed a newly identified bug. See [here](https://github.com/sympy/csympy/issues/204#issuecomment-46774428).
