### PR TITLE
Make BaseVisitor extensible

### DIFF
--- a/symengine/eval_arb.cpp
+++ b/symengine/eval_arb.cpp
@@ -18,7 +18,7 @@
 namespace SymEngine {
 
 class EvalArbVisitor : public BaseVisitor<EvalArbVisitor> {
-private:
+protected:
     long prec_;
     arb_ptr result_;
 public:

--- a/symengine/eval_arb.cpp
+++ b/symengine/eval_arb.cpp
@@ -22,7 +22,7 @@ private:
     long prec_;
     arb_ptr result_;
 public:
-    EvalArbVisitor(long precision) : BaseVisitor(this), prec_{precision} { }
+    EvalArbVisitor(long precision) : prec_{precision} { }
 
     void apply(arb_ptr result, const Basic &b) {
         arb_ptr tmp = result_;

--- a/symengine/eval_double.cpp
+++ b/symengine/eval_double.cpp
@@ -17,8 +17,8 @@
 
 namespace SymEngine {
 
-template <typename T, typename U>
-class EvalDoubleVisitor : public BaseVisitor<U> {
+template <typename T>
+class EvalDoubleVisitor : public BaseVisitor<EvalDoubleVisitor<T>> {
 protected:
     /*
        The 'result_' variable is assigned into at the very end of each visit()
@@ -29,7 +29,6 @@ protected:
     */
     T result_;
 public:
-    EvalDoubleVisitor(U *p) : BaseVisitor<U>(p) { }
 
     T apply(const Basic &b) {
         b.accept(*this);
@@ -220,9 +219,8 @@ public:
     }
 };
 
-class EvalRealDoubleVisitor : public EvalDoubleVisitor<double, EvalRealDoubleVisitor> {
+class EvalRealDoubleVisitor : public BaseVisitor<EvalRealDoubleVisitor, EvalDoubleVisitor<double>> {
 public:
-    EvalRealDoubleVisitor() : EvalDoubleVisitor(this) { };
 
     // Classes not implemented are
     // Subs, UpperGamma, LowerGamma, Dirichlet_eta, Zeta
@@ -243,9 +241,8 @@ public:
     };
 };
 
-class EvalComplexDoubleVisitor : public EvalDoubleVisitor<std::complex<double>, EvalComplexDoubleVisitor> {
+class EvalComplexDoubleVisitor : public BaseVisitor<EvalComplexDoubleVisitor, EvalDoubleVisitor<std::complex<double>>> {
 public:
-    EvalComplexDoubleVisitor() : EvalDoubleVisitor(this) { };
 
     // Classes not implemented are
     // Subs, UpperGamma, LowerGamma, Dirichlet_eta, Zeta

--- a/symengine/eval_mpc.cpp
+++ b/symengine/eval_mpc.cpp
@@ -20,7 +20,7 @@ private:
     mpfr_rnd_t rnd_;
     mpc_ptr result_;
 public:
-    EvalMPCVisitor(mpfr_rnd_t rnd) : BaseVisitor(this), rnd_{rnd} { }
+    EvalMPCVisitor(mpfr_rnd_t rnd) : rnd_{rnd} { }
 
     void apply(mpc_ptr result, const Basic &b) {
         mpc_ptr tmp = result_;

--- a/symengine/eval_mpc.cpp
+++ b/symengine/eval_mpc.cpp
@@ -16,7 +16,7 @@
 namespace SymEngine {
 
 class EvalMPCVisitor : public BaseVisitor<EvalMPCVisitor> {
-private:
+protected:
     mpfr_rnd_t rnd_;
     mpc_ptr result_;
 public:

--- a/symengine/eval_mpfr.cpp
+++ b/symengine/eval_mpfr.cpp
@@ -20,7 +20,7 @@ private:
     mpfr_rnd_t rnd_;
     mpfr_ptr result_;
 public:
-    EvalMPFRVisitor(mpfr_rnd_t rnd) : BaseVisitor(this), rnd_{rnd} { }
+    EvalMPFRVisitor(mpfr_rnd_t rnd) : rnd_{rnd} { }
 
     void apply(mpfr_ptr result, const Basic &b) {
         mpfr_ptr tmp = result_;

--- a/symengine/eval_mpfr.cpp
+++ b/symengine/eval_mpfr.cpp
@@ -16,7 +16,7 @@
 namespace SymEngine {
 
 class EvalMPFRVisitor : public BaseVisitor<EvalMPFRVisitor> {
-private:
+protected:
     mpfr_rnd_t rnd_;
     mpfr_ptr result_;
 public:

--- a/symengine/expand.cpp
+++ b/symengine/expand.cpp
@@ -20,10 +20,6 @@ private:
     RCP<const Number> coeff = zero;
     RCP<const Number> multiply = one;
 public:
-    ExpandVisitor() : BaseVisitor<ExpandVisitor>(this) {
-
-    }
-
     RCP<const Basic> apply(const Basic &b) {
         b.accept(*this);
         return Add::from_dict(coeff, std::move(d_));

--- a/symengine/lambda_double.h
+++ b/symengine/lambda_double.h
@@ -16,8 +16,8 @@
 
 namespace SymEngine {
 
-template<typename T, typename U>
-class LambdaDoubleVisitor : public BaseVisitor<U> {
+template<typename T>
+class LambdaDoubleVisitor : public BaseVisitor<LambdaDoubleVisitor<T>> {
 protected:
 /*
    The 'result_' variable is assigned into at the very end of each visit()
@@ -31,8 +31,6 @@ protected:
     fn result_;
     vec_basic symbols;
 public:
-    LambdaDoubleVisitor(U *p) : BaseVisitor<U>(p) {
-    }
 
     void init(const vec_basic &x, const Basic &b) {
         symbols = x;
@@ -243,9 +241,8 @@ public:
 };
 
 
-class LambdaRealDoubleVisitor : public LambdaDoubleVisitor<double, LambdaRealDoubleVisitor> {
+class LambdaRealDoubleVisitor : public BaseVisitor<LambdaRealDoubleVisitor, LambdaDoubleVisitor<double>> {
 public:
-    LambdaRealDoubleVisitor() : LambdaDoubleVisitor(this) { };
 
     // Classes not implemented are
     // Subs, UpperGamma, LowerGamma, Dirichlet_eta, Zeta
@@ -266,9 +263,8 @@ public:
     };
 };
 
-class LambdaComplexDoubleVisitor : public LambdaDoubleVisitor<std::complex<double>, LambdaComplexDoubleVisitor> {
+class LambdaComplexDoubleVisitor : public BaseVisitor<LambdaComplexDoubleVisitor, LambdaDoubleVisitor<std::complex<double>>> {
 public:
-    LambdaComplexDoubleVisitor() : LambdaDoubleVisitor(this) { };
 
     // Classes not implemented are
     // Subs, UpperGamma, LowerGamma, Dirichlet_eta, Zeta

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -5,9 +5,6 @@
 
 namespace SymEngine {
 
-StrPrinter::StrPrinter() : BaseVisitor<StrPrinter>(this) {
-
-}
 void StrPrinter::bvisit(const Basic &x) {
     std::ostringstream s;
     s << "<" << typeName<Basic>(x) << " instance at " << (const void*)this << ">";

--- a/symengine/printer.h
+++ b/symengine/printer.h
@@ -109,7 +109,7 @@ public:
 };
 
 class StrPrinter : public BaseVisitor<StrPrinter> {
-private:
+protected:
     std::string str_;
 public:
     static const std::vector<std::string> names_;

--- a/symengine/printer.h
+++ b/symengine/printer.h
@@ -12,9 +12,7 @@ enum class PrecedenceEnum {
 class Precedence : public BaseVisitor<Precedence> {
 public:
     PrecedenceEnum precedence;
-    Precedence() : BaseVisitor<Precedence>(this) {
 
-    }
     void bvisit(const Add &x) {
         precedence = PrecedenceEnum::Add;
     }
@@ -114,7 +112,6 @@ class StrPrinter : public BaseVisitor<StrPrinter> {
 private:
     std::string str_;
 public:
-    StrPrinter();
     static const std::vector<std::string> names_;
     void bvisit(const Basic &x);
     void bvisit(const Symbol &x);

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -39,6 +39,20 @@ using SymEngine::function_symbol;
 using SymEngine::I;
 using SymEngine::real_double;
 using SymEngine::complex_double;
+using SymEngine::BaseVisitor;
+using SymEngine::StrPrinter;
+using SymEngine::Sin;
+
+namespace SymEngine {
+class MyStrPrinter : public BaseVisitor<MyStrPrinter, StrPrinter> {
+public:
+    using StrPrinter::bvisit;
+
+    void bvisit(const Sin &x) {
+        str_ = "MySin(" + this->apply(x.get_arg()) + ")";
+    }
+};
+}
 
 TEST_CASE("test_printing(): printing", "[printing]")
 {
@@ -314,4 +328,15 @@ TEST_CASE("test_floats(): printing", "[printing]")
     REQUIRE(p->__str__() == "(-10.0000000000000000000000 + 10.0000000000000000000000*I)/x");
 #endif
 #endif
+}
+
+TEST_CASE("test custom printing", "[printing]")
+{
+    SymEngine::MyStrPrinter printer;
+    RCP<const Basic> p;
+    RCP<const Symbol> x = symbol("x");
+    p = sin(x);
+    CHECK(printer.apply(p) == "MySin(x)");
+    p = cos(sin(x));
+    CHECK(printer.apply(p) == "cos(MySin(x))");
 }

--- a/symengine/visitor.cpp
+++ b/symengine/visitor.cpp
@@ -34,8 +34,7 @@ void postorder_traversal(const Basic &b, Visitor &v)
     b.accept(v);
 }
 
-template<class T>
-void preorder_traversal_stop(const Basic &b, StopVisitor<T> &v)
+void preorder_traversal_stop(const Basic &b, StopVisitor &v)
 {
     b.accept(v);
     if (v.stop_) return;
@@ -61,7 +60,6 @@ RCP<const Basic> coeff(const Basic &b, const RCP<const Symbol> &x,
 class FreeSymbolsVisitor : public BaseVisitor<FreeSymbolsVisitor> {
 public:
     set_basic s;
-    FreeSymbolsVisitor() : BaseVisitor<FreeSymbolsVisitor>(this) { };
 
     void bvisit(const Symbol &x) {
         s.insert(x.rcp_from_this());

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -54,7 +54,7 @@ public:
 void preorder_traversal_stop(const Basic &b, StopVisitor &v);
 
 class HasSymbolVisitor : public BaseVisitor<HasSymbolVisitor, StopVisitor> {
-private:
+protected:
     RCP<const Symbol> x_;
     bool has_;
 public:
@@ -80,7 +80,7 @@ public:
 bool has_symbol(const Basic &b, const RCP<const Symbol> &x);
 
 class CoeffVisitor : public BaseVisitor<CoeffVisitor, StopVisitor> {
-private:
+protected:
     RCP<const Symbol> x_;
     RCP<const Integer> n_;
     RCP<const Basic> coeff_;

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -36,37 +36,28 @@ public:
 void preorder_traversal(const Basic &b, Visitor &v);
 void postorder_traversal(const Basic &b, Visitor &v);
 
-template<class T>
-class BaseVisitor : public Visitor {
+template<class Derived, class Base = Visitor>
+class BaseVisitor : public Base {
 
 public:
-    T *p_;
-public:
-    BaseVisitor(T* p) : p_ {p} {
-
-    };
 #   define SYMENGINE_ENUM( TypeID , Class) \
-    virtual void visit(const Class &x) { p_->bvisit(x); };
+    virtual void visit(const Class &x) { static_cast<Derived*>(this)->bvisit(x); };
 #   include "symengine/type_codes.inc"
 #   undef SYMENGINE_ENUM
 };
 
-template<class T>
-class StopVisitor : public BaseVisitor<T> {
+class StopVisitor : public Visitor {
 public:
-    StopVisitor(T *p) : BaseVisitor<T>(p) { };
     bool stop_;
 };
 
-template<class T>
-void preorder_traversal_stop(const Basic &b, StopVisitor<T> &v);
+void preorder_traversal_stop(const Basic &b, StopVisitor &v);
 
-class HasSymbolVisitor : public StopVisitor<HasSymbolVisitor> {
+class HasSymbolVisitor : public BaseVisitor<HasSymbolVisitor, StopVisitor> {
 private:
     RCP<const Symbol> x_;
     bool has_;
 public:
-    HasSymbolVisitor() : StopVisitor<HasSymbolVisitor>(this) { };
 
     void bvisit(const Symbol &x) {
         if (x_->__eq__(x)) {
@@ -88,13 +79,12 @@ public:
 
 bool has_symbol(const Basic &b, const RCP<const Symbol> &x);
 
-class CoeffVisitor : public StopVisitor<CoeffVisitor> {
+class CoeffVisitor : public BaseVisitor<CoeffVisitor, StopVisitor> {
 private:
     RCP<const Symbol> x_;
     RCP<const Integer> n_;
     RCP<const Basic> coeff_;
 public:
-    CoeffVisitor() : StopVisitor<CoeffVisitor>(this) { };
 
     void bvisit(const Add &x) {
         // TODO: Implement coeff for Add


### PR DESCRIPTION
With this approach to extend `StrPrinter` you can do 

```C++
class MyStrPrinter : public BaseVisitor<MyStrPrinter, StrPrinter> {
public:
    using StrPrinter::bvisit;
}
```
and override existing bvisit methods or add new ones. I'll add this to a new wiki page.

Source: https://katyscode.wordpress.com/2013/08/22/c-polymorphic-cloning-and-the-crtp-curiously-recurring-template-pattern/