### PR TITLE
Use inoutArg and Ptr

### DIFF
--- a/src/add.h
+++ b/src/add.h
@@ -44,7 +44,7 @@ public:
     /*!
     * Adds `(coeff*t)` to the dict `d`
     */
-    static void dict_add_term(umap_basic_num &d,
+    static void dict_add_term(const Ptr<umap_basic_num> &d,
             const RCP<const Number> &coef, const RCP<const Basic> &t);
     //! Converts the add dict into two appropriate instances
     void as_two_terms(const Ptr<RCP<const Basic>> &a,

--- a/src/csympy_rcp.h
+++ b/src/csympy_rcp.h
@@ -55,6 +55,12 @@ Ptr<T> outArg( T& arg )
     return Ptr<T>(&arg);
 }
 
+template<typename T> inline
+Ptr<T> inoutArg( T& arg )
+{
+    return Ptr<T>(&arg);
+}
+
 /* RCP */
 
 enum ENull { null };

--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -216,19 +216,19 @@ RCP<const CSymPy::Basic> Mul::from_dict(const RCP<const Number> &coef, map_basic
 }
 
 // Mul (t^exp) to the dict "d"
-void Mul::dict_add_term(map_basic_basic &d, const RCP<const Basic> &exp,
+void Mul::dict_add_term(const Ptr<map_basic_basic> &d, const RCP<const Basic> &exp,
         const RCP<const Basic> &t)
 {
-    auto it = d.find(t);
-    if (it == d.end()) {
-        insert(d, t, exp);
+    auto it = d->find(t);
+    if (it == d->end()) {
+        insert(*d, t, exp);
     } else {
         // Very common case, needs to be fast:
         if (is_a_Number(*it->second) && is_a_Number(*exp)) {
             RCP<const Number> tmp = rcp_static_cast<const Number>(it->second);
             iaddnum(outArg(tmp), rcp_static_cast<const Number>(exp));
             if (tmp->is_zero()) {
-                d.erase(it);
+                d->erase(it);
             } else {
                 it->second = tmp;
             }
@@ -237,7 +237,7 @@ void Mul::dict_add_term(map_basic_basic &d, const RCP<const Basic> &exp,
             it->second = add(it->second, exp);
             if (is_a<Integer>(*it->second) &&
                     rcp_static_cast<const Integer>(it->second)->is_zero()) {
-                d.erase(it);
+                d->erase(it);
             }
         }
     }

--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -455,19 +455,19 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
                         // We make a copy of the dict_:
                         map_basic_basic d2 = rcp_static_cast<const Mul>(term)->dict_;
                         term = Mul::from_dict(one, std::move(d2));
-                        Add::dict_add_term(d, mulnum(mulnum(p.second, q.second), coef2), term);
+                        Add::dict_add_term(inoutArg(d), mulnum(mulnum(p.second, q.second), coef2), term);
                     } else {
-                        Add::dict_add_term(d, mulnum(p.second, q.second), term);
+                        Add::dict_add_term(inoutArg(d), mulnum(p.second, q.second), term);
                     }
                 }
             }
-            Add::dict_add_term(d,
+            Add::dict_add_term(inoutArg(d),
                     mulnum(rcp_static_cast<const Add>(b)->coef_, p.second),
                     p.first);
         }
         // Handle the coefficient of "a":
         for (auto &q: (rcp_static_cast<const Add>(b))->dict_) {
-            Add::dict_add_term(d,
+            Add::dict_add_term(inoutArg(d),
                     mulnum(rcp_static_cast<const Add>(a)->coef_, q.second),
                     q.first);
         }
@@ -496,9 +496,9 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
                     // We make a copy of the dict_:
                     map_basic_basic d2 = rcp_static_cast<const Mul>(term)->dict_;
                     term = Mul::from_dict(one, std::move(d2));
-                    Add::dict_add_term(d, mulnum(mulnum(q.second, a_coef), coef2), term);
+                    Add::dict_add_term(inoutArg(d), mulnum(mulnum(q.second, a_coef), coef2), term);
                 } else {
-                    Add::dict_add_term(d, mulnum(a_coef, q.second), term);
+                    Add::dict_add_term(inoutArg(d), mulnum(a_coef, q.second), term);
                 }
             }
         }
@@ -506,7 +506,7 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
             iaddnum(outArg(coef),
                 mulnum(rcp_static_cast<const Add>(b)->coef_, a_coef));
         } else {
-            Add::dict_add_term(d,
+            Add::dict_add_term(inoutArg(d),
                     mulnum(rcp_static_cast<const Add>(b)->coef_, a_coef),
                     a_term);
         }
@@ -589,7 +589,7 @@ RCP<const Basic> Mul::diff(const RCP<const Symbol> &x) const
             iaddnum(outArg(overall_coef), coef);
         } else {
             RCP<const Basic> mul = Mul::from_dict(one, std::move(d));
-            Add::dict_add_term(add_dict, coef, mul);
+            Add::dict_add_term(inoutArg(add_dict), coef, mul);
         }
     }
     return Add::from_dict(overall_coef, std::move(add_dict));

--- a/src/mul.h
+++ b/src/mul.h
@@ -37,7 +37,7 @@ public:
     static RCP<const Basic> from_dict(const RCP<const Number> &coef,
             map_basic_basic &&d);
     //! Add terms to dict
-    static void dict_add_term(map_basic_basic &d,
+    static void dict_add_term(const Ptr<map_basic_basic> &d,
         const RCP<const Basic> &exp, const RCP<const Basic> &t);
     static void dict_add_term_new(const Ptr<RCP<const Number>> &coef, map_basic_basic &d, 
         const RCP<const Basic> &exp, const RCP<const Basic> &t);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -397,7 +397,7 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
                         rcp_static_cast<const Number>(
                         rcp_static_cast<const Integer>(base)->powint(*exp)));
                 } else if (is_a<Symbol>(*base)) {
-                    Mul::dict_add_term(d, exp, base);
+                    Mul::dict_add_term(inoutArg(d), exp, base);
                 } else {
                     RCP<const Basic> exp2, t, tmp;
                     tmp = pow(base, exp);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -440,7 +440,7 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
                 map_basic_basic d2 = rcp_static_cast<const Mul>(term)->dict_;
                 term = Mul::from_dict(one, std::move(d2));
             }
-            Add::dict_add_term(rd, coef2, term);
+            Add::dict_add_term(inoutArg(rd), coef2, term);
         }
     }
     RCP<const Basic> result = Add::from_dict(add_overall_coeff, std::move(rd));


### PR DESCRIPTION
One should be using a pointer (`const Ptr<> &`, since we do not use raw pointers directly) for inout arguments, instead of just a reference (`&`).

Benchmarks do not seem to be affected.

Most people agree that pointer is better, though not all. 
