### PR TITLE
Use the 'final' keyword in IMPLEMENT_TYPEID

### DIFF
--- a/src/basic.h
+++ b/src/basic.h
@@ -262,7 +262,7 @@ void hash_combine(std::size_t& seed, const T& v);
 /*! Type_code_id shared by all instances */ \
 const static TypeID type_code_id = ID; \
 /*! Virtual function that gives the type_code_id of the object */ \
-virtual TypeID get_type_code() const { return type_code_id; };
+virtual TypeID get_type_code() const final { return type_code_id; };
 
 #endif
 


### PR DESCRIPTION
The 'final' keyword makes sure that the virtual method is not overriden in
subclasses, as a check for us, since we only want to implement get_type_code()
in the lowest-level subclasses. Otherwise a compiler error will occur.

There might also be speed benefits to this.
