### PR TITLE
[WIP] Make zero, one RCP<const Basic>

### DIFF
--- a/benchmarks/symbench.cpp
+++ b/benchmarks/symbench.cpp
@@ -76,8 +76,8 @@ RCP<const Basic> hermite(RCP<const Integer> n, RCP<const Basic> y)
 {
     if (eq(n, one)) return mul(y, integer(2));
     if (eq(n, zero)) return one;
-    return expand(sub(mul(mul(integer(2), y), hermite(n->subint(*one), y)), 
-        mul(integer(2), mul(n->subint(*one), hermite(n->subint(*integer(2)), y)))));
+    return expand(sub(mul(mul(integer(2), y), hermite(n->subint(*rcp_static_cast<const Integer>(one)), y)), 
+        mul(integer(2), mul(n->subint(*rcp_static_cast<const Integer>(one)), hermite(n->subint(*integer(2)), y)))));
 }
 
 double R2()

--- a/src/add.cpp
+++ b/src/add.cpp
@@ -236,7 +236,7 @@ RCP<const Basic> Add::from_dict(const RCP<const Number> &coef, umap_basic_num &&
         } else {
             insert(m, p->first, one);
             insert(m, p->second, one);
-            return rcp(new Mul(one, std::move(m)));
+            return rcp(new Mul(rcp_static_cast<const Integer>(one), std::move(m)));
         }
     } else {
         return rcp(new Add(coef, std::move(d)));
@@ -266,13 +266,13 @@ void Add::as_coef_term(const RCP<const Basic> &self,
         *coef = (rcp_static_cast<const Mul>(self))->coef_;
         // We need to copy our 'dict_' here, as 'term' has to have its own.
         map_basic_basic d2 = (rcp_static_cast<const Mul>(self))->dict_;
-        *term = Mul::from_dict(one, std::move(d2));
+        *term = Mul::from_dict(rcp_static_cast<const Integer>(one), std::move(d2));
     } else if (is_a_Number(*self)) {
         *coef = rcp_static_cast<const Number>(self);
         *term = one;
     } else {
         CSYMPY_ASSERT(!is_a<Add>(*self));
-        *coef = one;
+        *coef = rcp_static_cast<const Integer>(one);
         *term = self;
     }
 }
