### PR TITLE
Fix #234: Remove additional `*` when `coef_` is `-1`

### DIFF
--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -106,7 +106,7 @@ std::string Mul::__str__() const
         o << *coef_;
 
     auto p = dict_.begin();
-    if (is_a_Number(*(p->first))) o << "*";
+    if (is_a_Number(*(p->first)) && neq(coef_, minus_one)) o << "*";
 
     for (; p != dict_.end(); p++) {
         if (is_a<Add>(*(p->first))) o << "(";

--- a/src/tests/basic/test_basic.cpp
+++ b/src/tests/basic/test_basic.cpp
@@ -409,24 +409,6 @@ void test_compare()
     assert(r2->__cmp__(*r1) == -cmp);
 }
 
-
-void test_print_minus_one(){
-
-    RCP<const Basic> r1, r2;
-    RCP<const Integer> i = integer(-1);
-    RCP<const Symbol> x  = symbol("x");
-    RCP<const Symbol> y  = symbol("y");
-    
-    
-    r1 = mul(x, i);
-    r2 = mul(r1, y);
-    assert(r1->__str__() == "-x");
-    assert(r1->__str__() != "-1x");
-    assert(r2->__str__() == "-x*y");
-    assert(r2->__str__() != "-1x*y");
-}
-
-
 int main(int argc, char* argv[])
 {
     print_stack_on_segfault();
@@ -446,8 +428,6 @@ int main(int argc, char* argv[])
     test_diff();
 
     test_compare();
-
-    test_print_minus_one();
 
     return 0;
 }

--- a/src/tests/printing/test_printing.cpp
+++ b/src/tests/printing/test_printing.cpp
@@ -16,10 +16,15 @@ using CSymPy::integer;
 using CSymPy::print_stack_on_segfault;
 using CSymPy::symbol;
 using CSymPy::add;
+using CSymPy::Symbol;
+using CSymPy::Integer;
 
 void test_printing()
 {
     RCP<const Basic> r, r1, r2;
+    RCP<const Integer> i = integer(-1);
+    RCP<const Symbol> x  = symbol("x");
+    RCP<const Symbol> y  = symbol("y");
 
     r = div(integer(12), pow(integer(196), div(integer(1), integer(2))));
     assert(r->__str__() == "3/49*196^(1/2)");
@@ -38,6 +43,16 @@ void test_printing()
     r2 = mul(integer(294), pow(integer(196), div(integer(-1), integer(2))));
     r = add(integer(-51), mul(r1, r2));
     assert(r->__str__() == "-33");
+
+    r1 = mul(x, i);
+    r2 = mul(r1, y);
+    assert(r1->__str__() == "-x");
+    assert(r1->__str__() != "-1x");
+    assert(r2->__str__() == "-x*y");
+    assert(r2->__str__() != "-1x*y");
+
+    r = mul(integer(-1), pow(integer(196), div(integer(1), integer(2))));
+    assert(r->__str__() == "-196^(1/2)");
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Fix for #234.
