### PR TITLE
Use setuptools by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,31 @@
 from __future__ import print_function
-from distutils.core import setup
-from distutils.command.build import build as _build
-from distutils.command.install import install as _install
+from os import getenv
 import subprocess
+
+# use setuptools by default as per the official advice at:
+# packaging.python.org/en/latest/current.html#packaging-tool-recommendations
+use_setuptools = True
+# set the environment variable USE_DISTUTILS=True to force the use of distutils
+use_distutils = getenv('USE_DISTUTILS')
+if use_distutils is not None:
+    if use_distutils.lower() == 'true':
+        use_setuptools = False
+    else:
+        print("Value {} for USE_DISTUTILS treated as False".\
+              format(use_distutils))
+
+from distutils.command.build import build as _build
+
+if use_setuptools:
+    try:
+        from setuptools import setup
+        from setuptools.command.install import install as _install
+    except ImportError:
+        use_setuptools = False
+
+if not use_setuptools:
+    from distutils.core import setup
+    from distutils.command.install import install as _install
 
 cmake_opts = [("WITH_PYTHON","yes")]
 


### PR DESCRIPTION
By default, `pip` uses `setuptools`.  Thus, subclassing install from distutils, rather than setuptools can be problematic.
- On Master

``` bash
$ pip install .
Unpacking /home/ptb/gitrepos/csympy
  Running setup.py (path:/tmp/pip-68avzy37-build/setup.py) egg_info for package from file:///home/ptb/gitrepos/csympy

Installing collected packages: csympy
  Running setup.py install for csympy
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: -c --help [cmd1 cmd2 ...]
       or: -c --help-commands
       or: -c cmd --help

    error: option --single-version-externally-managed not recognized
    Complete output from command /home/ptb/miniconda3/bin/python3 -c "import setuptools, tokenize;__file__='/tmp/pip-68avzy37-build/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-ivxvrh2g-record/install-record.txt --single-version-externally-managed --compile:
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]

   or: -c --help [cmd1 cmd2 ...]

   or: -c --help-commands

   or: -c cmd --help



error: option --single-version-externally-managed not recognized

----------------------------------------
Cleaning up...
Command /home/ptb/miniconda3/bin/python3 -c "import setuptools, tokenize;__file__='/tmp/pip-68avzy37-build/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-ivxvrh2g-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip-68avzy37-build
Storing debug log for failure in /home/ptb/.pip/pip.log
```
- This PR

