### PR TITLE
Use C++ lambda expressions for Lambdify (no deferred exception)

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -55,7 +55,7 @@ set(HEADERS
     basic-inl.h  dict.h           matrix.h     ntheory.h    rational.h complex.h
     visitor.h    eval_double.h    diophantine.h cwrapper.h  printer.h  real_double.h
     eval_mpfr.h  eval_arb.h       eval_mpc.h    complex_double.h
-    real_mpfr.h  complex_mpc.h    type_codes.inc
+    real_mpfr.h  complex_mpc.h    type_codes.inc lambda_double.h
 )
 
 # Configure SymEngine using our CMake options:

--- a/symengine/lambda_double.h
+++ b/symengine/lambda_double.h
@@ -1,0 +1,309 @@
+#ifndef SYMENGINE_LAMBDA_DOUBLE_H
+#define SYMENGINE_LAMBDA_DOUBLE_H
+
+#include <cmath>
+#include <functional>
+#include <complex>
+
+#include <symengine/basic.h>
+#include <symengine/symbol.h>
+#include <symengine/add.h>
+#include <symengine/integer.h>
+#include <symengine/rational.h>
+#include <symengine/complex.h>
+#include <symengine/mul.h>
+#include <symengine/pow.h>
+#include <symengine/functions.h>
+#include <symengine/constants.h>
+#include <symengine/visitor.h>
+#include <symengine/eval_double.h>
+
+namespace SymEngine {
+
+template<typename T, typename U>
+class LambdaDoubleVisitor : public BaseVisitor<U> {
+protected:
+/*
+   The 'result_' variable is assigned into at the very end of each visit()
+   methods below. The only place where these methods are called from is the
+   line 'b.accept(*this)' in apply() and the 'result_' is immediately
+   returned. Thus no corruption can happen and apply() can be safely called
+   recursively.
+*/
+
+    typedef std::function<T(const std::vector<T> &x)> fn;
+    fn result_;
+    vec_basic symbols;
+public:
+    LambdaDoubleVisitor(U *p) : BaseVisitor<U>(p) {
+    }
+
+    void init(const vec_basic &x, const Basic &b) {
+        symbols = x;
+        apply(b);
+    }
+
+    fn apply(const Basic &b) {
+        b.accept(*this);
+        return result_;
+    }
+
+    T call(const std::vector<T> &vec) {
+        return result_(vec);
+    }
+
+    void bvisit(const Integer &x) {
+        T tmp = x.i.get_d();
+        result_ = [=](const std::vector<T> &x_){ return tmp; };
+    }
+
+    void bvisit(const Rational &x) {
+        T tmp = x.i.get_d();
+        result_ = [=](const std::vector<T> &x){ return tmp; };
+    }
+
+    void bvisit(const RealDouble &x) {
+        T tmp = x.i;
+        result_ = [=](const std::vector<T> &x){ return tmp; };
+    }
+
+#ifdef HAVE_SYMENGINE_MPFR
+    void bvisit(const RealMPFR &x) {
+        T tmp = mpfr_get_d(x.i.get_mpfr_t(), MPFR_RNDN);
+        result_ = [=](const std::vector<T> &x){ return tmp; };
+    }
+#endif
+
+    void bvisit(const Add &x) {
+        fn tmp = apply(*x.coef_);
+        fn tmp1, tmp2;
+        for (auto &p: x.dict_) {
+            tmp1 = apply(*(p.first));
+            tmp2 = apply(*(p.second));
+            tmp = [=](const std::vector<T> &x){ return tmp(x) + tmp1(x) * tmp2(x); };
+        }
+        result_ = tmp;
+    }
+
+    void bvisit(const Mul &x) {
+        fn tmp = apply(*x.coef_);
+        fn tmp1, tmp2;
+        for (auto &p: x.dict_) {
+            tmp1 = apply(*(p.first));
+            tmp2 = apply(*(p.second));
+            tmp = [=](const std::vector<T> &x){ return tmp(x) * std::pow(tmp1(x), tmp2(x)); };
+        }
+        result_ = tmp;
+    }
+
+    void bvisit(const Pow &x) {
+        fn exp_ = apply(*(x.get_exp()));
+        if (eq(*(x.get_base()), *E)) {
+            result_ = [=](const std::vector<T> &x){ return std::exp(exp_(x)); };
+        } else {
+            fn base_ = apply(*(x.get_base()));
+            result_ = [=](const std::vector<T> &x){ return std::pow(base_(x), exp_(x)); };
+        }
+    }
+
+    void bvisit(const Sin &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::sin(tmp(x)); };
+    }
+
+    void bvisit(const Cos &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::cos(tmp(x)); };
+    }
+
+    void bvisit(const Tan &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::tan(tmp(x)); };
+    }
+
+    void bvisit(const Symbol &x) {
+        std::cout << "Searching for " << x.__str__() << " in vector of size " << symbols.size() << std::endl;
+        for (unsigned i = 0; i < symbols.size(); ++i) {
+            std::cout << "Searched " << symbols[i]->__str__() << std::endl;
+            if (eq(x, *symbols[i])) {
+                result_ = [=](const std::vector<T> &x){ return x[i]; };
+                return;
+            }
+        }
+        throw std::runtime_error("Symbol not in the symbols vector.");
+    };
+
+    void bvisit(const Log &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::log(tmp(x)); };
+    };
+
+    void bvisit(const Cot &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return 1.0 / std::tan(tmp(x)); };
+    };
+
+    void bvisit(const Csc &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return 1.0 / std::sin(tmp(x)); };
+    };
+
+    void bvisit(const Sec &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return 1.0 / std::cos(tmp(x)); };
+    };
+
+    void bvisit(const ASin &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::asin(tmp(x)); };
+    };
+
+    void bvisit(const ACos &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::acos(tmp(x)); };
+    };
+
+    void bvisit(const ASec &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::acos(1.0 / tmp(x)); };
+    };
+
+    void bvisit(const ACsc &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::asin(1.0 / tmp(x)); };
+    };
+
+    void bvisit(const ATan &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::atan(tmp(x)); };
+    };
+
+    void bvisit(const ACot &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::atan(1.0 / tmp(x)); };
+    };
+
+    void bvisit(const Sinh &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::sinh(tmp(x)); };
+    };
+
+    void bvisit(const Cosh &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::cosh(tmp(x)); };
+    };
+
+    void bvisit(const Tanh &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::tanh(tmp(x)); };
+    };
+
+    void bvisit(const Coth &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return 1.0 / std::tanh(tmp(x)); };
+    };
+
+    void bvisit(const ASinh &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::asinh(tmp(x)); };
+    };
+
+    void bvisit(const ACosh &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::acosh(tmp(x)); };
+    };
+
+    void bvisit(const ATanh &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::atanh(tmp(x)); };
+    };
+
+    void bvisit(const ACoth &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::atanh(1.0 / tmp(x)); };
+    };
+
+    void bvisit(const ASech &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::acosh(1.0 / tmp(x)); };
+    };
+
+    void bvisit(const Constant &x) {
+        if (eq(x, *pi)) {
+            result_ = [=](const std::vector<T> &x){ return std::atan2(0, -1); };
+        } else if (eq(x, *E)) {
+            result_ = [=](const std::vector<T> &x){ return std::exp(1); };
+        } else {
+            throw std::runtime_error("Constant " + x.get_name() + " is not implemented.");
+        }
+    };
+
+    void bvisit(const Abs &x) {
+        fn tmp = apply(*(x.get_arg()));
+        result_ = [=](const std::vector<T> &x){ return std::abs(tmp(x)); };
+    };
+
+    void bvisit(const Basic &) {
+        throw std::runtime_error("Not implemented.");
+    };
+};
+
+
+class LambdaRealDoubleVisitor : public LambdaDoubleVisitor<double, LambdaRealDoubleVisitor> {
+public:
+    LambdaRealDoubleVisitor() : LambdaDoubleVisitor(this) { };
+
+    // Classes not implemented are
+    // Subs, UpperGamma, LowerGamma, Dirichlet_eta, Zeta
+    // LeviCivita, KroneckerDelta, FunctionSymbol, LambertW
+    // Derivative, Complex, ComplexDouble, ComplexMPC
+
+    using LambdaDoubleVisitor::bvisit;
+
+    void bvisit(const ATan2 &x) {
+        fn num = apply(*(x.get_num()));
+        fn den = apply(*(x.get_den()));
+        result_ = [=](const std::vector<double> &x){ return std::atan2(num(x), den(x)); };
+    };
+
+    void bvisit(const Gamma &x) {
+        fn tmp = apply(*(x.get_args()[0]));
+        result_ = [=](const std::vector<double> &x){ return std::tgamma(tmp(x)); };
+    };
+};
+
+class LambdaComplexDoubleVisitor : public LambdaDoubleVisitor<std::complex<double>, LambdaComplexDoubleVisitor> {
+public:
+    LambdaComplexDoubleVisitor() : LambdaDoubleVisitor(this) { };
+
+    // Classes not implemented are
+    // Subs, UpperGamma, LowerGamma, Dirichlet_eta, Zeta
+    // LeviCivita, KroneckerDelta, FunctionSymbol, LambertW
+    // Derivative, ATan2, Gamma
+
+    using LambdaDoubleVisitor::bvisit;
+
+    void bvisit(const Complex &x) {
+        double t1 = x.real_.get_d(), t2 = x.imaginary_.get_d();
+        result_ = [=](const std::vector<std::complex<double>> &x){ return std::complex<double>(t1, t2); };
+    };
+
+    void bvisit(const ComplexDouble &x) {
+        std::complex<double> tmp = x.i;
+        result_ = [=](const std::vector<std::complex<double>> &x){ return tmp; };
+    };
+#ifdef HAVE_SYMENGINE_MPC
+    void bvisit(const ComplexMPC &x) {
+        mpfr_class t(x.get_prec());
+        double real, imag;
+        mpc_real(t.get_mpfr_t(), x.i.get_mpc_t(), MPFR_RNDN);
+        real = mpfr_get_d(t.get_mpfr_t(), MPFR_RNDN);
+        mpc_imag(t.get_mpfr_t(), x.i.get_mpc_t(), MPFR_RNDN);
+        imag = mpfr_get_d(t.get_mpfr_t(), MPFR_RNDN);
+        std::complex<double> tmp(real, imag);
+        result_ = [=](const std::vector<std::complex<double>> &x){ return tmp; };
+    }
+#endif
+};
+}
+#endif //SYMENGINE_LAMBDA_DOUBLE_H

