### PR TITLE
Add test function so tests can be run from within python terminal

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -51,10 +51,14 @@ if [[ "${WITH_ARB}" != "" ]]; then
 fi
 if [[ "${PYTHON_INSTALL}" == "yes" ]]; then
     git clean -dfx
-    python setup.py install
-    mkdir empty
+    pip install .
+    mkdir -p empty
     cd empty
-    py.test --pyargs csympy
+    cat << EOF | python
+import csympy
+if not csympy.test():
+    raise Exception('Tests failed')
+EOF
     cd ..
     exit 0
 fi

--- a/csympy/__init__.py
+++ b/csympy/__init__.py
@@ -1,3 +1,8 @@
 from .lib.csympy_wrapper import (Symbol, Integer, sympify, SympifyError, Add,
         Mul, Pow, sin, cos, sqrt, function_symbol, I)
 from .utilities import var
+
+def test():
+    import pytest, os
+    return not pytest.cmdline.main(
+        [os.path.dirname(os.path.abspath(__file__))])


### PR DESCRIPTION
- PR

``` python
>>> import csympy
>>> csympy.test()
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
collected 67 items 

miniconda3/lib/python3.4/site-packages/csympy/tests/test_arit.py .............
miniconda3/lib/python3.4/site-packages/csympy/tests/test_functions.py ...
miniconda3/lib/python3.4/site-packages/csympy/tests/test_integer.py .....
miniconda3/lib/python3.4/site-packages/csympy/tests/test_matrices.py ...............
miniconda3/lib/python3.4/site-packages/csympy/tests/test_subs.py ....
miniconda3/lib/python3.4/site-packages/csympy/tests/test_symbol.py ..
miniconda3/lib/python3.4/site-packages/csympy/tests/test_sympify.py ......
miniconda3/lib/python3.4/site-packages/csympy/tests/test_sympy_conv.py ...................

========================== 67 passed in 0.75 seconds ===========================
True
>>> 
```
