### PR TITLE
Travis: Test Python in out of tree build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,13 @@ matrix:
     # These test the default Release build with other Python versions
     - python: 2.6
       env:
-        - TEST_IN_TREE="yes" WITH_PYTHON="yes"
+        - WITH_PYTHON="yes"
     - python: 3.2
       env:
-        - TEST_IN_TREE="yes" WITH_PYTHON="yes"
+        - WITH_PYTHON="yes"
     - python: 3.3
       env:
-        - TEST_IN_TREE="yes" WITH_PYTHON="yes"
+        - WITH_PYTHON="yes"
 before_install:
   - sudo apt-get update
   - sudo apt-get install cmake libgmp-dev


### PR DESCRIPTION
By default we should be using out of tree build, so we now test that by
default. The in tree build is only tested few times so that it works (both with
and without Python 2.7), but for all the Python versions, we just check the out
of tree build.
