### PR TITLE
Fix not canonical bugs

### DIFF
--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -51,8 +51,12 @@ bool Mul::is_canonical(const RCP<const Number> &coef,
             return false;
         // e.g. (x*y)**2 (={xy:2}), which should be represented as x**2*y**2
         //     (={x:2, y:2})
-        if (is_a<Mul>(*p.first) && is_a<Integer>(*p.second))
-            return false;
+        if (is_a<Mul>(*p.first)) {
+            if (is_a<Integer>(*p.second)) return false;
+            if (neq(*static_cast<const Mul &>(*p.first).coef_, *one) &&
+                neq(*static_cast<const Mul &>(*p.first).coef_, *minus_one))
+                return false;
+        }
         // e.g. x**2**y (={x**2:y}), which should be represented as x**(2y)
         //     (={x:2y})
         if (is_a<Pow>(*p.first))

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -51,7 +51,7 @@ bool Mul::is_canonical(const RCP<const Number> &coef,
             return false;
         // e.g. (x*y)**2 (={xy:2}), which should be represented as x**2*y**2
         //     (={x:2, y:2})
-        if (is_a<Mul>(*p.first))
+        if (is_a<Mul>(*p.first) && is_a<Integer>(*p.second))
             return false;
         // e.g. x**2**y (={x**2:y}), which should be represented as x**(2y)
         //     (={x:2y})
@@ -123,7 +123,10 @@ RCP<const SymEngine::Basic> Mul::from_dict(const RCP<const Number> &coef, map_ba
         }
         if (coef->is_one()) {
             // Create a Pow() here:
-            return pow(p->first, p->second);
+            if (eq(*p->second, *one)) {
+                return p->first;
+            }
+            return make_rcp<const Pow>(p->first, p->second);
         } else {
             return make_rcp<const Mul>(coef, std::move(d));
         }
@@ -217,8 +220,10 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef, map_basic_basic 
                         rcp_static_cast<const Number>(it->second)));
                 }
                 d.erase(it);
+                return;
             } else if (rcp_static_cast<const Integer>(it->second)->is_zero()) {
                 d.erase(it);
+                return;
             } else if (is_a<Complex>(*t)) {
                 if (rcp_static_cast<const Integer>(it->second)->is_one()) {
                     imulnum(outArg(*coef), rcp_static_cast<const Number>(t));
@@ -227,6 +232,7 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef, map_basic_basic 
                     idivnum(outArg(*coef), rcp_static_cast<const Number>(t));
                     d.erase(it);
                 }
+                return;
             }
         } else if (is_a<Rational>(*it->second)) {
             if (is_a_Number(*t)) {
@@ -243,11 +249,22 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef, map_basic_basic 
                     imulnum(outArg(*coef), pownum(rcp_static_cast<const Number>(t),
                                                   rcp_static_cast<const Number>(integer(q))));
                 }
+                return;
             }
-        } else if (is_a_Number(*it->second) && static_cast<const Number &>(*it->second).is_zero()) {
-            // In 1*x**0.0, result should be 1.0
-            imulnum(outArg(*coef), pownum(rcp_static_cast<const Number>(it->second), zero));
-            d.erase(it);
+        }
+        if (is_a_Number(*it->second)) {
+            if (static_cast<const Number &>(*it->second).is_zero()) {
+                // In 1*x**0.0, result should be 1.0
+                imulnum(outArg(*coef), pownum(rcp_static_cast<const Number>(it->second), zero));
+                d.erase(it);
+            } else if (is_a<Mul>(*it->first)) {
+                RCP<const Mul> m = rcp_static_cast<const Mul>(it->first);
+                if (is_a<Integer>(*it->second) || (neq(*m->coef_, *one) && neq(*m->coef_, *minus_one))) {
+                    RCP<const Number> exp_ = rcp_static_cast<const Number>(it->second);
+                    d.erase(it);
+                    m->power_num(outArg(*coef), d, exp_);
+                }
+            }
         }
     }
 }
@@ -459,37 +476,60 @@ RCP<const Basic> mul_expand(const RCP<const Mul> &self)
     return mul_expand_two(a, b);
 }
 
