### PR TITLE
Tests for `homogeneous_lde`

### DIFF
--- a/src/tests/ntheory/test_diophantine.cpp
+++ b/src/tests/ntheory/test_diophantine.cpp
@@ -35,6 +35,11 @@ void test_homogeneous_lde()
 {
     std::vector<DenseMatrix> basis, true_basis;
 
+    // First two tests are taken from the following paper:
+    // Evelyne Contejean, Herve Devie. An Efficient Incremental Algorithm
+    // for Solving Systems of Linear Diophantine Equations. Information and
+    // computation, 113(1):143-172, August 1994.
+
     DenseMatrix A = DenseMatrix(2, 4, {
         integer(-1), integer(1), integer(2), integer(-3),
         integer(-1), integer(3), integer(-2), integer(-1)});


### PR DESCRIPTION
I added two additional tests (very simple ones). Now I remember why I included `Find solutions in negative integers if possible` as a to-do in the [original PR](https://github.com/sympy/sympy/pull/7241). The algorithm we are using can't find solutions in negative integers. For example, the equation `2x + 3y = 0`  has a solution (either `{3, -2}` or `{-3, 2}`) but the algorithm can't find one. Still, the algorithm finds all the positive solutions and can solve a system of linear Diophantine equations efficiently.
