### PR TITLE
Update gcc to 4.7 and enable C++11 in libgmpxx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,14 @@ os:
   - osx
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
     - libgmp-dev
     - libmpfr-dev
     - libmpc-dev
     - binutils-dev
+    - g++-4.7
 env:
   ## All these variables are sent into the bin/test_travis.sh script. See this
   ## script to know how they are used. Most of them are just passed to cmake,

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -18,9 +18,15 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]] && [[ "${CC}" == "gcc" ]]; then
     export CC=gcc-4.8
     export CXX=g++-4.8
 fi
-if [[ "${WITH_PIRANHA}" == "yes" ]]; then
-    export CC=gcc-4.8
-    export CXX=g++-4.8
+
+if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ "${CC}" == "gcc" ]]; then
+    if [[ "${WITH_PIRANHA}" == "yes" ]]; then
+        export CC=gcc-4.8
+        export CXX=g++-4.8
+    else
+        export CC=gcc-4.7
+        export CXX=g++-4.7
+    fi
 fi
 
 export SOURCE_DIR=`pwd`

--- a/symengine/dict.h
+++ b/symengine/dict.h
@@ -8,6 +8,7 @@
 #ifndef SYMENGINE_DICT_H
 #define SYMENGINE_DICT_H
 
+#define __GMPXX_USE_CXX11 1
 #include <gmpxx.h>
 
 namespace SymEngine {


### PR DESCRIPTION
Enabling C++11 features in latest gmp requires user-defined literals which is only avaiable in gcc-4.7

GCC version was not upgraded to 4.8 because MSVC is lacking features in gcc-4.8