### PR TITLE
Lambdify - fast numerical evaluation into Python buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ symengine/ruby/ext/symengine/extconf.h
 symengine/ruby/notebooks/.ipynb_checkpoints/
 symengine/ruby/notebooks/Gemfile.lock
 symengine/ruby/callgrind.out.*
+dist/
+.cache/
+symengine.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ env:
   - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
   # Release build shared lib with Python 2.7:
   - TEST_IN_TREE="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7" BUILD_SHARED_LIBS="yes"
+  # NumPy not available:
+  - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7" SKIP_NUMPY="yes"
 
   # These test the setup.py file
   - TEST_IN_TREE="yes" PYTHON_INSTALL="yes" PYTHON_VERSION="2.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ install:
 - if [%COMPILER%]==[MinGW-w64] if [%WITH_PYTHON%]==[yes] 7z x -aoa -oC:\ pyx64.7z > NUL
 
 - if [%WITH_PYTHON%]==[yes] set PATH=C:\Python%PYTHON_VERSION%;C:\Python%PYTHON_VERSION%\Scripts;%PATH%
-- if [%WITH_PYTHON%]==[yes] pip install nose pytest sympy
+- if [%WITH_PYTHON%]==[yes] pip install nose pytest sympy numpy
 - if [%WITH_PYTHON%]==[yes] pip install --install-option="--no-cython-compile" cython
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,7 +91,7 @@ build_script:
 test_script:
 - ctest --output-on-failure
 - if [%WITH_PYTHON%]==[yes] cd symengine/python
-- if [%WITH_PYTHON%]==[yes] if not [%COMPILER%]==[MSVC15] nosetests
+- if [%WITH_PYTHON%]==[yes] if not [%COMPILER%]==[MSVC15] py.test
 - if [%WITH_PYTHON%]==[yes] mkdir empty && cd empty
 - if [%WITH_PYTHON%]==[yes] python C:\projects\symengine\bin\test_python.py
 

