### PR TITLE
Function 'fraction_free_LU' was declared twice

### DIFF
--- a/src/matrix.h
+++ b/src/matrix.h
@@ -98,9 +98,6 @@ public:
         DenseMatrix &B, std::vector<unsigned> &pivotlist);
     friend unsigned pivot(DenseMatrix &B, unsigned r, unsigned c);
 
-    // Matrix Decomposition
-    friend void fraction_free_LU(const DenseMatrix &A, DenseMatrix &L, DenseMatrix &U);
-
     // Ax = b
     friend void augment_dense(const DenseMatrix &A, const DenseMatrix &b,
         DenseMatrix &C);


### PR DESCRIPTION
This was triggering a compiler warning:

.../csympy/src/matrix.h:118:23: warning: ‘void CSymPy::fraction_free_LU(const CSymPy::DenseMatrix&, CSymPy::DenseMatrix&, CSymPy::DenseMatrix&)’ is already a friend of class ‘CSymPy::DenseMatrix’ [enabled by default]

So we just delete the duplicate declaration.

/cc @thilina