--- a/symengine/lambda_double.h
+++ b/symengine/lambda_double.h
@@ -122,9 +122,7 @@ public:
     }
 
     void bvisit(const Symbol &x) {
-        std::cout << "Searching for " << x.__str__() << " in vector of size " << symbols.size() << std::endl;
         for (unsigned i = 0; i < symbols.size(); ++i) {
-            std::cout << "Searched " << symbols[i]->__str__() << std::endl;
             if (eq(x, *symbols[i])) {
                 result_ = [=](const std::vector<T> &x){ return x[i]; };
                 return;

--- a/symengine/tests/eval/CMakeLists.txt
+++ b/symengine/tests/eval/CMakeLists.txt
@@ -21,3 +21,7 @@ endif()
 add_executable(test_eval_double test_eval_double.cpp)
 target_link_libraries(test_eval_double symengine catch)
 add_test(test_eval_double ${PROJECT_BINARY_DIR}/test_eval_double)
+
+add_executable(test_lambda_double test_lambda_double.cpp)
+target_link_libraries(test_lambda_double symengine catch)
+add_test(test_lambda_double ${PROJECT_BINARY_DIR}/test_lambda_double)

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -35,10 +35,10 @@ TEST_CASE("Evaluate to double", "[lambda_double]")
     REQUIRE(::fabs(d - 1.75) < 1e-12);
 
     // Evaluating to double when there are complex doubles raise an exception
-    SYMENGINE_CHECK_THROW(v.init({x}, *add(complex_double(std::complex<double>(1, 2)), x)), std::runtime_error);
+    CHECK_THROW_AS(v.init({x}, *add(complex_double(std::complex<double>(1, 2)), x)), std::runtime_error);
 
     // Undefined symbols raise an exception
-    SYMENGINE_CHECK_THROW(v.init({x}, *r), std::runtime_error);
+    CHECK_THROW_AS(v.init({x}, *r), std::runtime_error);
 }
 
 TEST_CASE("Evaluate to std::complex<double>", "[lambda_complex_double]")
@@ -64,5 +64,5 @@ TEST_CASE("Evaluate to std::complex<double>", "[lambda_complex_double]")
     REQUIRE(::fabs(d.imag() - 0.0) < 1e-12);
 
     // Undefined symbols raise an exception
-    SYMENGINE_CHECK_THROW(v.init({x}, *r), std::runtime_error);
+    CHECK_THROW_AS(v.init({x}, *r), std::runtime_error);
 }

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -1,0 +1,72 @@
+#include "catch.hpp"
+
+#include <symengine/lambda_double.h>
+
+using SymEngine::Basic;
+using SymEngine::RCP;
+using SymEngine::real_double;
+using SymEngine::symbol;
+using SymEngine::add;
+using SymEngine::mul;
+using SymEngine::pow;
+using SymEngine::integer;
+using SymEngine::vec_basic;
+using SymEngine::complex_double;
+using SymEngine::LambdaRealDoubleVisitor;
+using SymEngine::LambdaComplexDoubleVisitor;
+
+TEST_CASE("Evaluate to double", "[lambda_double]")
+{
+    RCP<const Basic> x, y, z, r;
+    double d;
+    x = symbol("x");
+    y = symbol("y");
+    z = symbol("z");
+
+    r = add(x, add(mul(y, z), pow(x, integer(2))));
+
+    LambdaRealDoubleVisitor v;
+    v.init({x, y, z}, *r);
+
+    d = v.call({1.5, 2.0, 3.0});
+    REQUIRE(::fabs(d - 9.75) < 1e-12);
+
+    d = v.call({1.5, -1.0, 2.0});
+    REQUIRE(::fabs(d - 1.75) < 1e-12);
+
+    // Evaluating to double when there are complex doubles raise an exception
+    SYMENGINE_CHECK_THROW(v.init({x}, *add(complex_double(std::complex<double>(1, 2)), x)), std::runtime_error);
+
+    // When raise_error is False, exception is raised when called only.
+    v.init({x}, *add(complex_double(std::complex<double>(1, 2)), x), false);
+    SYMENGINE_CHECK_THROW(v.call({1.0}), std::runtime_error);
+
+    // Undefined symbols raise an exception
+    SYMENGINE_CHECK_THROW(v.init({x}, *r), std::runtime_error);
+}
+
+TEST_CASE("Evaluate to std::complex<double>", "[lambda_complex_double]")
+{
+    RCP<const Basic> x, y, z, r;
+    std::complex<double> d;
+    x = symbol("x");
+    y = symbol("y");
+    z = symbol("z");
+
+    r = add(x, add(mul(y, z), pow(x, complex_double(std::complex<double>(3, 4)))));
+
+    LambdaComplexDoubleVisitor v;
+    v.init({x, y, z}, *r);
+
+    d = v.call({std::complex<double>(1.5, 1.0), std::complex<double>(2.5, 4.0), std::complex<double>(-8.3, 3.2)});
+    REQUIRE(::fabs(d.real() + 32.360749607381) < 1e-12);
+    REQUIRE(::fabs(d.imag() + 24.6630395370884) < 1e-12);
+
+    v.init({x, y, z}, *add(x, add(mul(y, z), pow(x, integer(2)))));
+    d = v.call({std::complex<double>(1.5, 0.0), std::complex<double>(-1.0, 0.0), std::complex<double>(2.0, 0.0)});
+    REQUIRE(::fabs(d.real() - 1.75) < 1e-12);
+    REQUIRE(::fabs(d.imag() - 0.0) < 1e-12);
+
+    // Undefined symbols raise an exception
+    SYMENGINE_CHECK_THROW(v.init({x}, *r), std::runtime_error);
+}

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -35,10 +35,10 @@ TEST_CASE("Evaluate to double", "[lambda_double]")
     REQUIRE(::fabs(d - 1.75) < 1e-12);
 
     // Evaluating to double when there are complex doubles raise an exception
-    CHECK_THROW_AS(v.init({x}, *add(complex_double(std::complex<double>(1, 2)), x)), std::runtime_error);
+    CHECK_THROWS_AS(v.init({x}, *add(complex_double(std::complex<double>(1, 2)), x)), std::runtime_error);
 
     // Undefined symbols raise an exception
-    CHECK_THROW_AS(v.init({x}, *r), std::runtime_error);
+    CHECK_THROWS_AS(v.init({x}, *r), std::runtime_error);
 }
 
 TEST_CASE("Evaluate to std::complex<double>", "[lambda_complex_double]")
