### PR TITLE
Remove unused local typedef

### DIFF
--- a/src/teuchos/Teuchos_RCP.hpp
+++ b/src/teuchos/Teuchos_RCP.hpp
@@ -645,7 +645,6 @@ Teuchos::rcpWithInvertedObjOwnership(const RCP<T> &child,
   const RCP<ParentT> &parent)
 {
   using std::make_pair;
-  typedef std::pair<RCP<T>, RCP<ParentT> > Pair_t;
   return rcpWithEmbeddedObj(child.getRawPtr(), make_pair(child, parent), false);
 }
 


### PR DESCRIPTION
This fixes the following warning in gcc 4.8.2:

```
/home/ondrej/repos/csympy/src/teuchos/Teuchos_RCP.hpp: In function ‘Teuchos::RCP<T1> Teuchos::rcpWithInvertedObjOwnership(const Teuchos::RCP<T1>&, const Teuchos::RCP<T2>&)’:
/home/ondrej/repos/csympy/src/teuchos/Teuchos_RCP.hpp:648:44: warning: typedef ‘Pair_t’ locally defined but not used [-Wunused-local-typedefs]
   typedef std::pair<RCP<T>, RCP<ParentT> > Pair_t;
                                            ^
```
