### PR TITLE
Remove "git clean -dfx"

### DIFF
--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -5,11 +5,6 @@ set -e
 # Echo each command
 set -x
 
-# Shippable currently does not clean the directory after previous builds
-# (https://github.com/Shippable/support/issues/238), so
-# we need to do it ourselves.
-git clean -dfx
-
 if [[ "${CC}" == "" ]]; then
     export CC=gcc
     export CXX=g++


### PR DESCRIPTION
Since, we are not using `shippable` now.