-RCP<const Basic> Mul::power_all_terms(const RCP<const Basic> &exp) const
+void Mul::power_num(const Ptr<RCP<const Number>> &coef, map_basic_basic &d,
+                    const RCP<const Number> &exp) const
 {
     if (is_a_Number(*exp) && rcp_static_cast<const Number>(exp)->is_zero()) {
         // (x*y)**(0.0) should return 1.0
-        return pownum(rcp_static_cast<const Number>(exp), zero);
+        imulnum(coef, pownum(rcp_static_cast<const Number>(exp), zero));
+        return;
     }
-    SymEngine::map_basic_basic d;
-    RCP<const Basic> new_coef = pow(coef_, exp);
-    RCP<const Number> coef_num = one;
+    RCP<const Basic> new_coef;
     RCP<const Basic> new_exp;
-    for (auto &p: dict_) {
-        new_exp = mul(p.second, exp);
-        // No need for additional dict checks here.
-        // The dict should be of standard form before this is
-        // called.
-        Mul::dict_add_term_new(outArg(coef_num), d, new_exp, p.first);
+    if (is_a<Integer>(*exp)) {
+        // For eg. (3*y*(x**(1/2))**2 should be expanded to 9*x*y**2
+        new_coef = pow(coef_, exp);
+        for (auto &p: dict_) {
+            new_exp = mul(p.second, exp);
+            if (is_a<Integer>(*new_exp) && is_a<Mul>(*p.first)) {
+                static_cast<const Mul &>(*p.first).power_num(coef, d, rcp_static_cast<const Number>(new_exp));
+            } else {
+                // No need for additional dict checks here.
+                // The dict should be of standard form before this is
+                // called.
+                Mul::dict_add_term_new(coef, d, new_exp, p.first);
+            }
+        }
+    } else {
+        if (coef_->is_negative()) {
+            // (3*x*y)**(1/2) -> 3**(1/2)*(x*y)**(1/2)
+            new_coef = pow(coef_->mul(*minus_one), exp);
+            map_basic_basic d1 = dict_;
+            Mul::dict_add_term_new(coef, d, exp, Mul::from_dict(minus_one, std::move(d1)));
+        } else if (coef_->is_positive()) {
+            // (-3*x*y)**(1/2) -> 3**(1/2)*(-x*y)**(1/2)
+            new_coef = pow(coef_, exp);
+            map_basic_basic d1 = dict_;
+            Mul::dict_add_term_new(coef, d, exp, Mul::from_dict(one, std::move(d1)));
+        } else {
+            // ((1+2*I)*x*y)**(1/2) is kept as it is
+            new_coef = one;
+            Mul::dict_add_term_new(coef, d, exp, this->rcp_from_this());
+        }
     }
     if (is_a_Number(*new_coef)) {
-        imulnum(outArg(coef_num), rcp_static_cast<const Number>(new_coef));
+        imulnum(coef, rcp_static_cast<const Number>(new_coef));
     }  else if (is_a<Mul>(*new_coef)) {
         RCP<const Mul> tmp = rcp_static_cast<const Mul>(new_coef);
-        imulnum(outArg(coef_num), tmp->coef_);
+        imulnum(coef, tmp->coef_);
         for (auto &q: tmp->dict_) {
-            Mul::dict_add_term_new(outArg(coef_num), d, q.second, q.first);
+            Mul::dict_add_term_new(coef, d, q.second, q.first);
         }
     } else {
         RCP<const Basic> _exp, t;
         Mul::as_base_exp(new_coef, outArg(_exp), outArg(t));
-        Mul::dict_add_term_new(outArg(coef_num), d, _exp, t);
+        Mul::dict_add_term_new(coef, d, _exp, t);
     }
-    return Mul::from_dict(coef_num, std::move(d));
 }
 
 RCP<const Basic> Mul::diff(const RCP<const Symbol> &x) const

--- a/symengine/mul.h
+++ b/symengine/mul.h
@@ -50,7 +50,8 @@ public:
     void as_two_terms(const Ptr<RCP<const Basic>> &a,
             const Ptr<RCP<const Basic>> &b) const;
     //! Power all terms with the exponent `exp`
-    RCP<const Basic> power_all_terms(const RCP<const Basic> &exp) const;
+    void power_num(const Ptr<RCP<const Number>> &coef, map_basic_basic &d,
+                   const RCP<const Number> &exp) const;
 
     //! \return true if both `coef` and `dict` are in canonical form
     bool is_canonical(const RCP<const Number> &coef,

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -176,10 +176,11 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
             return rcp_static_cast<const Number>(a)->pow(*rcp_static_cast<const Number>(b));
         }
     }
-    if (is_a<Mul>(*a) && is_a<Integer>(*b)) {
-        // Convert (x*y)**b = x**b*y**b, where 'b' is an integer. This holds for
-        // any complex 'x', 'y' and integer 'b'.
-        return rcp_static_cast<const Mul>(a)->power_all_terms(b);
+    if (is_a<Mul>(*a) && is_a_Number(*b)) {
+        map_basic_basic d;
+        RCP<const Number> coef = one;
+        rcp_static_cast<const Mul>(a)->power_num(outArg(coef), d, rcp_static_cast<const Number>(b));
+        return Mul::from_dict(coef, std::move(d));
     }
     if (is_a<Pow>(*a) && is_a<Integer>(*b)) {
         // Convert (x**y)**b = x**(b*y), where 'b' is an integer. This holds for

--- a/symengine/tests/basic/test_arit.cpp
+++ b/symengine/tests/basic/test_arit.cpp
@@ -648,6 +648,18 @@ TEST_CASE("Pow: arit", "[arit]")
     r1 = pow(x, real_double(0.0));
     r2 = real_double(1.0);
     REQUIRE(eq(*r1, *r2));
+
+    r1 = sqrt(mul(i2, x));
+    r2 = mul(sqrt(i2), sqrt(x));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = sqrt(mul(neg(i2), x));
+    r2 = mul(sqrt(i2), sqrt(neg(x)));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = pow(mul(sqrt(mul(y, x)), x), i2);
+    r2 = mul(pow(x, i3), y);
+    REQUIRE(eq(*r1, *r2));
 }
 
 TEST_CASE("Log: arit", "[arit]")

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -66,7 +66,7 @@ TEST_CASE("test_printing(): printing", "[printing]")
     REQUIRE(r->__str__() == "23*(7/3)**(1/2)*(5/2)**(1/2)");
 
     r = pow(div(symbol("x"), integer(2)), div(integer(1), integer(2)));
-    REQUIRE(r->__str__() == "((1/2)*x)**(1/2)");
+    REQUIRE(r->__str__() == "(1/2)**(1/2)*x**(1/2)");
 
     r = pow(div(integer(3), integer(2)),div(integer(1), integer(2)));
     REQUIRE(r->__str__() == "(3/2)**(1/2)");


### PR DESCRIPTION
`sqrt(-2*x*y)` is expanded to `sqrt(2)*sqrt(-x*y)`
`pow(sqrt(x*y)*x, 2)` is expanded to `x**3*y`

Background: https://gitter.im/sympy/sympy?at=561260400b9059c80b7a5d0e was hitting not canonical errors and with this PR, all expressions are canonical.