### PR TITLE
Fix for #705

### DIFF
--- a/symengine/expand.cpp
+++ b/symengine/expand.cpp
@@ -138,9 +138,9 @@ public:
             }
             if (eq(*a_term, *one)) {
                 iaddnum(outArg(coeff),
-                        _mulnum(multiply, _mulnum(rcp_static_cast<const Add>(b)->coef_, a_coef)));
+                        _mulnum(rcp_static_cast<const Add>(b)->coef_, a_coef));
             } else {
-                Add::dict_add_term(d_, _mulnum(multiply, _mulnum(rcp_static_cast<const Add>(b)->coef_, a_coef)),
+                Add::dict_add_term(d_, _mulnum(rcp_static_cast<const Add>(b)->coef_, a_coef),
                                    a_term);
             }
             return;

--- a/symengine/tests/basic/test_arit.cpp
+++ b/symengine/tests/basic/test_arit.cpp
@@ -918,6 +918,14 @@ TEST_CASE("Expand2: arit", "[arit]")
     r1 = expand(pow(add(real_double(0.0), x), i2));
     r2 = add(real_double(0.0), pow(x, i2));
     REQUIRE(eq(*r1, *r2));
+
+    r1 = expand(add(mul(i2, add(x, one)), mul(i3, mul(x, add(x, one)))));
+    r2 = add(i2, add(mul(i5, x), mul(i3, pow(x, i2))));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = expand(mul(i3, add(x, one)));
+    r2 = add(mul(i3, x), i3);
+    REQUIRE(eq(*r1, *r2));
 }
 
 TEST_CASE("Expand3: arit", "[arit]")


### PR DESCRIPTION
`a_coef` was already multiplied by `multiply`. Removed the extra multiplication.
Fixes #705 