### PR TITLE
Reproduce the chain rule in more cases

### DIFF
--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -813,6 +813,7 @@ TEST_CASE("Subs: functions", "[functions]")
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> z = symbol("z");
     RCP<const Symbol> _x = symbol("_x");
+    RCP<const Symbol> __x = symbol("__x");
     RCP<const Basic> r1, r2, r3, r4;
 
     // Test Subs::subs
@@ -844,9 +845,9 @@ TEST_CASE("Subs: functions", "[functions]")
     r2 = r1->diff(y);
     r3 = Subs::create(Derivative::create(function_symbol("f", {add(y, y), _x}), {_x, _x}), 
                         {{_x, add(x, y)}});
-    r4 = Subs::create(Derivative::create(function_symbol("f", {add(y, y), _x}), {_x, y}), 
-                        {{_x, add(x, y)}});
-    r3 = add(r3, r4);
+    r4 = Subs::create(Derivative::create(function_symbol("f", {__x, _x}), {__x, _x}), 
+                        {{_x, add(x, y)}, {__x, add(y, y)}});
+    r3 = add(r3, add(r4, r4));
     REQUIRE(eq(*r2, *r3));
 }
 


### PR DESCRIPTION
If the user takes g(y, f(x)) and differentiates wrt x once and y once,
output that says `Derivative(f(x), x)*Subs(Derivative(g(y, _x), _x, y),
(_x), (f(x)))` is much more useful than `Derivative(g(y, f(x)), y, x)`.
To ensure that higher order derivatives do not result in `Subs` types
nested inside eachother, this code pre-empts this every time a `Subs`
type is substituted. This slows the function down, but it is a rarely
used function since `Subs` is not supposed to be used directly.