### PR TITLE
[WIP] Symbol: use global counter

### DIFF
--- a/symengine/symbol.cpp
+++ b/symengine/symbol.cpp
@@ -4,21 +4,18 @@
 
 namespace SymEngine {
 
-Symbol::Symbol(const std::string &name)
-    : name_{name}
-{
-}
+std::map<int, std::string> Symbol::global_symbols;
+std::map<int, std::size_t> Symbol::global_symbols_hashes;
 
 std::size_t Symbol::__hash__() const
 {
-    std::hash<std::string> hash_fn;
-    return hash_fn(name_);
+    return global_symbols_hashes[name_counter_];
 }
 
 bool Symbol::__eq__(const Basic &o) const
 {
     if (is_a<Symbol>(o))
-        return name_ == static_cast<const Symbol &>(o).name_;
+        return name_counter_ == static_cast<const Symbol &>(o).name_counter_;
     return false;
 }
 
@@ -26,13 +23,13 @@ int Symbol::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Symbol>(o))
     const Symbol &s = static_cast<const Symbol &>(o);
-    if (name_ == s.name_) return 0;
-    return name_ < s.name_ ? -1 : 1;
+    if (name_counter_ == s.name_counter_) return 0;
+    return name_counter_ < s.name_counter_ ? -1 : 1;
 }
 
 RCP<const Basic> Symbol::diff(const RCP<const Symbol> &x) const
 {
-    if (x->name_ == this->name_)
+    if (x->name_counter_ == this->name_counter_)
         return one;
     else
         return zero;

--- a/symengine/symbol.h
+++ b/symengine/symbol.h
@@ -12,13 +12,21 @@ namespace SymEngine {
 
 class Symbol : public Basic {
 private:
-    //! name of Symbol
-    std::string name_;
+    //! name of the Symbol is global_symbols[name_counter_]
+    int name_counter_;
+    static std::map<int, std::string> global_symbols;
+    static std::map<int, std::size_t> global_symbols_hashes;
 
 public:
     IMPLEMENT_TYPEID(SYMBOL)
     //! Symbol Constructor
-    Symbol(const std::string &name);
+    Symbol(const std::string &name) {
+        name_counter_ = global_symbols.size();
+        global_symbols.insert(std::make_pair(name_counter_, name));
+        std::hash<std::string> hash_fn;
+        global_symbols_hashes.insert(std::make_pair(name_counter_, hash_fn(name)));
+    }
+
     //! \return Size of the hash
     virtual std::size_t __hash__() const;
     /*! Equality comparator
@@ -34,7 +42,7 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return name of the Symbol.
     inline std::string get_name() const {
-        return name_;
+        return global_symbols[name_counter_];
     }
     /*! Differentiate w.r.t other symbol.
      * \param x - Symbol to be differentiated with.


### PR DESCRIPTION
This compares integers instead of strings when comparing Symbols. This should be a lot faster. Currently it uses a global `int -> string` and `int-> hash` table. It changes the ordering a bit, i.e previously we compared e.g. "x" < "y", now we do e.g. 1 < 2, and so some tests fail. Most tests pass, so it should be working.

I am trying to see if it speeds up any benchmarks.
