### PR TITLE
Speedup Add::__hash__()

### DIFF
--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -50,12 +50,12 @@ bool Add::is_canonical(const RCP<const Number> &coef,
 
 std::size_t Add::__hash__() const
 {
-    std::size_t seed = ADD;
+    std::size_t seed = ADD, temp;
     hash_combine<Basic>(seed, *coef_);
-    map_basic_num ordered(dict_.begin(), dict_.end());
-    for (const auto &p: ordered) {
-        hash_combine<Basic>(seed, *(p.first));
-        hash_combine<Basic>(seed, *(p.second));
+    for (const auto &p: dict_) {
+        temp = p.first->hash();
+        hash_combine<Basic>(temp, *(p.second));
+        seed += temp;
     }
     return seed;
 }

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -55,7 +55,7 @@ std::size_t Add::__hash__() const
     for (const auto &p: dict_) {
         temp = p.first->hash();
         hash_combine<Basic>(temp, *(p.second));
-        seed += temp;
+        seed ^= temp;
     }
     return seed;
 }


### PR DESCRIPTION
I checked benchmarks. Improvements in `expand6` (from 5604ms to 5077ms) and `expand7` (4586ms to 3752ms). No visible change in `expand2` and `add1`