### PR TITLE
Removed redundant `throw 10` line from csympy_assert.h

### DIFF
--- a/src/csympy_assert.h
+++ b/src/csympy_assert.h
@@ -16,7 +16,6 @@ try \
 { \
 expression; \
 CSYMPY_ERROR("expected exception not thrown");\
-throw 10; \
 } \
 catch(exception &) \
 { \


### PR DESCRIPTION
This is in continuation with #241 
