### PR TITLE
Build fix: remove unknown definition

### DIFF
--- a/benchmarks/add1.cpp
+++ b/benchmarks/add1.cpp
@@ -16,7 +16,6 @@ using CSymPy::Add;
 using CSymPy::Mul;
 using CSymPy::Pow;
 using CSymPy::Symbol;
-using CSymPy::umap_basic_int;
 using CSymPy::map_vec_int;
 using CSymPy::integer;
 using CSymPy::multinomial_coefficients;


### PR DESCRIPTION
This was caused by merging #163. Since the PR was created and before we merged
it, we renamed umap_basic_int to umap_basic_num.
