### PR TITLE
Improve setup.py to pass along arguments to cmake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,79 @@
 from __future__ import print_function
 from distutils.core import setup
 from distutils.command.build import build as _build
+from distutils.command.install import install as _install
 import subprocess
 
+cmake_opts = [("WITH_PYTHON","yes")]
+
+def process_opts(opts):
+    return ['-D'+'='.join(o) for o in opts]
+
 def cmake_build():
-    if subprocess.call(["cmake", ".", "-DWITH_PYTHON=yes"]) != 0:
+    cmake_cmd = ["cmake", "."]
+    cmake_cmd.extend(process_opts(cmake_opts))
+    if subprocess.call(cmake_cmd) != 0:
         raise EnvironmentError("error calling cmake")
 
     if subprocess.call("make") != 0:
         raise EnvironmentError("error calling make")
 
 class BuildWithCmake(_build):
+    _build_opts = _build.user_options
+    user_options = [
+        ('define=', 'D',
+         'cmake <var>:<type>=<value>'),
+    ]
+    user_options.extend(_build_opts)
+
+    def initialize_options(self):
+        _build.initialize_options(self)
+        self.define = None
+
+    def finalize_options(self):
+        _build.finalize_options(self)
+        # The argument parsing will result in self.define being a string, but
+        # it has to be a list of 2-tuples.
+        # Multiple symbols can be separated with semi-colons.
+        if self.define:
+            defines = self.define.split(';')
+            self.define = [(s.strip(), None) if '=' not in s else
+                           tuple(ss.strip() for ss in s.split('='))
+                           for s in defines]
+            cmake_opts.extend(self.define)
+
     def run(self):
         cmake_build()
         # can't use super() here because _build is an old style class in 2.7
         _build.run(self)
+
+class InstallWithCmake(_install):
+    _install_opts = _install.user_options
+    user_options = [
+        ('define=', 'D',
+         'cmake <var>:<type>=<value>'),
+    ]
+    user_options.extend(_install_opts)
+
+    def initialize_options(self):
+        _install.initialize_options(self)
+        self.define = None
+
+    def finalize_options(self):
+        _install.finalize_options(self)
+        # The argument parsing will result in self.define being a string, but
+        # it has to be a list of 2-tuples.
+        # Multiple symbols can be separated with semi-colons.
+        if self.define:
+            defines = self.define.split(';')
+            self.define = [(s.strip(), None) if '=' not in s else
+                           tuple(ss.strip() for ss in s.split('='))
+                           for s in defines]
+            cmake_opts.extend(self.define)
+
+    def run(self):
+        # can't use super() here because _install is an old style class in 2.7
+        _install.run(self)
 
 long_description = '''
 CSymPy is a standalone fast C++ symbolic manipulation library.
@@ -33,5 +92,6 @@ setup(name = "csympy",
       package_data= {'' : ['lib/csympy_wrapper.so']},
       cmdclass={
           'build' : BuildWithCmake,
+          'install' : InstallWithCmake,
           }
   )


### PR DESCRIPTION
Add build/install flag --define which passes arguments to cmake

``` bash
python setup.py build --define="CMAKE_BUILD_TYPE:STRING='Debug'; \
WITH_BFD:BOOL=OFF; WITH_CSYMPY_ASSERT:BOOL=ON"
```

results in

``` bash
Configuration results
---------------------
C++ compiler: /usr/bin/c++
Build type: Debug
C++ compiler flags: -std=c++0x -Wall -Wextra -fPIC -g -Wno-unused-parameter -ggdb
Installation prefix: /usr/local
WITH_CSYMPY_ASSERT: ON
WITH_CSYMPY_RCP: yes
WITH_CSYMPY_THREAD_SAFE: no
GMP_INCLUDE_DIRS: /usr/include
GMP_LIBRARIES: /usr/lib64/libgmpxx.so;/usr/lib64/libgmp.so
WITH_BFD: OFF
WITH_PYTHON: yes
Python library: /home/ptb/miniconda3/lib/libpython3.4m.so
Python include path: /home/ptb/miniconda3/include/python3.4m
Python install path: /home/ptb/miniconda3/lib/python3.4/site-packages
Cython path: /home/ptb/miniconda3/bin/cython
WITH_ECM: no
WITH_PRIMESIEVE: no
...
```