@@ -315,7 +315,7 @@ RCP<const Basic> add(const RCP<const Basic> &a, const RCP<const Basic> &b)
         Add::dict_add_term(d, coef, t);
         auto it = d.find(one);
         if (it == d.end()) {
-            coef = zero;
+            coef = rcp_static_cast<const Integer>(zero);
         } else {
             coef = it->second;
             d.erase(it);
@@ -357,7 +357,7 @@ RCP<const Basic> add_expand(const RCP<const Add> &self)
 RCP<const Basic> Add::diff(const RCP<const Symbol> &x) const
 {
     CSymPy::umap_basic_num d;
-    RCP<const Number> coef=zero, coef2;
+    RCP<const Number> coef=rcp_static_cast<const Integer>(zero), coef2;
     RCP<const Basic> t;
     for (auto &p: dict_) {
         RCP<const Basic> term = p.first->diff(x);
@@ -424,7 +424,7 @@ vec_basic Add::get_args() const {
     vec_basic args;
     if (!coef_->is_zero()) args.push_back(coef_);
     for (auto &p: dict_) {
-        args.push_back(Add::from_dict(zero, {{p.first, p.second}}));
+        args.push_back(Add::from_dict(rcp_static_cast<const Integer>(zero), {{p.first, p.second}}));
     }
     return args;
 }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -44,10 +44,10 @@ RCP<const Basic> Constant::diff(const RCP<const Symbol> &x) const
     return zero;
 }
 
-RCP<const Integer> zero = rcp(new Integer(0));
-RCP<const Integer> one = rcp(new Integer(1));
+RCP<const Basic> zero = rcp(new Integer(0));
+RCP<const Basic> one = rcp(new Integer(1));
 RCP<const Integer> minus_one = rcp(new Integer(-1));
-RCP<const Number> I = Complex::from_two_nums(*zero, *one);
+RCP<const Number> I = Complex::from_two_nums(*(rcp_static_cast<const Integer>(zero)), *rcp_static_cast<const Integer>(one));
 
 RCP<const Constant> pi = rcp(new Constant("pi"));
 RCP<const Constant> E = rcp(new Constant("E"));

--- a/src/constants.h
+++ b/src/constants.h
@@ -59,8 +59,8 @@ inline RCP<const Constant> constant(const std::string &name)
 }
 
 // Constant Numbers
-extern RCP<const Integer> zero;
-extern RCP<const Integer> one;
+extern RCP<const Basic> zero;
+extern RCP<const Basic> one;
 extern RCP<const Integer> minus_one;
 extern RCP<const Number> I;
 

--- a/src/dense_matrix.cpp
+++ b/src/dense_matrix.cpp
@@ -889,7 +889,7 @@ void LDL(const DenseMatrix &A, DenseMatrix &L, DenseMatrix &D)
     // Initialize L
     for (i = 0; i < col; i++)
         for (j = 0; j < col; j++)
-            L.m_[i*col + j] = (i != j) ? zero : one;
+            L.m_[i*col + j] = (i != j) ? rcp_static_cast<const Integer>(zero) : rcp_static_cast<const Integer>(one);
 
     for (i = 0; i < col; i++) {
         for (j = 0; j < i; j++) {

--- a/src/diophantine.cpp
+++ b/src/diophantine.cpp
@@ -91,15 +91,15 @@ void homogeneous_lde(std::vector<DenseMatrix> &basis, const DenseMatrix &A)
             for (unsigned i = 0; i < q; i++) {
                 CSYMPY_ASSERT(is_a<Integer>(*T.get(0, i)));
                 T.set(0, i,
-                    rcp_static_cast<const Integer>(T.get(0, i))->addint(*one));
+                    rcp_static_cast<const Integer>(T.get(0, i))->addint(*rcp_static_cast<const Integer>(one)));
 
                 if (i > 0) {
                     CSYMPY_ASSERT(is_a<Integer>(*T.get(0, i - 1)));
                     T.set(0, i - 1,
-                        rcp_static_cast<const Integer>(T.get(0, i - 1))->subint(*one));
+                        rcp_static_cast<const Integer>(T.get(0, i - 1))->subint(*rcp_static_cast<const Integer>(one)));
                 }
 
-                dot = zero;
+                dot = rcp_static_cast<const Integer>(zero);
                 for (unsigned j = 0; j < p; j++) {
                     CSYMPY_ASSERT(is_a<Integer>(*product.get(j, 0)));
                     RCP<const Integer> p_j0 = rcp_static_cast<const Integer>(product.get(j, 0));

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -2780,7 +2780,7 @@ RCP<const Basic> gamma(const RCP<const Basic> &arg)
     if (is_a<Integer>(*arg)) {
         RCP<const Integer> arg_ = rcp_static_cast<const Integer>(arg);
         if (arg_->is_positive()) {
-            return factorial((arg_->subint(*one))->as_int());
+            return factorial((arg_->subint(*rcp_static_cast<const Integer>(one)))->as_int());
         } else {
             throw std::runtime_error("Complex Infinity not yet implemented");
         }
@@ -2792,12 +2792,12 @@ RCP<const Basic> gamma(const RCP<const Basic> &arg)
             n = quotient_f(*(integer(abs(arg_->i.get_num()))), *(integer(arg_->i.get_den())));
             if (arg_->is_positive()) {
                 k = n;
-                coeff = one;
+                coeff = rcp_static_cast<const Integer>(one);
             } else {
-                n = n->addint(*one);
+                n = n->addint(*rcp_static_cast<const Integer>(one));
                 k = n;
                 if ((n->as_int() & 1) == 0) {
-                    coeff = one;
+                    coeff = rcp_static_cast<const Integer>(one);
                 } else {
                     coeff = minus_one;
                 }
@@ -2881,7 +2881,7 @@ RCP<const Basic> lowergamma(const RCP<const Basic> &s, const RCP<const Basic> &x
         if (s_int->is_one()) {
             return sub(one, exp(mul(minus_one, x)));
         } else if (s_int->i > 1) {
-            s_int = s_int->subint(*one);
+            s_int = s_int->subint(*rcp_static_cast<const Integer>(one));
             return sub(mul(s_int, lowergamma(s_int, x)), mul(pow(x, s_int), exp(mul(minus_one, x))));
         } else {
             return rcp(new LowerGamma(s, x));
@@ -2890,7 +2890,7 @@ RCP<const Basic> lowergamma(const RCP<const Basic> &s, const RCP<const Basic> &x
         // TODO: Implement `erf`. Currently the recursive expansion has no base case
         // when s is of form n/2 n is Integer
         RCP<const Number> s_num = rcp_static_cast<const Number>(s);
-        s_num = subnum(s_num, one);
+        s_num = subnum(s_num, rcp_static_cast<const Integer>(one));
         if (s_num->is_positive()) {
             return sub(mul(s_num, lowergamma(s_num, x)), mul(pow(x, s_num), exp(mul(minus_one, x))));
         } else {
@@ -2961,7 +2961,7 @@ RCP<const Basic> uppergamma(const RCP<const Basic> &s, const RCP<const Basic> &x
         if (s_int->is_one()) {
             return exp(mul(minus_one, x));
         } else if (s_int->i > 1) {
-            s_int = s_int->subint(*one);
+            s_int = s_int->subint(*rcp_static_cast<const Integer>(one));
             return add(mul(s_int, uppergamma(s_int, x)), mul(pow(x, s_int), exp(mul(minus_one, x))));
         } else {
             // TODO: implement unpolarfy to handle this case
@@ -2971,7 +2971,7 @@ RCP<const Basic> uppergamma(const RCP<const Basic> &s, const RCP<const Basic> &x
         // TODO: Implement `erf`. Currently the recursive expansion has no base case
         // when s is of form n/2 n is Integer
         RCP<const Number> s_num = rcp_static_cast<const Number>(s);
-        s_num = subnum(s_num, one);
+        s_num = subnum(s_num, rcp_static_cast<const Integer>(one));
         if (s_num->is_positive()) {
             return add(mul(s_num, uppergamma(s_num, x)), mul(pow(x, s_num), exp(mul(minus_one, x))));
         } else {

--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -372,7 +372,7 @@ void Mul::as_base_exp(const RCP<const Basic> &self, const Ptr<RCP<const Basic>> 
 RCP<const Basic> mul(const RCP<const Basic> &a, const RCP<const Basic> &b)
 {
     CSymPy::map_basic_basic d;
-    RCP<const Number> coef = one;
+    RCP<const Number> coef = rcp_static_cast<const Integer>(one);
     if (CSymPy::is_a<Mul>(*a) && CSymPy::is_a<Mul>(*b)) {
         RCP<const Mul> A = rcp_static_cast<const Mul>(a);
         RCP<const Mul> B = rcp_static_cast<const Mul>(b);
@@ -454,7 +454,7 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
                                 rcp_static_cast<const Mul>(term)->coef_;
                         // We make a copy of the dict_:
                         map_basic_basic d2 = rcp_static_cast<const Mul>(term)->dict_;
-                        term = Mul::from_dict(one, std::move(d2));
+                        term = Mul::from_dict(rcp_static_cast<const Integer>(one), std::move(d2));
                         Add::dict_add_term(d, mulnum(mulnum(p.second, q.second), coef2), term);
                     } else {
                         Add::dict_add_term(d, mulnum(p.second, q.second), term);
@@ -479,7 +479,7 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
         RCP<const Basic> a_term;
         Add::as_coef_term(a, outArg(a_coef), outArg(a_term));
 
-        RCP<const Number> coef = zero;
+        RCP<const Number> coef = rcp_static_cast<const Integer>(zero);
         umap_basic_num d;
         d.reserve((rcp_static_cast<const Add>(b))->dict_.size());
         for (auto &q: (rcp_static_cast<const Add>(b))->dict_) {
@@ -495,7 +495,7 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
                             rcp_static_cast<const Mul>(term)->coef_;
                     // We make a copy of the dict_:
                     map_basic_basic d2 = rcp_static_cast<const Mul>(term)->dict_;
-                    term = Mul::from_dict(one, std::move(d2));
+                    term = Mul::from_dict(rcp_static_cast<const Integer>(one), std::move(d2));
                     Add::dict_add_term(d, mulnum(mulnum(q.second, a_coef), coef2), term);
                 } else {
                     Add::dict_add_term(d, mulnum(a_coef, q.second), term);
@@ -528,7 +528,7 @@ RCP<const Basic> Mul::power_all_terms(const RCP<const Basic> &exp) const
 {
     CSymPy::map_basic_basic d;
     RCP<const Basic> new_coef = pow(coef_, exp);
-    RCP<const Number> coef_num = one;
+    RCP<const Number> coef_num = rcp_static_cast<const Integer>(one);
     RCP<const Basic> new_exp;
     for (auto &p: dict_) {
         new_exp = mul(p.second, exp);
@@ -563,7 +563,7 @@ RCP<const Basic> Mul::power_all_terms(const RCP<const Basic> &exp) const
 
 RCP<const Basic> Mul::diff(const RCP<const Symbol> &x) const
 {
-    RCP<const Number> overall_coef = zero;
+    RCP<const Number> overall_coef = rcp_static_cast<const Integer>(zero);
     umap_basic_num add_dict;
     for (auto &p: dict_) {
         RCP<const Number> coef = coef_;
@@ -588,7 +588,7 @@ RCP<const Basic> Mul::diff(const RCP<const Symbol> &x) const
         if (d.size() == 0) {
             iaddnum(outArg(overall_coef), coef);
         } else {
-            RCP<const Basic> mul = Mul::from_dict(one, std::move(d));
+            RCP<const Basic> mul = Mul::from_dict(rcp_static_cast<const Integer>(one), std::move(d));
             Add::dict_add_term(add_dict, coef, mul);
         }
     }
@@ -633,7 +633,7 @@ vec_basic Mul::get_args() const {
     vec_basic args;
     if (!coef_->is_one()) args.push_back(coef_);
     for (auto &p: dict_) {
-        args.push_back(Mul::from_dict(one, {{p.first, p.second}}));
+        args.push_back(Mul::from_dict(rcp_static_cast<const Integer>(one), {{p.first, p.second}}));
     }
     return args;
 }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -128,7 +128,7 @@ RCP<const Number> pow_number(const RCP<const Number> &x, long n)
 {
     RCP<const Number> r, p;
     long mask = 1;
-    r = one;
+    r = rcp_static_cast<const Integer>(one);
     p = x;
     while (mask > 0 && n >= mask) {
         if (n & mask)
@@ -149,7 +149,7 @@ void pow_complex(const Ptr<RCP<const Number>> &self,
         RCP<const Number> res;
         res = mod(exp_, *integer(4));
         if (eq(res, zero)) {
-            res = one;
+            res = rcp_static_cast<const Integer>(one);
         } else if (eq(res, one)) {
             res = I;
         } else if (eq(res, integer(2))) {
@@ -161,7 +161,7 @@ void pow_complex(const Ptr<RCP<const Number>> &self,
     } else if (exp_.is_positive()) {
         *self = pow_number(base_, exp_.as_int());
     } else {
-        *self = pow_number(divnum(one, base_), -1 * exp_.as_int());
+        *self = pow_number(divnum(rcp_static_cast<const Integer>(one), base_), -1 * exp_.as_int());
     }
 
 }
@@ -174,7 +174,7 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
     if (eq(a, one)) return one;
     if (eq(a, minus_one)) {
         if (is_a<Integer>(*b)) {
-            return is_a<Integer>(*div(b, integer(2))) ? one : minus_one;
+            return is_a<Integer>(*div(b, integer(2))) ? rcp_static_cast<const Integer>(one) : minus_one;
         } else if (is_a<Rational>(*b) &&
                     (rcp_static_cast<const Rational>(b)->i.get_num() == 1) &&
                     (rcp_static_cast<const Rational>(b)->i.get_den() == 2)) {
@@ -374,7 +374,7 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
     if (! (base->coef_->is_zero())) {
         // Add the numerical coefficient into the dictionary. This
         // allows a little bit easier treatment below.
-        insert(base_dict, base->coef_, one);
+        insert(base_dict, base->coef_, rcp_static_cast<const Integer>(one));
     }
     int m = base_dict.size();
     multinomial_coefficients_mpz(m, n, r);
@@ -382,12 +382,12 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
     // This speeds up overall expansion. For example for the benchmark
     // (y + x + z + w)^60 it improves the timing from 135ms to 124ms.
     rd.reserve(2*r.size());
-    RCP<const Number> add_overall_coeff=zero;
+    RCP<const Number> add_overall_coeff=rcp_static_cast<const Integer>(zero);
     for (auto &p: r) {
         auto power = p.first.begin();
         auto i2 = base_dict.begin();
         map_basic_basic d;
-        RCP<const Number> overall_coeff=one;
+        RCP<const Number> overall_coeff=rcp_static_cast<const Integer>(one);
         for (; power != p.first.end(); ++power, ++i2) {
             if (*power > 0) {
                 RCP<const Integer> exp = rcp(new Integer(*power));
@@ -438,7 +438,7 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
                         rcp_static_cast<const Mul>(term)->coef_);
                 // We make a copy of the dict_:
                 map_basic_basic d2 = rcp_static_cast<const Mul>(term)->dict_;
-                term = Mul::from_dict(one, std::move(d2));
+                term = Mul::from_dict(rcp_static_cast<const Integer>(one), std::move(d2));
             }
             Add::dict_add_term(rd, coef2, term);
         }

--- a/src/rational.h
+++ b/src/rational.h
@@ -146,12 +146,12 @@ public:
         // Since 'this' is in canonical form, so is this**other, so we simply
         // pass num/den into the constructor directly:
         if (!neg)
-            if (abs(den) == one->i)
+            if (abs(den) == rcp_static_cast<const Integer>(one)->i)
                 return rcp(new Integer(num*sgn(den)));
             else
                 return rcp(new Rational(mpq_class(num*sgn(den), abs(den))));
         else
-            if (abs(num) == one->i)
+            if (abs(num) == rcp_static_cast<const Integer>(one)->i)
                 return rcp(new Integer(den*sgn(num)));
             else
                 return rcp(new Rational(mpq_class(den*sgn(num), abs(num))));

--- a/src/tests/basic/test_basic.cpp
+++ b/src/tests/basic/test_basic.cpp
@@ -29,6 +29,7 @@ using CSymPy::zero;
 using CSymPy::Number;
 using CSymPy::pow;
 using CSymPy::RCP;
+using CSymPy::rcp_static_cast;
 using CSymPy::print_stack_on_segfault;
 using CSymPy::Complex;
 using CSymPy::has_symbol;
@@ -89,9 +90,9 @@ void test_add()
     insert(m, y, rcp(new Integer(3)));
 
     m2 = m;
-    RCP<const Add> a = rcp(new Add(zero, std::move(m2)));
+    RCP<const Add> a = rcp(new Add(rcp_static_cast<const Integer>(zero), std::move(m2)));
     insert(m, x, rcp(new Integer(-2)));
-    RCP<const Add> b = rcp(new Add(zero, std::move(m)));
+    RCP<const Add> b = rcp(new Add(rcp_static_cast<const Integer>(zero), std::move(m)));
     std::cout << *a << std::endl;
     std::cout << *b << std::endl;
 
@@ -156,7 +157,7 @@ void test_integer()
     assert(eq(k, rcp(new Integer(-5))));
     assert(neq(k, rcp(new Integer(12))));
 
-    CSYMPY_CHECK_THROW(divnum(i, zero), std::runtime_error)
+    CSYMPY_CHECK_THROW(divnum(i, rcp_static_cast<const Integer>(zero)), std::runtime_error)
 }
 
 void test_rational()
@@ -255,7 +256,7 @@ void test_rational()
     assert(eq(divnum(r2, r1), r3));
 
     r1 = Rational::from_two_ints(integer(2), integer(3));
-    r2 = zero;
+    r2 = rcp_static_cast<const Integer>(zero);
     CSYMPY_CHECK_THROW(divnum(r1, r2), std::runtime_error)
 }
 
@@ -268,9 +269,9 @@ void test_mul()
     insert(m, y, rcp(new Integer(3)));
 
     m2 = m;
-    RCP<const Mul> a = rcp(new Mul(one, std::move(m2)));
+    RCP<const Mul> a = rcp(new Mul(rcp_static_cast<const Integer>(one), std::move(m2)));
     insert(m, x, rcp(new Integer(-2)));
-    RCP<const Mul> b = rcp(new Mul(one, std::move(m)));
+    RCP<const Mul> b = rcp(new Mul(rcp_static_cast<const Integer>(one), std::move(m)));
     std::cout << *a << std::endl;
     std::cout << *b << std::endl;
 


### PR DESCRIPTION
This needs to be carefully benchmarked, but it avoids frequent `refcount_` increases and decreases in here:

``` c++
    // Copy constructor
    template<class T2> RCP(const RCP<T2>& r_ptr) : ptr_(r_ptr.get()) {
        if (!is_null()) (ptr_->refcount_)++;
    }
```

which was triggered by expressions like `eq(b, zero)` in here:

``` c++
RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
{
    if (eq(b, zero)) return one;
    if (eq(b, one)) return a;
...
```

The `b` was passed as is (not incrementing the refcount), but both `zero` and `one` was temporary incremented and then decremented. The only difference was that `zero` and `one` was defined as `RCP<const Integer>` and was passed into `RCP<const Basic>` and so the copy constructor above (with the `T2` template) was called and somehow the compiler didn't optimize out the refcount increase. By applying the changes in this PR, the `zero` and `one` are now defined as `RCP<const Basic>` and thus the compiler doesn't need to create a new `RCP` instance with a different template (thus incrementing the refcount), but rather just passes a reference to the same `RCP` (avoiding incrementing the refcount).

See also the section "5.7.2 Conversions between different memory management types" in [TeuchosMemoryManagementSAND](http://web.ornl.gov/~8vt/TeuchosMemoryManagementSAND.pdf).
