### PR TITLE
CMake: include our headers first

### DIFF
--- a/csympy/lib/CMakeLists.txt
+++ b/csympy/lib/CMakeLists.txt
@@ -3,8 +3,8 @@ set(SRC
     )
 
 include_directories(${PYTHON_INCLUDE_PATH})
-include_directories(${csympy_BINARY_DIR}/src ${teuchos_BINARY_DIR})
-include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(BEFORE ${csympy_BINARY_DIR}/src ${teuchos_BINARY_DIR})
+include_directories(BEFORE ${CMAKE_SOURCE_DIR}/src)
 
 cython_add_module_pyx(csympy_wrapper csympy.pxd)
 add_python_library(csympy_wrapper ${SRC})

--- a/src/teuchos/CMakeLists.txt
+++ b/src/teuchos/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # Configure Teuchos using our CMake options:
 configure_file(Teuchos_config.h.in Teuchos_config.h)
 # Include the config file:
-include_directories(${teuchos_BINARY_DIR})
+include_directories(BEFORE ${teuchos_BINARY_DIR})
 
 add_library(teuchos ${SRC})
 


### PR DESCRIPTION
This should have been part of PR #246. Now the Python wrappers compile fine
even if older csympy installation is present.
