### PR TITLE
Update renaming sh.exe 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,27 +31,31 @@ environment:
       COMPILER: MinGW-w64
 
 install:
+# Download MPIR and compile it
 - if [%COMPILER%]==[MSVC15] set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
 - if [%COMPILER%]==[MSVC15] call bin\appveyor-download.cmd https://raw.githubusercontent.com/symengine/dependencies/fd912ad34c848e7a7a9dab4628f836ab167b9e59/mpir-2.7.0.zip
 - if [%COMPILER%]==[MSVC15] 7z x mpir-2.7.0.zip > NUL
 - if [%COMPILER%]==[MSVC15] msbuild mpir-2.7.0/build.vc14/lib_mpir_gc/lib_mpir_gc.vcxproj /p:Configuration=%BUILD_TYPE% /p:Platform=%PLATFORM% /p:PlatformToolset=%PLATFORMTOOLSET% /verbosity:minimal
 - if [%COMPILER%]==[MSVC15] msbuild mpir-2.7.0/build.vc14/lib_mpir_cxx/lib_mpir_cxx.vcxproj /p:Configuration=%BUILD_TYPE% /p:Platform=%PLATFORM% /p:PlatformToolset=%PLATFORMTOOLSET% /verbosity:minimal
+# Rename mpir.lib to gmp.lib as CMake looks for gmp
 - if [%COMPILER%]==[MSVC15] copy mpir-2.7.0\build.vc14\lib_mpir_gc\%PLATFORM%\%BUILD_TYPE%\mpir.lib mpir-2.7.0\lib\%PLATFORM%\%BUILD_TYPE%\gmp.lib
 - if [%COMPILER%]==[MSVC15] copy mpir-2.7.0\build.vc14\lib_mpir_cxx\%PLATFORM%\%BUILD_TYPE%\mpirxx.lib mpir-2.7.0\lib\%PLATFORM%\%BUILD_TYPE%\gmpxx.lib
 
 - if [%COMPILER%]==[MinGW] set PATH=C:\MinGW\bin;%PATH%
 - if [%COMPILER%]==[MinGW] mingw-get update
-- if [%COMPILER%]==[MinGW] rename "C:\Program Files (x86)\Git\bin\sh.exe" "sh2.exe"
 - if [%COMPILER%]==[MinGW] mingw-get install mingw32-gmp
 
-- if [%COMPILER%]==[MinGW-w64] set PATH=C:\mingw64\bin;%PATH%
-- if [%COMPILER%]==[MinGW-w64] rename "C:\Program Files (x86)\Git\bin\sh.exe" "sh2.exe"
+# Rename sh.exe as sh.exe in PATH interferes with MinGW
+- rename "C:\Program Files\Git\usr\bin\sh.exe" "sh2.exe"
 
+# Download MinGW-w64 toolchain
 - if [%COMPILER%]==[MinGW-w64] call bin\appveyor-download.cmd "https://raw.githubusercontent.com/symengine/dependencies/5cff7d1736877336cf9fb58267111beea4fa152f/x86_64-4.9.1-release-posix-seh-rt_v3-rev1.7z" -FileName mw64.7z
 - if [%COMPILER%]==[MinGW-w64] 7z x -oC:\ mw64.7z > NUL
+- if [%COMPILER%]==[MinGW-w64] set PATH=C:\mingw64\bin;%PATH%
+# Download pre-compiled gmp binaries
 - if [%COMPILER%]==[MinGW-w64] call bin\appveyor-download.cmd "https://raw.githubusercontent.com/symengine/dependencies/5cff7d1736877336cf9fb58267111beea4fa152f/gmp-6.0.0-x86_64-w64-mingw32.7z" -FileName gmp.7z
 - if [%COMPILER%]==[MinGW-w64] 7z x -oC:\mingw64 gmp.7z > NUL
-
+# Download patched libpythonXX.a
 - if [%COMPILER%]==[MinGW-w64] if [%WITH_PYTHON%]==[yes] call bin\appveyor-download.cmd "https://raw.githubusercontent.com/symengine/dependencies/5cff7d1736877336cf9fb58267111beea4fa152f/python-x86_64-w64-mingw32.7z" -FileName pyx64.7z
 - if [%COMPILER%]==[MinGW-w64] if [%WITH_PYTHON%]==[yes] 7z x -aoa -oC:\ pyx64.7z > NUL
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,22 +12,22 @@ environment:
     - BUILD_TYPE: "Debug"
       COMPILER: MSVC15
       PLATFORM: "Win32"
+    - BUILD_TYPE: "Debug"
+      COMPILER: MinGW
+    - BUILD_TYPE: "Debug"
+      COMPILER: MSVC15
+      PLATFORM: "x64"
+    - BUILD_TYPE: "Debug"
+      COMPILER: MinGW-w64
     - BUILD_TYPE: "Release"
       COMPILER: MSVC15
       PLATFORM: "Win32"
-    - BUILD_TYPE: "Debug"
-      COMPILER: MSVC15
-      PLATFORM: "x64"
-    - BUILD_TYPE: "Release"
-      COMPILER: MSVC15
-      PLATFORM: "x64"
-    - BUILD_TYPE: "Debug"
-      COMPILER: MinGW
     - BUILD_TYPE: "Release"
       COMPILER: MinGW
     - BUILD_TYPE: "Release"
-      COMPILER: MinGW-w64
-    - BUILD_TYPE: "Debug"
+      COMPILER: MSVC15
+      PLATFORM: "x64"
+    - BUILD_TYPE: "Release"
       COMPILER: MinGW-w64
 
 install:


### PR DESCRIPTION
Path of sh.exe changed in appveyor and it is interfering with MinGW builds. Renaming sh.exe in the updated path to fix it.