### PR TITLE
Fix for #461

### DIFF
--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -7,6 +7,8 @@
 #ifndef SYMENGINE_INTEGER_H
 #define SYMENGINE_INTEGER_H
 
+#include <type_traits>
+
 #include <symengine/basic.h>
 #include <symengine/number.h>
 
@@ -152,12 +154,13 @@ struct RCPIntegerKeyLess
         return false;
     }
 };
-//! \return RCP<const Integer> from `int`
-inline RCP<const Integer> integer(int i)
+//! \return RCP<const Integer> from integral values
+template<typename T> inline
+typename std::enable_if<std::is_integral<T>::value, RCP<const Integer>>::type
+integer(T i)
 {
-    return make_rcp<const Integer>(i);
+    return make_rcp<const Integer>(mpz_class(i));
 }
-
 //! \return RCP<const Integer> from `mpz_class`
 inline RCP<const Integer> integer(mpz_class i)
 {
@@ -180,4 +183,3 @@ inline Integer::Integer(mpz_class i) : i{i} {}
 } // SymEngine
 
 #endif
-

--- a/symengine/tests/basic/test_integer.cpp
+++ b/symengine/tests/basic/test_integer.cpp
@@ -66,3 +66,16 @@ TEST_CASE("iabs: integer", "[integer]")
     REQUIRE(eq(*iabs(*_i9), *integer(9)));
     REQUIRE(eq(*iabs(*i12), *integer(12)));
 }
+
+TEST_CASE("fix#461: integer", "[integer]")
+{
+    RCP<const Integer> ir;
+
+    long lmax = std::numeric_limits<long>::max();
+    ir = integer(lmax);
+    REQUIRE(static_cast<mpz_class>(lmax) == ir->as_mpz());
+
+    unsigned long ulmax = std::numeric_limits<unsigned long>::max();
+    ir = integer(ulmax);
+    REQUIRE(static_cast<mpz_class>(ulmax) == ir->as_mpz());
+}


### PR DESCRIPTION
Output of 
```
long xr = 6167950454l;
cout << " xr : " << xr << endl;
RCP<const Integer> ir = integer(xr);
cout << "*ir : " << *ir << endl;
```
Previous :
```
 xr : 6167950454
*ir : 1872983158
```
After this :
```
 xr : 6167950454
*ir : 6167950454
```