``` bash
$ pip install .
Unpacking /home/ptb/gitrepos/csympy
  Running setup.py (path:/tmp/pip-gn__oeaj-build/setup.py) egg_info for package from file:///home/ptb/gitrepos/csympy

Installing collected packages: csympy
  Running setup.py install for csympy
    -- The C compiler identification is GNU 4.8.3
    -- The CXX compiler identification is GNU 4.8.3
    -- Check for working C compiler: /usr/bin/cc
    -- Check for working C compiler: /usr/bin/cc -- works
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Check for working CXX compiler: /usr/bin/c++
    -- Check for working CXX compiler: /usr/bin/c++ -- works
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Found GMP: /usr/lib64/libgmpxx.so;/usr/lib64/libgmp.so
    -- Python version: 3.4
    -- Python install path: /home/ptb/miniconda3/lib/python3.4/site-packages
    -- Found PYTHON: /home/ptb/miniconda3/lib/libpython3.4m.so
    -- Found CYTHON: /home/ptb/miniconda3/bin/cython


    Configuration results
    ---------------------
    C++ compiler: /usr/bin/c++
    Build type: Release
    C++ compiler flags: -std=c++0x -Wall -Wextra -fPIC -O3 -march=native -ffast-math -funroll-loops -Wno-unused-parameter
    Installation prefix: /usr/local
    WITH_CSYMPY_ASSERT: no
    WITH_CSYMPY_RCP: yes
    WITH_CSYMPY_THREAD_SAFE: no
    GMP_INCLUDE_DIRS: /usr/include
    GMP_LIBRARIES: /usr/lib64/libgmpxx.so;/usr/lib64/libgmp.so
    WITH_BFD: no
    WITH_PYTHON: yes
    Python library: /home/ptb/miniconda3/lib/libpython3.4m.so
    Python include path: /home/ptb/miniconda3/include/python3.4m
    Python install path: /home/ptb/miniconda3/lib/python3.4/site-packages
    Cython path: /home/ptb/miniconda3/bin/cython
    WITH_ECM: no
    WITH_PRIMESIEVE: no
    WITH_ARB: no
    -- Configuring done
    -- Generating done
    -- Build files have been written to: /tmp/pip-gn__oeaj-build
    Scanning dependencies of target csympy
    [  2%] Building CXX object src/CMakeFiles/csympy.dir/csympy_rcp.cpp.o
    [  4%] Building CXX object src/CMakeFiles/csympy.dir/basic.cpp.o
    [  6%] Building CXX object src/CMakeFiles/csympy.dir/dict.cpp.o
    [  8%] Building CXX object src/CMakeFiles/csympy.dir/symbol.cpp.o
    [ 10%] Building CXX object src/CMakeFiles/csympy.dir/number.cpp.o
    [ 13%] Building CXX object src/CMakeFiles/csympy.dir/integer.cpp.o
    [ 15%] Building CXX object src/CMakeFiles/csympy.dir/rational.cpp.o
    [ 17%] Building CXX object src/CMakeFiles/csympy.dir/complex.cpp.o
    [ 19%] Building CXX object src/CMakeFiles/csympy.dir/constants.cpp.o
    [ 21%] Building CXX object src/CMakeFiles/csympy.dir/add.cpp.o
    [ 23%] Building CXX object src/CMakeFiles/csympy.dir/mul.cpp.o
    [ 26%] Building CXX object src/CMakeFiles/csympy.dir/pow.cpp.o
    [ 28%] Building CXX object src/CMakeFiles/csympy.dir/functions.cpp.o
    [ 30%] Building CXX object src/CMakeFiles/csympy.dir/monomials.cpp.o
    [ 32%] Building CXX object src/CMakeFiles/csympy.dir/rings.cpp.o
    [ 34%] Building CXX object src/CMakeFiles/csympy.dir/ntheory.cpp.o
    [ 36%] Building CXX object src/CMakeFiles/csympy.dir/dense_matrix.cpp.o
    [ 39%] Building CXX object src/CMakeFiles/csympy.dir/sparse_matrix.cpp.o
    [ 41%] Building CXX object src/CMakeFiles/csympy.dir/matrix.cpp.o
    Linking CXX static library libcsympy.a
    [ 41%] Built target csympy
    Scanning dependencies of target teuchos
    [ 43%] Building CXX object src/teuchos/CMakeFiles/teuchos.dir/Teuchos_dyn_cast.cpp.o
    [ 45%] Building CXX object src/teuchos/CMakeFiles/teuchos.dir/Teuchos_Ptr.cpp.o
    [ 47%] Building CXX object src/teuchos/CMakeFiles/teuchos.dir/Teuchos_RCPNode.cpp.o
    [ 50%] Building CXX object src/teuchos/CMakeFiles/teuchos.dir/Teuchos_TestForException.cpp.o
    [ 52%] Building CXX object src/teuchos/CMakeFiles/teuchos.dir/Teuchos_TypeNameTraits.cpp.o
    [ 54%] Building CXX object src/teuchos/CMakeFiles/teuchos.dir/Teuchos_stacktrace.cpp.o
    Linking CXX static library libteuchos.a
    [ 54%] Built target teuchos
    Scanning dependencies of target test_rcp
    [ 56%] Building CXX object src/tests/rcp/CMakeFiles/test_rcp.dir/test_rcp.cpp.o
    Linking CXX executable test_rcp
    [ 56%] Built target test_rcp
    Scanning dependencies of target test_arit
    [ 58%] Building CXX object src/tests/basic/CMakeFiles/test_arit.dir/test_arit.cpp.o
    Linking CXX executable test_arit
    [ 58%] Built target test_arit
    Scanning dependencies of target test_basic
    [ 60%] Building CXX object src/tests/basic/CMakeFiles/test_basic.dir/test_basic.cpp.o
    Linking CXX executable test_basic
    [ 60%] Built target test_basic
    Scanning dependencies of target test_functions
    [ 63%] Building CXX object src/tests/basic/CMakeFiles/test_functions.dir/test_functions.cpp.o
    Linking CXX executable test_functions
    [ 63%] Built target test_functions
    Scanning dependencies of target test_integer
    [ 65%] Building CXX object src/tests/basic/CMakeFiles/test_integer.dir/test_integer.cpp.o
    Linking CXX executable test_integer
    [ 65%] Built target test_integer
    Scanning dependencies of target test_poly
    [ 67%] Building CXX object src/tests/basic/CMakeFiles/test_poly.dir/test_poly.cpp.o
    Linking CXX executable test_poly
    [ 67%] Built target test_poly
    Scanning dependencies of target test_subs
    [ 69%] Building CXX object src/tests/basic/CMakeFiles/test_subs.dir/test_subs.cpp.o
    Linking CXX executable test_subs
    [ 69%] Built target test_subs
    Scanning dependencies of target test_ntheory
    [ 71%] Building CXX object src/tests/ntheory/CMakeFiles/test_ntheory.dir/test_ntheory.cpp.o
    Linking CXX executable test_ntheory
    [ 71%] Built target test_ntheory
    Scanning dependencies of target test_matrix
    [ 73%] Building CXX object src/tests/matrix/CMakeFiles/test_matrix.dir/test_matrix.cpp.o
    Linking CXX executable test_matrix
    [ 73%] Built target test_matrix
    Scanning dependencies of target test_printing
    [ 76%] Building CXX object src/tests/printing/CMakeFiles/test_printing.dir/test_printing.cpp.o
    Linking CXX executable test_printing
    [ 76%] Built target test_printing
    Scanning dependencies of target add1
    [ 78%] Building CXX object benchmarks/CMakeFiles/add1.dir/add1.cpp.o
    Linking CXX executable add1
    [ 78%] Built target add1
    Scanning dependencies of target expand1
    [ 80%] Building CXX object benchmarks/CMakeFiles/expand1.dir/expand1.cpp.o
    Linking CXX executable expand1
    [ 80%] Built target expand1
    Scanning dependencies of target expand2
    [ 82%] Building CXX object benchmarks/CMakeFiles/expand2.dir/expand2.cpp.o
    Linking CXX executable expand2
    [ 82%] Built target expand2
    Scanning dependencies of target expand2b
    [ 84%] Building CXX object benchmarks/CMakeFiles/expand2b.dir/expand2b.cpp.o
    Linking CXX executable expand2b
    [ 84%] Built target expand2b
    Scanning dependencies of target expand3
    [ 86%] Building CXX object benchmarks/CMakeFiles/expand3.dir/expand3.cpp.o
    Linking CXX executable expand3
    [ 86%] Built target expand3
    Scanning dependencies of target matrix_add1
    [ 89%] Building CXX object benchmarks/CMakeFiles/matrix_add1.dir/matrix_add1.cpp.o
    Linking CXX executable matrix_add1
    [ 89%] Built target matrix_add1
    Scanning dependencies of target matrix_add2
    [ 91%] Building CXX object benchmarks/CMakeFiles/matrix_add2.dir/matrix_add2.cpp.o
    Linking CXX executable matrix_add2
    [ 91%] Built target matrix_add2
    Scanning dependencies of target matrix_mul1
    [ 93%] Building CXX object benchmarks/CMakeFiles/matrix_mul1.dir/matrix_mul1.cpp.o
    Linking CXX executable matrix_mul1
    [ 93%] Built target matrix_mul1
    Scanning dependencies of target matrix_mul2
    [ 95%] Building CXX object benchmarks/CMakeFiles/matrix_mul2.dir/matrix_mul2.cpp.o
    Linking CXX executable matrix_mul2
    [ 95%] Built target matrix_mul2
    [ 97%] Cythonizing csympy_wrapper.pyx
    Scanning dependencies of target csympy_wrapper
    [100%] Building CXX object csympy/lib/CMakeFiles/csympy_wrapper.dir/csympy_wrapper.cpp.o
    Linking CXX shared library csympy_wrapper.so
    [100%] Built target csympy_wrapper

Successfully installed csympy
Cleaning up...
```