@@ -64,5 +64,5 @@ TEST_CASE("Evaluate to std::complex<double>", "[lambda_complex_double]")
     REQUIRE(::fabs(d.imag() - 0.0) < 1e-12);
 
     // Undefined symbols raise an exception
-    CHECK_THROW_AS(v.init({x}, *r), std::runtime_error);
+    CHECK_THROWS_AS(v.init({x}, *r), std::runtime_error);
 }

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -37,10 +37,6 @@ TEST_CASE("Evaluate to double", "[lambda_double]")
     // Evaluating to double when there are complex doubles raise an exception
     SYMENGINE_CHECK_THROW(v.init({x}, *add(complex_double(std::complex<double>(1, 2)), x)), std::runtime_error);
 
-    // When raise_error is False, exception is raised when called only.
-    v.init({x}, *add(complex_double(std::complex<double>(1, 2)), x), false);
-    SYMENGINE_CHECK_THROW(v.call({1.0}), std::runtime_error);
-
     // Undefined symbols raise an exception
     SYMENGINE_CHECK_THROW(v.init({x}, *r), std::runtime_error);
 }


### PR DESCRIPTION
This is from https://github.com/symengine/symengine/pull/603

It is an alternative to https://github.com/symengine/symengine/pull/621 which introduces a deferred exception.
This relies on choosing real/complex at instantiation of `Lamdify` from Python instead of at `__call__`.

cherry-picked from https://github.com/isuruf/symengine/commit/c0f757c4274c1eba7d48ffb899f81da6ae5eec64

~~Note: tests from #621 are still missing in this PR.~~ (they are in since 7248c1c)