### PR TITLE
Fix a bug in transpose_dense()

### DIFF
--- a/src/dense_matrix.cpp
+++ b/src/dense_matrix.cpp
@@ -168,13 +168,11 @@ void DenseMatrix::FFLDU(MatrixBase&L, MatrixBase &D, MatrixBase &U) const
 // ----------------------------- Matrix Transpose ----------------------------//
 void transpose_dense(const DenseMatrix &A, DenseMatrix &B)
 {
-    CSYMPY_ASSERT(B.row_ == A.row_ && B.col_ == A.col_);
+    CSYMPY_ASSERT(B.row_ == A.col_ && B.col_ == A.row_);
 
-    unsigned row = A.row_, col = A.col_;
-
-    for (unsigned i = 0; i < row; i++)
-        for (unsigned j = 0; j < col; j++)
-            B.m_[j*col + i] = A.m_[i*col + j];
+    for (unsigned i = 0; i < A.row_; i++)
+        for (unsigned j = 0; j < A.col_; j++)
+            B.m_[j*B.col_ + i] = A.m_[i*A.col_ + j];
 }
 
 // ------------------------------- Submatrix ---------------------------------//

--- a/src/tests/matrix/test_matrix.cpp
+++ b/src/tests/matrix/test_matrix.cpp
@@ -209,6 +209,14 @@ void test_transpose_dense()
 
     assert(B == DenseMatrix(3, 3, {symbol("a"), symbol("p"), symbol("u"), symbol("b"),
         symbol("q"), symbol("v"), symbol("c"), symbol("r"), symbol("w")}));
+
+    RCP<const Basic> x = symbol("x");
+    RCP<const Basic> y = symbol("x");
+    RCP<const Basic> z = symbol("x");
+    A = DenseMatrix(1, 3, {x, y, z});
+    B = DenseMatrix(3, 1);
+    transpose_dense(A, B);
+    assert(B == DenseMatrix(3, 1, {x, y, z}));
 }
 
 void test_submatrix_dense()


### PR DESCRIPTION
The function was implemented incorrectly if the number of rows and columns is
different. A test for this was added that fails.

The assert statement was fixed as well as the loop, now the added test passes.

Fixes #304.
