### PR TITLE
Change FunctionWrapper as the base class for user defined functions

### DIFF
--- a/symengine/eval_arb.cpp
+++ b/symengine/eval_arb.cpp
@@ -220,7 +220,7 @@ public:
         throw std::runtime_error("Not implemented.");
     }
 
-    void bvisit(const FunctionSymbol &x) {
+    void bvisit(const FunctionWrapper &x) {
         x.eval(prec_)->accept(*this);
     }
 
@@ -278,9 +278,6 @@ public:
         throw std::runtime_error("Not implemented.");
     };
     void bvisit(const UpperGamma &) {
-        throw std::runtime_error("Not implemented.");
-    };
-    void bvisit(const FunctionWrapper &) {
         throw std::runtime_error("Not implemented.");
     };
 

--- a/symengine/eval_double.cpp
+++ b/symengine/eval_double.cpp
@@ -215,7 +215,7 @@ public:
         apply(*(x.eval(53)));
     }
 
-    void bvisit(const FunctionSymbol &x) {
+    void bvisit(const FunctionWrapper &x) {
         apply(*(x.eval(53)));
     }
 };

--- a/symengine/eval_mpc.cpp
+++ b/symengine/eval_mpc.cpp
@@ -253,7 +253,7 @@ public:
         x.eval(mpc_get_prec(result_))->accept(*this);
     }
 
-    void bvisit(const FunctionSymbol &x) {
+    void bvisit(const FunctionWrapper &x) {
         x.eval(mpc_get_prec(result_))->accept(*this);
     }
 

--- a/symengine/eval_mpfr.cpp
+++ b/symengine/eval_mpfr.cpp
@@ -227,7 +227,7 @@ public:
         x.eval(mpfr_get_prec(result_))->accept(*this);
     }
 
-    void bvisit(const FunctionSymbol &x) {
+    void bvisit(const FunctionWrapper &x) {
         x.eval(mpfr_get_prec(result_))->accept(*this);
     }
 

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1492,11 +1492,6 @@ RCP<const Basic> FunctionSymbol::subs(const map_basic_basic &subs_dict) const
     return create(v);
 }
 
-RCP<const Number> FunctionSymbol::eval(long bits) const
-{
-    throw std::runtime_error("Not Implemented/Defined");
-}
-
 RCP<const Basic> function_symbol(std::string name, const vec_basic &arg)
 {
     return make_rcp<const FunctionSymbol>(name, arg);
@@ -1507,52 +1502,21 @@ RCP<const Basic> function_symbol(std::string name, const RCP<const Basic> &arg)
     return make_rcp<const FunctionSymbol>(name, arg);
 }
 
-FunctionWrapper::FunctionWrapper(void* obj, std::string name, std::string hash, const vec_basic &arg,
-    void(*dec_ref)(void *), int(*comp)(void *, void *))
-    : FunctionSymbol(name, arg)
+FunctionWrapper::FunctionWrapper(std::string name, const RCP<const Basic> &arg)
+        : FunctionSymbol(name, arg)
 {
-    obj_ = obj;
-    hash_ = hash;
-    dec_ref_ = dec_ref;
-    comp_ = comp;
-    SYMENGINE_ASSERT(is_canonical(arg_))
+
 }
 
-FunctionWrapper::~FunctionWrapper()
+FunctionWrapper::FunctionWrapper(std::string name, const vec_basic &vec)
+        : FunctionSymbol(name, vec)
 {
-    (*dec_ref_)(obj_);
+
 }
 
-std::size_t FunctionWrapper::__hash__() const
+RCP<const Number> FunctionWrapper::eval(long bits) const
 {
-    std::size_t seed = 0;
-    hash_combine<std::string>(seed, hash_);
-    return seed;
-}
-
-int FunctionWrapper::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<FunctionWrapper>(o))
-    const FunctionWrapper &s = static_cast<const FunctionWrapper &>(o);
-    return (*comp_)(obj_, s.obj_);
-}
-
-bool FunctionWrapper::__eq__(const Basic &o) const
-{
-    if (is_a<FunctionWrapper>(o) and
-        (*comp_)(obj_, static_cast<const FunctionWrapper &>(o).obj_) == 0)
-        return true;
-    return false;
-}
-
-RCP<const Basic> FunctionWrapper::diff(const RCP<const Symbol> &x) const
-{
-    for (auto &a : arg_) {
-        if (neq(*a->diff(x), *zero)) {
-            return Derivative::create(rcp_from_this(), {x});
-        }
-    }
-    return zero;
+    throw std::runtime_error("Not Implemented.");
 }
 
 /* ---------------------------- */

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -544,7 +544,6 @@ public:
 
     virtual void accept(Visitor &v) const;
     virtual RCP<const Basic> create(const vec_basic &x) const;
-    virtual RCP<const Number> eval(long bits) const;
 };
 
 //! Create a new FunctionSymbol instance:
@@ -553,42 +552,17 @@ RCP<const Basic> function_symbol(std::string name,
 RCP<const Basic> function_symbol(std::string name,
         const vec_basic &arg);
 
-/*! Class to hold a pointer to a function object
-*   FunctionWrapper can be used to wrap any C/C++ object
-*   (eg: Python object through Python/C API) 
+/*! Use this class to define custom functions by overriding
+ *  the defaut behaviour for create, eval, diff, __eq__, compare etc.
 * */
 
 class FunctionWrapper: public FunctionSymbol {
-private:
-    void* obj_;
-    std::string hash_;
-    void (*dec_ref_)(void *);
-    int (*comp_)(void *, void *);
-
 public:
     IMPLEMENT_TYPEID(FUNCTIONWRAPPER)
-    /*! FunctionWrapper Constructor
-     * \param obj - Pointer to the function object
-     * \param name - Name of the function
-     * \param hash - Hash value of obj
-     * \param arg - Arguments of the function
-     * \param dec_ref - Function pointer to decrease the reference count
-     * \param comp - Function pointer to compare two function objects
-     * */
-    FunctionWrapper(void* obj, std::string name, std::string hash, const vec_basic &arg,
-        void (*dec_ref)(void *), int (*comp)(void *, void *));
-    ~FunctionWrapper();
-    virtual std::size_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
-    //! \return Pointer to the function object
-    inline void* get_object() const { return obj_; }
-
+    FunctionWrapper(std::string name, const vec_basic &arg);
+    FunctionWrapper(std::string name, const RCP<const Basic> &arg);
+    virtual RCP<const Number> eval(long bits) const;
     virtual void accept(Visitor &v) const;
-    virtual RCP<const Basic> create(const vec_basic &x) const {
-        throw std::runtime_error("Not Implmented.");
-    }
 };
 
 /*! Derivative operator


### PR DESCRIPTION
This is to make a distinction between `FunctionSymbol` and other user defined functions