### PR TITLE
Change libfind macro to function

### DIFF
--- a/cmake/LibFindMacros.cmake
+++ b/cmake/LibFindMacros.cmake
@@ -22,7 +22,7 @@
 #     set(LIBS ${LIBS} ${GMP_LIBRARIES})
 #     # LIBS is later used in target_link_libraries()
 
-macro (libfind_library libname pkg)
+function (libfind_library libname pkg)
     string(TOUPPER ${pkg} PKG)
     string(TOUPPER ${libname} LIBNAME)
 
@@ -64,9 +64,9 @@ macro (libfind_library libname pkg)
     else()
         set(${LIBNAME}_LIBRARY_FOUND yes)
     endif()
-endmacro()
+endfunction()
 
-macro (libfind_include HEADER pkg)
+function (libfind_include HEADER pkg)
     string(TOUPPER ${pkg} PKG)
 
     find_path(${PKG}_INCLUDE_DIR
@@ -95,4 +95,4 @@ macro (libfind_include HEADER pkg)
         PATH_SUFFIXES
             ${pkg}
     )
-endmacro()
+endfunction()


### PR DESCRIPTION
CMake's `function` has variable scopes while `macro` is textual replacements, which is not desirable when defining temporary variables inside a macro which are used elsewhere.