### PR TITLE
Remove vec_int_eq

### DIFF
--- a/symengine/dict.h
+++ b/symengine/dict.h
@@ -127,16 +127,8 @@ typedef struct
     }
 } vec_int_hash;
 
-typedef struct
-{
-    //! \return true if `x==y`
-    inline bool operator() (const vec_int &x, const vec_int &y) const {
-        return x == y;
-    }
-} vec_int_eq;
-
 typedef std::unordered_map<vec_int, mpz_class,
-        vec_int_hash, vec_int_eq> umap_vec_mpz;
+        vec_int_hash> umap_vec_mpz;
 
 } // SymEngine
 


### PR DESCRIPTION
There is no need of having `vec_int_eq` functor. `operator==` is already defined for `vector<'T>`s. ref : http://en.cppreference.com/w/cpp/container/vector/operator_cmp.