--- a/benchmarks/Lambdify.py
+++ b/benchmarks/Lambdify.py
@@ -1,0 +1,31 @@
+from time import clock
+import numpy as np
+import sympy as sp
+import symengine as se
+
+# Real-life example (ion speciation problem in water chemistry)
+
+x = sp.symarray('x', 14)
+p = sp.symarray('p', 14)
+args = np.concatenate((x, p))
+exp = sp.exp
+exprs = [x[0] + x[1] - x[4] + 36.252574322669, x[0] - x[2] + x[3] + 21.3219379611249, x[3] + x[5] - x[6] + 9.9011158998744, 2*x[3] + x[5] - x[7] + 18.190422234653, 3*x[3] + x[5] - x[8] + 24.8679190043357, 4*x[3] + x[5] - x[9] + 29.9336062089226, -x[10] + 5*x[3] + x[5] + 28.5520551531262, 2*x[0] + x[11] - 2*x[4] - 2*x[5] + 32.4401680272417, 3*x[1] - x[12] + x[5] + 34.9992934135095, 4*x[1] - x[13] + x[5] + 37.0716199972041, p[0] - p[1] + 2*p[10] + 2*p[11] - p[12] - 2*p[13] + p[2] + 2*p[5] + 2*p[6] + 2*p[7] + 2*p[8] + 2*p[9] - exp(x[0]) + exp(x[1]) - 2*exp(x[10]) - 2*exp(x[11]) + exp(x[12]) + 2*exp(x[13]) - exp(x[2]) - 2*exp(x[5]) - 2*exp(x[6]) - 2*exp(x[7]) - 2*exp(x[8]) - 2*exp(x[9]), -p[0] - p[1] - 15*p[10] - 2*p[11] - 3*p[12] - 4*p[13] - 4*p[2] - 3*p[3] - 2*p[4] - 3*p[6] - 6*p[7] - 9*p[8] - 12*p[9] + exp(x[0]) + exp(x[1]) + 15*exp(x[10]) + 2*exp(x[11]) + 3*exp(x[12]) + 4*exp(x[13]) + 4*exp(x[2]) + 3*exp(x[3]) + 2*exp(x[4]) + 3*exp(x[6]) + 6*exp(x[7]) + 9*exp(x[8]) + 12*exp(x[9]), -5*p[10] - p[2] - p[3] - p[6] - 2*p[7] - 3*p[8] - 4*p[9] + 5*exp(x[10]) + exp(x[2]) + exp(x[3]) + exp(x[6]) + 2*exp(x[7]) + 3*exp(x[8]) + 4*exp(x[9]), -p[1] - 2*p[11] - 3*p[12] - 4*p[13] - p[4] + exp(x[1]) + 2*exp(x[11]) + 3*exp(x[12]) + 4*exp(x[13]) + exp(x[4]), -p[10] - 2*p[11] - p[12] - p[13] - p[5] - p[6] - p[7] - p[8] - p[9] + exp(x[10]) + 2*exp(x[11]) + exp(x[12]) + exp(x[13]) + exp(x[5]) + exp(x[6]) + exp(x[7]) + exp(x[8]) + exp(x[9])]
+lmb_symengine = se.Lambdify(args, exprs)
+lmb_sympy = sp.lambdify(args, exprs)
+
+inp = np.ones(28)
+
+tim_symengine = clock()
+res_symengine = np.empty(len(exprs))
+for i in range(500):
+    res_symengine = lmb_symengine(inp)
+    #lmb_symengine.unsafe_real_real(inp, res_symengine)
+tim_symengine = clock() - tim_symengine
+
+tim_sympy = clock()
+for i in range(500):
+    res_sympy = lmb_sympy(*inp)
+tim_sympy = clock() - tim_sympy
+
+print('symengine speed-up factor (higher is better) vs sympy: %12.5g' %
+      (tim_sympy/tim_symengine))

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -95,7 +95,7 @@ if [[ "${WITH_PYTHON}" == "yes" && "${WITH_SAGE}" != "yes" || "${PYTHON_INSTALL}
     conda update -q conda;
     conda info -a;
 
-    conda create -q -n test-environment python="${PYTHON_VERSION}" pip cython sympy nose pytest;
+    conda create -q -n test-environment python="${PYTHON_VERSION}" pip cython sympy nose pytest numpy;
     source activate test-environment;
 fi
 if [[ "${WITH_SAGE}" == "yes" ]]; then

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -95,7 +95,7 @@ if [[ "${WITH_PYTHON}" == "yes" && "${WITH_SAGE}" != "yes" || "${PYTHON_INSTALL}
     conda update -q conda;
     conda info -a;
 
-    CONDA_PKGS="pip cython sympy nose pytest numpy"
+    CONDA_PKGS="pip cython sympy nose pytest"
     if [[ "${SKIP_NUMPY}" == "yes" ]]; then
         true;  # pass
     else

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -96,6 +96,7 @@ if [[ "${WITH_PYTHON}" == "yes" && "${WITH_SAGE}" != "yes" || "${PYTHON_INSTALL}
     conda info -a;
 
     conda create -q -n test-environment python="${PYTHON_VERSION}" pip cython sympy nose pytest numpy;
+    python -c "import cython; import sys; cyver = cython.__version__.split('.'); sys.exit(1 if cyver[0]=='0' and int(cyver[1]) < 23 else 0)" && echo "Cython up-to-date" || pip install --upgrade --install-option="--no-cython-compile" cython
     source activate test-environment;
 fi
 if [[ "${WITH_SAGE}" == "yes" ]]; then

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -96,8 +96,8 @@ if [[ "${WITH_PYTHON}" == "yes" && "${WITH_SAGE}" != "yes" || "${PYTHON_INSTALL}
     conda info -a;
 
     conda create -q -n test-environment python="${PYTHON_VERSION}" pip cython sympy nose pytest numpy;
-    python -c "import cython; import sys; cyver = cython.__version__.split('.'); sys.exit(1 if cyver[0]=='0' and int(cyver[1]) < 23 else 0)" && echo "Cython up-to-date" || pip install --upgrade --install-option="--no-cython-compile" cython
     source activate test-environment;
+    python -c "import cython; import sys; cyver = cython.__version__.split('.'); sys.exit(1 if cyver[0]=='0' and int(cyver[1]) < 23 else 0)" && echo "Cython up-to-date" || pip install --upgrade --install-option="--no-cython-compile" cython;
 fi
 if [[ "${WITH_SAGE}" == "yes" ]]; then
     wget -O- http://files.sagemath.org/linux/64bit/sage-6.8-x86_64-Linux-Ubuntu_12.04_64_bit.tar.gz | tar xz

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -103,13 +103,6 @@ if [[ "${WITH_PYTHON}" == "yes" && "${WITH_SAGE}" != "yes" || "${PYTHON_INSTALL}
     fi
     conda create -q -n test-environment python="${PYTHON_VERSION}" "${CONDA_PKGS}";
     source activate test-environment;
-    if python -c "import cython; import sys; cyver = cython.__version__.split('.'); sys.exit(1 if cyver[0]=='0' and int(cyver[1]) < 23 else 0)"; then
-        echo "Cython up-to-date";
-    else
-        echo "Cython in conda repos too old";
-        conda remove cython
-        pip install --upgrade --install-option="--no-cython-compile" cython;
-    fi
 fi
 if [[ "${WITH_SAGE}" == "yes" ]]; then
     wget -O- http://files.sagemath.org/linux/64bit/sage-6.8-x86_64-Linux-Ubuntu_12.04_64_bit.tar.gz | tar xz

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -101,7 +101,7 @@ if [[ "${WITH_PYTHON}" == "yes" && "${WITH_SAGE}" != "yes" || "${PYTHON_INSTALL}
     else
         CONDA_PKGS="${CONDA_PKGS} numpy";
     fi
-    conda create -q -n test-environment python="${PYTHON_VERSION}" "${CONDA_PKGS}";
+    conda create -q -n test-environment python="${PYTHON_VERSION}" ${CONDA_PKGS};
     source activate test-environment;
 fi
 if [[ "${WITH_SAGE}" == "yes" ]]; then

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -99,7 +99,7 @@ ctest --output-on-failure
 # Python
 if [[ "${WITH_PYTHON}" == "yes" ]] && [[ "${WITH_SAGE}" != "yes" ]]; then
     cd symengine/python
-    nosetests -v
+    py.test -v
     cd ../../
 fi
 # Ruby

--- a/symengine/python/cmake/cython_test.pyx
+++ b/symengine/python/cmake/cython_test.pyx
@@ -83,3 +83,8 @@ cdef extern from "<symengine/add.h>" namespace "SymEngine":
 
     cdef cppclass Add(Basic):
         void as_two_terms(const Ptr[RCP[Basic]] &a, const Ptr[RCP[Basic]] &b)
+
+
+# Test that cpdef void is supported (https://github.com/cython/cython/commit/7df9d654b3e6c3d5812a95904872d35a3c94ef77)
+cpdef void func(double[::1] inp):
+    pass

--- a/symengine/python/cmake/cython_test.pyx
+++ b/symengine/python/cmake/cython_test.pyx
@@ -85,6 +85,7 @@ cdef extern from "<symengine/add.h>" namespace "SymEngine":
         void as_two_terms(const Ptr[RCP[Basic]] &a, const Ptr[RCP[Basic]] &b)
 
 
+# Currently not used:
 # Test that cpdef void is supported (https://github.com/cython/cython/commit/7df9d654b3e6c3d5812a95904872d35a3c94ef77)
-cpdef void func(double[::1] inp):
-    pass
+# cpdef void func(double[::1] inp):
+#     pass

--- a/symengine/python/symengine/__init__.py
+++ b/symengine/python/symengine/__init__.py
@@ -2,7 +2,7 @@ from .lib.symengine_wrapper import (Symbol, Integer, sympify, SympifyError,
         Add, Mul, Pow, exp, log, sqrt, function_symbol, I, E, pi,
         have_mpfr, have_mpc, RealDouble, ComplexDouble, DenseMatrix,
         sin, cos, tan, cot, csc, sec, asin, acos, atan, acot, acsc, asec,
-        sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth)
+        sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth, Lambdify)
 from .utilities import var, symbols
 
 if have_mpfr:

--- a/symengine/python/symengine/__init__.py
+++ b/symengine/python/symengine/__init__.py
@@ -2,7 +2,8 @@ from .lib.symengine_wrapper import (Symbol, Integer, sympify, SympifyError,
         Add, Mul, Pow, exp, log, sqrt, function_symbol, I, E, pi,
         have_mpfr, have_mpc, RealDouble, ComplexDouble, DenseMatrix,
         sin, cos, tan, cot, csc, sec, asin, acos, atan, acot, acsc, asec,
-        sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth, Lambdify)
+        sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth, Lambdify,
+        LambdifyCSE)
 from .utilities import var, symbols
 
 if have_mpfr:

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -1765,11 +1765,11 @@ def with_buffer(iterable):
     else:
         return iterable  # iterable supports memoryview
 
-ctypedef fused real_type:
+ctypedef fused InType:
     cython.doublecomplex
     cython.double
 
-ctypedef fused real_type2:
+ctypedef fused OutType:
     cython.doublecomplex
     cython.double
 
@@ -1822,11 +1822,11 @@ cdef class Lambdify(object):
             e_ = sympify(e)
             self.exprs.push_back(e_.thisptr)
 
-    # Two fused types real_type and real_type2 are the same, but with Cython >= 0.21,
+    # Two fused types InType and OutType are the same, but with Cython >= 0.21,
     # fused types have to be declared under different names to generate different
     # methods for each combination of inp and out
 
-    cdef void _real(self, real_type[::1] inp, real_type2[::1] out):
+    cdef void _real(self, InType[::1] inp, OutType[::1] out):
         cdef symengine.map_basic_basic d
         cdef symengine.vec_basic expr_subs
         cdef size_t idx, ninp = inp.size, nout = out.size
@@ -1838,7 +1838,7 @@ cdef class Lambdify(object):
 
         # Create the substitution "dict"
         for idx in range(ninp):
-            if real_type == cython.double:
+            if InType == cython.double:
                 d[self.args[idx]] = symengine.make_rcp_RealDouble(inp[idx])
             else:
                 d[self.args[idx]] = symengine.make_rcp_ComplexDouble(inp[idx])
@@ -1848,7 +1848,7 @@ cdef class Lambdify(object):
             expr_subs.push_back(deref(self.exprs[idx]).subs(d))
 
         # Convert expr_subs to doubles write to out
-        if real_type2 == cython.double:
+        if OutType == cython.double:
             as_real(expr_subs, out)
         else:
             as_complex(expr_subs, out)

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -2098,13 +2098,14 @@ def LambdifyCSE(args, exprs, cse=None, concatenate=None):
         from numpy import concatenate
     subs, new_exprs = cse(exprs)
     cse_symbs, cse_exprs = zip(*subs)
-    lmb = Lambdify(args + cse_symbs, new_exprs)
+    lmb = Lambdify(tuple(args) + cse_symbs, new_exprs)
     cse_lambda = Lambdify(args, cse_exprs)
 
     def cb(inp, out=None, **kwargs):
         cse_vals = cse_lambda(inp, **kwargs)
         new_inp = concatenate((inp, cse_vals))
         return lmb(new_inp, out, **kwargs)
+
     return cb
 
 

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -126,7 +126,10 @@ def sympy2symengine(a, raise_error=False):
     elif isinstance(a, sympy.Rational):
         return Integer(a.p) / Integer(a.q)
     elif isinstance(a, sympy.Float):
-        return RealMPFR(str(a), a._prec)
+        IF HAVE_SYMENGINE_MPFR:
+            return RealMPFR(str(a), a._prec)
+        ELSE:
+            return RealDouble(float(str(a)))
     elif a is sympy.I:
         return I
     elif a is sympy.E:

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -1745,7 +1745,6 @@ cdef class Lambdify(object):
     cdef symengine.vec_basic args, exprs
 
     def __cinit__(self, args, exprs):
-        cdef symengine.vec_basic args_, exprs_
         cdef Basic e_
         try:
             self.out_shape = exprs.shape
@@ -1757,12 +1756,10 @@ cdef class Lambdify(object):
 
         for e in args:
             e_ = sympify(e)
-            args_.push_back(e_.thisptr)
-        self.args = args_
+            self.args.push_back(e_.thisptr)
         for e in exprs.flatten():
             e_ = sympify(e)
-            exprs_.push_back(e_.thisptr)
-        self.exprs = exprs_
+            self.exprs.push_back(e_.thisptr)
 
     cdef void _cb(self, cnp.ndarray[cnp.float64_t, ndim=1] inp,
                   cnp.ndarray[cnp.float64_t, ndim=1] out):

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -2001,8 +2001,12 @@ cdef class Lambdify(object):
                 out = np.empty(new_out_size, dtype=np.complex128 if
                                complex_out else np.float64)
             else:
-                out = cython.view.array(shape=new_out_shape,
-                                        itemsize=sizeof(double), format='d')
+                if complex_out:
+                    out = cython.view.array(shape=new_out_shape,
+                                            itemsize=sizeof(double complex), format='Zd')
+                else:
+                    out = cython.view.array(shape=new_out_shape,
+                                            itemsize=sizeof(double), format='d')
             reshape_out = len(new_out_shape) > 1
         else:
             if use_numpy:

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -100,16 +100,13 @@ cdef c2py(RCP[const symengine.Basic] o):
     r.thisptr = o
     return r
 
-def sympy2symengine(a, raise_error=False, prefer_mpfr=True):
+def sympy2symengine(a, raise_error=False):
     """
     Converts 'a' from SymPy to SymEngine.
 
     If the expression cannot be converted, it either returns None (if
     raise_error==False) or raises a SympifyError exception (if
     raise_error==True).
-
-    The default is that sympy.Float is converted to RealMPFR, if faster
-    RealDouble is preferred, set ``prefer_mpfr=True``.
     """
     import sympy
     from sympy.core.function import AppliedUndef as sympy_AppliedUndef
@@ -117,20 +114,20 @@ def sympy2symengine(a, raise_error=False, prefer_mpfr=True):
         return Symbol(a.name)
     elif isinstance(a, sympy.Mul):
         x, y = a.as_two_terms()
-        return sympy2symengine(x, True, prefer_mpfr) * sympy2symengine(y, True, prefer_mpfr)
+        return sympy2symengine(x, True) * sympy2symengine(y, True)
     elif isinstance(a, sympy.Add):
         x, y = a.as_two_terms()
-        return sympy2symengine(x, True, prefer_mpfr) + sympy2symengine(y, True, prefer_mpfr)
+        return sympy2symengine(x, True) + sympy2symengine(y, True)
     elif isinstance(a, (sympy.Pow, sympy.exp)):
         x, y = a.as_base_exp()
-        return sympy2symengine(x, True, prefer_mpfr) ** sympy2symengine(y, True, prefer_mpfr)
+        return sympy2symengine(x, True) ** sympy2symengine(y, True)
     elif isinstance(a, sympy.Integer):
         return Integer(a.p)
     elif isinstance(a, sympy.Rational):
         return Integer(a.p) / Integer(a.q)
     elif isinstance(a, sympy.Float):
         IF HAVE_SYMENGINE_MPFR:
-            if prefer_mpfr:
+            if a._prec > 53:
                 return RealMPFR(str(a), a._prec)
             else:
                 return RealDouble(float(str(a)))
@@ -188,7 +185,7 @@ def sympy2symengine(a, raise_error=False, prefer_mpfr=True):
     elif isinstance(a, sympy.log):
         return log(a.args[0])
     elif isinstance(a, sympy.Abs):
-        return abs(sympy2symengine(a.args[0], True, prefer_mpfr))
+        return abs(sympy2symengine(a.args[0], True))
     elif isinstance(a, sympy.Derivative):
         return Derivative(a.expr, a.variables)
     elif isinstance(a, sympy.Subs):
@@ -208,7 +205,7 @@ def sympy2symengine(a, raise_error=False, prefer_mpfr=True):
     if raise_error:
         raise SympifyError("sympy2symengine: Cannot convert '%r' to a symengine type." % a)
 
-def sympify(a, raise_error=True, prefer_mpfr=True):
+def sympify(a, raise_error=True):
     """
     Converts an expression 'a' into a SymEngine type.
 
@@ -218,8 +215,6 @@ def sympify(a, raise_error=True, prefer_mpfr=True):
     a ............. An expression to convert.
     raise_error ... Will raise an error on a failure (default True), otherwise
                     it returns None if 'a' cannot be converted.
-    prefer_mpfr ... Whether MPFR of double are preferred the preferred conversion
-                    for sympy.Float.
 
     Examples
     ========
@@ -242,18 +237,18 @@ def sympify(a, raise_error=True, prefer_mpfr=True):
     elif isinstance(a, tuple):
         v = []
         for e in a:
-            v.append(sympify(e, True, prefer_mpfr))
+            v.append(sympify(e, True))
         return tuple(v)
     elif isinstance(a, list):
         v = []
         for e in a:
-            v.append(sympify(e, True, prefer_mpfr))
+            v.append(sympify(e, True))
         return v
     elif hasattr(a, '_symengine_'):
         return a._symengine_()
     elif hasattr(a, '_sympy_'):
-        return sympy2symengine(a._sympy_(), raise_error, prefer_mpfr)
-    return sympy2symengine(a, raise_error, prefer_mpfr)
+        return sympy2symengine(a._sympy_(), raise_error)
+    return sympy2symengine(a, raise_error)
 
 cdef class Basic(object):
 
@@ -1745,7 +1740,6 @@ def powermod_list(a, b, m):
         s.append(c2py(<RCP[const symengine.Basic]>(v[i])))
     return s
 
-# Is this really intentional? eval_double already defined earlier:
 def eval_double(basic):
     cdef Basic b = sympify(basic)
     return symengine.eval_double(deref(b.thisptr))
@@ -1871,7 +1865,7 @@ cdef class Lambdify(object):
                     self.args.push_back(deref(mtx).get(ri, ci))
         else:
             for e in args:
-                e_ = sympify(e, prefer_mpfr=False)
+                e_ = sympify(e)
                 self.args.push_back(e_.thisptr)
 
         if isinstance(exprs, DenseMatrix):
@@ -1887,7 +1881,7 @@ cdef class Lambdify(object):
             except AttributeError:
                 exprs = tuple(exprs)
             for e in exprs:
-                e_ = sympify(e, prefer_mpfr=False)
+                e_ = sympify(e)
                 self.exprs.push_back(e_.thisptr)
 
     # Two fused types InType and OutType are the same, but with Cython >= 0.21,

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -1953,7 +1953,12 @@ cdef class Lambdify(object):
         cdef double complex[::1] cmplx_out_view, cmplx_inp_view
         cdef size_t nbroadcast = 1
 
-        inp_shape = getattr(inp, 'shape', (len(inp),))
+        try:
+            inp_shape = getattr(inp, 'shape', (len(inp),))
+        except TypeError:
+            inp = tuple(inp)
+            inp_shape = (len(inp),)
+
         inp_size = reduce(mul, inp_shape)
         if inp_size % self.inp_size != 0:
             raise ValueError("Broadcasting failed")

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -1708,7 +1708,7 @@ import cython
 from operator import mul
 from functools import reduce
 from libc.string cimport memcpy
-
+cimport cpython.version  # To detect 2.6 since it lacks memoryview object
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
@@ -1731,7 +1731,12 @@ def with_buffer(iterable):
         if not, return a cython.view.array object (which does) """
     cdef double[::1] cy_arr_view
     try:
-        memoryview(iterable)
+        if PY_MAJOR_VERSION == 2 and PY_MINOR_VERSION == 6:
+            eval('buffer(iterable)')
+        else:
+            eval('memoryview(iterable)')
+        # When dropping 2.6, above may be replaced by:
+        # memoryview(iterable)
     except TypeError:
         # Cython's array to the rescue
         cy_arr =  cython.view.array(shape=(_size(iterable),),

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -5,6 +5,12 @@ from libcpp cimport bool
 from libcpp.string cimport string
 from cpython cimport PyObject, Py_XINCREF, Py_XDECREF, \
     PyObject_CallMethodObjArgs
+from libc.string cimport memcpy
+import cython
+import warnings
+from operator import mul
+from functools import reduce
+
 
 include "config.pxi"
 
@@ -1732,17 +1738,6 @@ def eval_double(basic):
     cdef Basic b = sympify(basic)
     return symengine.eval_double(deref(b.thisptr))
 
-# Prototype for Lambdify below
-
-import cython
-import warnings
-from operator import mul
-from functools import reduce
-from libc.string cimport memcpy
-
-# To detect 2.6 since it lacks memoryview object:
-from cpython.version cimport PY_MAJOR_VERSION, PY_MINOR_VERSION
-
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
@@ -1914,16 +1909,18 @@ cdef class Lambdify(object):
         else:
             as_complex(expr_subs, out)
 
-    cpdef void unsafe_real_real(self, double[::1] inp, double[::1] out):
+    # the four cpdef:ed methods below may use void return type
+    # once Cython 0.23 (from 2015) is acceptable as requirement.
+    cpdef unsafe_real_real(self, double[::1] inp, double[::1] out):
         self._eval(inp, out)
 
-    cpdef void unsafe_real_complex(self, double[::1] inp, double complex[::1] out):
+    cpdef unsafe_real_complex(self, double[::1] inp, double complex[::1] out):
         self._eval(inp, out)
 
-    cpdef void unsafe_complex_real(self, double complex[::1] inp, double[::1] out):
+    cpdef unsafe_complex_real(self, double complex[::1] inp, double[::1] out):
         self._eval(inp, out)
 
-    cpdef void unsafe_complex_complex(self, double complex[::1] inp, double complex[::1] out):
+    cpdef unsafe_complex_complex(self, double complex[::1] inp, double complex[::1] out):
         self._eval(inp, out)
 
     def __call__(self, inp, out=None, use_numpy=None, complex_in=False, complex_out=False):

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -1826,7 +1826,7 @@ cdef class Lambdify(object):
     # fused types have to be declared under different names to generate different
     # methods for each combination of inp and out
 
-    cdef void _real(self, InType[::1] inp, OutType[::1] out):
+    cdef void _eval(self, InType[::1] inp, OutType[::1] out):
         cdef symengine.map_basic_basic d
         cdef symengine.vec_basic expr_subs
         cdef size_t idx, ninp = inp.size, nout = out.size
@@ -1854,16 +1854,16 @@ cdef class Lambdify(object):
             as_complex(expr_subs, out)
 
     cdef void _real_real(self, double[::1] inp, double[::1] out):
-        self._real(inp, out)
+        self._eval(inp, out)
 
     cdef void _real_complex(self, double[::1] inp, double complex[::1] out):
-        self._real(inp, out)
+        self._eval(inp, out)
 
     cdef void _complex_real(self, double complex[::1] inp, double[::1] out):
-        self._real(inp, out)
+        self._eval(inp, out)
 
     cdef void _complex_complex(self, double complex[::1] inp, double complex[::1] out):
-        self._real(inp, out)
+        self._eval(inp, out)
 
     def __call__(self, inp, out=None, use_numpy=None, complex_in=False, complex_out=False):
         """

--- a/symengine/python/symengine/tests/CMakeLists.txt
+++ b/symengine/python/symengine/tests/CMakeLists.txt
@@ -12,5 +12,6 @@ install(FILES __init__.py
     test_sympify.py
     test_sympy_conv.py
     test_var.py
+    test_lambdify.py
     DESTINATION ${PY_PATH}
     )

--- a/symengine/python/symengine/tests/test_lambdify.py
+++ b/symengine/python/symengine/tests/test_lambdify.py
@@ -34,13 +34,13 @@ def test_Lambdify():
 
 def _get_2_to_2by2_numpy():
     args = x, y = se.symbols('x y')
-    exprs = np.array([[x+y, x*y],
+    exprs = np.array([[x+y+1.0, x*y],
                       [x/y, x**y]])
     l = se.Lambdify(args, exprs)
 
     def check(A, inp):
         X, Y = inp
-        assert abs(A[0, 0] - (X+Y)) < 1e-15
+        assert abs(A[0, 0] - (X+Y+1.0)) < 1e-15
         assert abs(A[0, 1] - (X*Y)) < 1e-15
         assert abs(A[1, 0] - (X/Y)) < 1e-15
         assert abs(A[1, 1] - (X**Y)) < 1e-13

--- a/symengine/python/symengine/tests/test_lambdify.py
+++ b/symengine/python/symengine/tests/test_lambdify.py
@@ -6,9 +6,19 @@ import numpy as np
 from symengine import Lambdify
 
 def test_Lambdify():
-    pass
     n = 7
     args = x, y, z = se.symbols('x y z')
     l = Lambdify(args, [x+y+z, x**2, (x-y)/z, x*y*z])
     assert np.allclose(l(range(n, n+len(args))),
                        [3*n+3, n**2, -1/(n+2), n*(n+1)*(n+2)])
+
+def test_Lambdify_2dim_numpy():
+    args = x, y = se.symbols('x y')
+    exprs = np.array([[x+y, x*y],
+                      [x/y, x**y]])
+    l = Lambdify(args, exprs)
+    A = l((5, 7))
+    assert abs(A[0, 0] - 12) < 1e-15
+    assert abs(A[0, 1] - 35) < 1e-15
+    assert abs(A[1, 0] - 5/7) < 1e-15
+    assert abs(A[1, 1] - 5**7) < 1e-13

--- a/symengine/python/symengine/tests/test_lambdify.py
+++ b/symengine/python/symengine/tests/test_lambdify.py
@@ -60,7 +60,7 @@ def _get_array():
     ref = [X+Y+Z, math.sin(X)*math.log(Y)*math.exp(Z)]
 
     def check(arr):
-        assert all([abs(x1-x2) < 1e-15 for x1, x2 in zip(ref, arr)])
+        assert all([abs(x1-x2) < 1e-13 for x1, x2 in zip(ref, arr)])
     return args, exprs, inp, check
 
 

--- a/symengine/python/symengine/tests/test_lambdify.py
+++ b/symengine/python/symengine/tests/test_lambdify.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import array
 import cmath
+import itertools
 import math
 import operator
 import sys
@@ -224,7 +225,6 @@ def _get_1_to_2by3_matrix():
 
     def check(A, inp):
         X, = inp
-        print(np.array(A), np.array(A).shape)
         assert abs(A[0, 0] - (X+1)) < 1e-15
         assert abs(A[0, 1] - (X+2)) < 1e-15
         assert abs(A[0, 2] - (X+3)) < 1e-15
@@ -254,7 +254,6 @@ def _test_2dim_Matrix_broadcast(use_numpy):
     l, check = _get_1_to_2by3_matrix()
     inp = range(1, 5)
     out = l(inp, use_numpy=use_numpy)
-    print(np.array(out))  # debug
     for i in range(len(inp)):
         check(out[i, ...], (inp[i],))
 
@@ -283,6 +282,7 @@ def test_jacobian():
                              [Y + 1, X + 1]])
 
 
+@pytest.mark.skipif(not HAVE_NUMPY, reason='requires numpy')
 def test_excessive_args():
     x = se.symbols('x')
     lmb = se.Lambdify([x], [-x])
@@ -293,6 +293,7 @@ def test_excessive_args():
     assert np.allclose(out, -1)
 
 
+@pytest.mark.skipif(not HAVE_NUMPY, reason='requires numpy')
 def test_excessive_out():
     x = se.symbols('x')
     lmb = se.Lambdify([x], [-x])
@@ -343,6 +344,7 @@ def test_2_to_2by2_numpy():
     check(A, inp)
 
 
+@pytest.mark.skipif(not HAVE_NUMPY, reason='requires numpy')
 def test_unsafe_real_real():
     l, check = _get_2_to_2by2_list()
     inp = np.array([13., 17.])
@@ -351,6 +353,7 @@ def test_unsafe_real_real():
     check(out.reshape((2, 2)), inp)
 
 
+@pytest.mark.skipif(not HAVE_NUMPY, reason='requires numpy')
 def test_unsafe_real_complex():
     l, check = _get_2_to_2by2_list()
     inp = np.array([-4, 17.])
@@ -359,6 +362,7 @@ def test_unsafe_real_complex():
     check(out.reshape((2, 2)), inp)
 
 
+@pytest.mark.skipif(not HAVE_NUMPY, reason='requires numpy')
 def test_unsafe_complex_real():
     l, check = _get_2_to_2by2_list()
     inp = np.array([13, 4j], dtype=np.complex128)
@@ -367,9 +371,17 @@ def test_unsafe_complex_real():
     check(out.reshape((2, 2)), inp)
 
 
+@pytest.mark.skipif(not HAVE_NUMPY, reason='requires numpy')
 def test_unsafe_complex_complex():
     l, check = _get_2_to_2by2_list()
     inp = np.array([13+11j, 7+4j], dtype=np.complex128)
     out = np.empty(4, dtype=np.complex128)
     l.unsafe_complex_complex(inp, out)
     check(out.reshape((2, 2)), inp)
+
+
+def test_itertools_chain():
+    l, check = _get_2_to_2by2_list()
+    inp = itertools.chain([13], [17])
+    A = l(inp, use_numpy=False)
+    check(A, inp)

--- a/symengine/python/symengine/tests/test_lambdify.py
+++ b/symengine/python/symengine/tests/test_lambdify.py
@@ -35,7 +35,6 @@ def _get_2_to_2by2_numpy():
                       [x/y, x**y]])
     l = se.Lambdify(args, exprs)
     def check(A, inp):
-        print(A)
         X, Y = inp
         assert abs(A[0, 0] - (X+Y)) < 1e-15
         assert abs(A[0, 1] - (X*Y)) < 1e-15
@@ -47,7 +46,9 @@ def _get_2_to_2by2_numpy():
 def test_Lambdify_2dim_numpy():
     lmb, check = _get_2_to_2by2_numpy()
     for inp in [(5, 7), np.array([5, 7]), [5.0, 7.0]]:
-        check(lmb(inp), inp)
+        A = lmb(inp)
+        assert A.shape == (2, 2)
+        check(A, inp)
 
 
 def _get_array():
@@ -169,7 +170,6 @@ def test_cse():
     cse_lambda = se.Lambdify(args, cse_exprs)
     cse_vals = cse_lambda(inp)
     new_inp = np.concatenate((inp, cse_vals))
-    print(args, cse_symbs, new_exprs, new_inp, cse_vals)
     out = lmb(new_inp)
     assert allclose(out, ref)
 
@@ -192,3 +192,26 @@ def test_broadcast_fortran():
     assert A.shape == (3, 2, 2)
     for i in range(n):
         check(A[i, ...], inp[i, :])
+
+
+def _get_1_to_2by3_matrix():
+    x = se.symbols('x')
+    args = x,
+    exprs = se.DenseMatrix(2, 3, [x+1, x+2, x+3,
+                                  1/x, 1/(x*x), 1/(x**3.0)])
+    l = se.Lambdify(args, exprs)
+    def check(A, inp):
+        X, = inp
+        assert abs(A[0, 0] - (X+1)) < 1e-15
+        assert abs(A[0, 1] - (X+2)) < 1e-15
+        assert abs(A[0, 2] - (X+3)) < 1e-15
+        assert abs(A[1, 0] - (1/X)) < 1e-15
+        assert abs(A[1, 1] - (1/(X*X))) < 1e-15
+        assert abs(A[1, 2] - (1/(X**3.0))) < 1e-15
+    return l, check
+
+
+def test_2dim_Matrix():
+    l, check = _get_1_to_2by3_matrix()
+    inp = [7]
+    check(l(inp), inp)

--- a/symengine/python/symengine/tests/test_lambdify.py
+++ b/symengine/python/symengine/tests/test_lambdify.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function)
+
+import symengine as se
+import numpy as np
+from symengine import Lambdify
+
+def test_Lambdify():
+    pass
+    n = 7
+    args = x, y, z = se.symbols('x y z')
+    l = Lambdify(args, [x+y+z, x**2, (x-y)/z, x*y*z])
+    assert np.allclose(l(range(n, n+len(args))),
+                       [3*n+3, n**2, -1/(n+2), n*(n+1)*(n+2)])

--- a/symengine/python/symengine/tests/test_lambdify.py
+++ b/symengine/python/symengine/tests/test_lambdify.py
@@ -1,24 +1,55 @@
 # -*- coding: utf-8 -*-
 from __future__ import (absolute_import, division, print_function)
 
-import symengine as se
+import array
+import math
+import sys
+
+import pytest
 import numpy as np
-from symengine import Lambdify
+
+import symengine as se
+
 
 def test_Lambdify():
     n = 7
     args = x, y, z = se.symbols('x y z')
-    l = Lambdify(args, [x+y+z, x**2, (x-y)/z, x*y*z])
+    l = se.Lambdify(args, [x+y+z, x**2, (x-y)/z, x*y*z])
     assert np.allclose(l(range(n, n+len(args))),
                        [3*n+3, n**2, -1/(n+2), n*(n+1)*(n+2)])
+
 
 def test_Lambdify_2dim_numpy():
     args = x, y = se.symbols('x y')
     exprs = np.array([[x+y, x*y],
                       [x/y, x**y]])
-    l = Lambdify(args, exprs)
+    l = se.Lambdify(args, exprs)
     A = l((5, 7))
     assert abs(A[0, 0] - 12) < 1e-15
     assert abs(A[0, 1] - 35) < 1e-15
     assert abs(A[1, 0] - 5/7) < 1e-15
     assert abs(A[1, 1] - 5**7) < 1e-13
+
+def _get_array():
+    X, Y, Z = inp = array.array('d', [1, 2, 3])
+    args = x, y, z = se.symbols('x y z')
+    exprs = [x+y+z, se.sin(x)*se.log(y)*se.exp(z)]
+    ref = [X+Y+Z, math.sin(X)*math.log(Y)*math.exp(Z)]
+    return args, exprs, inp, ref
+
+
+def test_array():
+    args, exprs, inp, ref = _get_array()
+    lmb = se.Lambdify(args, exprs)
+    out = lmb(inp)
+    assert all([abs(x1-x2) < 1e-15 for x1, x2 in zip(ref, out)])
+
+
+@pytest.mark.skipif(sys.version_info[0] < 3, reason='requires Py3')
+def test_array_out():
+    args, exprs, inp, ref = _get_array()
+    lmb = se.Lambdify(args, exprs)
+    out1 = array.array('d', [0, 0, 0])
+    out2 = lmb(inp, out1)
+    assert out1 is out2
+    assert all([abs(x1-x2) < 1e-15 for x1, x2 in zip(ref, out1)])

--- a/symengine/python/symengine/tests/test_matrices.py
+++ b/symengine/python/symengine/tests/test_matrices.py
@@ -2,6 +2,14 @@ from symengine import symbols
 from symengine.lib.symengine_wrapper import (DenseMatrix, Symbol, Integer,
     function_symbol, I, NonSquareMatrixError)
 from symengine.utilities import raises
+import pytest
+
+try:
+    import numpy as np
+    HAVE_NUMPY = True
+except ImportError:
+    HAVE_NUMPY = False
+
 
 def test_get():
     A = DenseMatrix(2, 2, [1, 2, 3, 4])
@@ -245,3 +253,27 @@ def test_jacobian():
     x = DenseMatrix(4, 1, [x, y, z, t])
     J = D.jacobian(x)
     assert J == J_correct
+
+def test_len():
+    A = DenseMatrix(2, 2, [1, 2, 3, 4])
+    assert len(A) == 4
+
+def test_shape():
+    A = DenseMatrix(2, 2, [1, 2, 3, 4])
+    assert A.shape == (2, 2)
+
+@pytest.mark.skipif(not HAVE_NUMPY, reason='requires numpy')
+def test_dump_real():
+    ref = [1, 2, 3, 4]
+    A = DenseMatrix(2, 2, ref)
+    out = np.empty(4)
+    A.dump_real(out)
+    assert np.allclose(out, ref)
+
+@pytest.mark.skipif(not HAVE_NUMPY, reason='requires numpy')
+def test_dump_complex():
+    ref = [1j, 2j, 3j, 4j]
+    A = DenseMatrix(2, 2, ref)
+    out = np.empty(4, dtype=np.complex128)
+    A.dump_complex(out)
+    assert np.allclose(out, ref)


### PR DESCRIPTION
This is a suggestion for lambdify functionality.

- [x] handle numpy dependency (~~currently just assumed, any ideas?~~) - made optional
- [x] add numpy to CI(?)
- [x] support symengine.DenseMatrix (needs testing)
- [x] extended testing for different input shapes and orders (C and Fortran)
- [x] complex data type (what about taking two kwargs: `complex_in=False, complex_out=False` in `__call__`.
- [x] support for broadcasting (input is always converted to be C-contiguous, inp.shape[:-1] are the broadcasted dimensions).
- [x] Common subexpression elimination convenience (`LambdifyCSE`)
- [x] add benchmarks for Lambdify
- [ ] optimize the implementation (see `benchmarks/Lambdify.py`)

I am rather new to CMake etc so please let me know if there are things I've missed.