### PR TITLE
Remove methods from core

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -60,6 +60,7 @@ set(HEADERS
     visitor.h    eval_double.h    diophantine.h cwrapper.h  printer.h  real_double.h
     eval_mpfr.h  eval_arb.h       eval_mpc.h    complex_double.h
     real_mpfr.h  complex_mpc.h    type_codes.inc lambda_double.h series.h
+    basic-methods.inc
 )
 
 # Configure SymEngine using our CMake options:

--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRC
     real_double.cpp
     complex_double.cpp
     expand.cpp
+    derivative.cpp
 )
 
 if (WITH_MPFR)

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -295,30 +295,6 @@ RCP<const Basic> sub(const RCP<const Basic> &a, const RCP<const Basic> &b)
     return add(a, mul(minus_one, b));
 }
 
-RCP<const Basic> Add::diff(const RCP<const Symbol> &x) const
-{
-    SymEngine::umap_basic_num d;
-    RCP<const Number> coef=zero, coef2;
-    RCP<const Basic> t;
-    for (const auto &p: dict_) {
-        RCP<const Basic> term = p.first->diff(x);
-        if (is_a<Integer>(*term) and rcp_static_cast<const Integer>(term)->is_zero()) {
-            continue;
-        } else if (is_a_Number(*term)) {
-            iaddnum(outArg(coef),
-                    mulnum(p.second, rcp_static_cast<const Number>(term)));
-        } else if (is_a<Add>(*term)) {
-            for (const auto &q: (rcp_static_cast<const Add>(term))->dict_)
-                Add::dict_add_term(d, mulnum(q.second, p.second), q.first);
-            iaddnum(outArg(coef), mulnum(p.second, rcp_static_cast<const Add>(term)->coef_));
-        } else {
-            Add::as_coef_term(mul(p.second, term), outArg(coef2), outArg(t));
-            Add::dict_add_term(d, coef2, t);
-        }
-    }
-    return Add::from_dict(coef, std::move(d));
-}
-
 void Add::as_two_terms(const Ptr<RCP<const Basic>> &a,
             const Ptr<RCP<const Basic>> &b) const
 {

--- a/symengine/add.h
+++ b/symengine/add.h
@@ -65,8 +65,6 @@ public:
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     virtual vec_basic get_args() const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! \return Add made from `a + b`

--- a/symengine/add.h
+++ b/symengine/add.h
@@ -59,8 +59,6 @@ public:
     //! \return `true` if it is in canonical form
     bool is_canonical(const RCP<const Number> &coef,
             const umap_basic_num& dict) const;
-    //! Differentiates w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! Substitutes the dict
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 

--- a/symengine/basic-methods.inc
+++ b/symengine/basic-methods.inc
@@ -1,3 +1,4 @@
 #define SYMENGINE_INCLUDE_METHODS \
 virtual void accept(Visitor &v) const; \
-virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
+virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const; \
+virtual RCP<const Basic> diff2(const RCP<const Symbol> &x) const;

--- a/symengine/basic-methods.inc
+++ b/symengine/basic-methods.inc
@@ -1,4 +1,3 @@
 #define SYMENGINE_INCLUDE_METHODS \
 virtual void accept(Visitor &v) const; \
-virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const; \
 virtual RCP<const Basic> diff2(const RCP<const Symbol> &x) const;

--- a/symengine/basic-methods.inc
+++ b/symengine/basic-methods.inc
@@ -1,3 +1,3 @@
-#define SYMENGINE_INCLUDE_METHODS \
-virtual void accept(Visitor &v) const; \
-virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
+#define SYMENGINE_INCLUDE_METHODS(SUFFIX) \
+virtual void accept(Visitor &v) const SUFFIX; \
+virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const SUFFIX;

--- a/symengine/basic-methods.inc
+++ b/symengine/basic-methods.inc
@@ -1,0 +1,2 @@
+#define SYMENGINE_INCLUDE_METHODS \
+virtual void accept(Visitor &v) const;

--- a/symengine/basic-methods.inc
+++ b/symengine/basic-methods.inc
@@ -1,3 +1,3 @@
 #define SYMENGINE_INCLUDE_METHODS \
 virtual void accept(Visitor &v) const; \
-virtual RCP<const Basic> diff2(const RCP<const Symbol> &x) const;
+virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;

--- a/symengine/basic-methods.inc
+++ b/symengine/basic-methods.inc
@@ -1,2 +1,3 @@
 #define SYMENGINE_INCLUDE_METHODS \
-virtual void accept(Visitor &v) const;
+virtual void accept(Visitor &v) const; \
+virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -144,7 +144,7 @@ public:
      */
     std::string __str__() const;
 
-    //! Returns the derivative of self
+    //! Returns the derivative of 'self' w.r.t Symbol `x`
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
     //! Substitutes 'subs_dict' into 'self'.

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -83,6 +83,8 @@ enum TypeID {
     TypeID_Count
 };
 
+#include "basic-methods.inc"
+
 class Basic : public EnableRCPFromThis<Basic> {
 private:
     //! Private variables
@@ -144,9 +146,6 @@ public:
      */
     std::string __str__() const;
 
-    //! Returns the derivative of 'self' w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const = 0;
-
     //! Substitutes 'subs_dict' into 'self'.
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
@@ -158,7 +157,7 @@ public:
     //! Returns the list of arguments
     virtual vec_basic get_args() const = 0;
 
-    virtual void accept(Visitor &v) const = 0;
+    SYMENGINE_INCLUDE_METHODS(=0)
 };
 
 //! Our hash:
@@ -256,14 +255,12 @@ void hash_combine(std::size_t& seed, const T& v);
 //! Inline members and functions
 #include "basic-inl.h"
 
-#include "basic-methods.inc"
-
 // Macro to define the type_code_id variable and its getter method
 #define IMPLEMENT_TYPEID(ID) \
 /*! Type_code_id shared by all instances */ \
 const static TypeID type_code_id = ID; \
 /*! Virtual function that gives the type_code_id of the object */ \
 virtual TypeID get_type_code() const { return type_code_id; }; \
-SYMENGINE_INCLUDE_METHODS
+SYMENGINE_INCLUDE_METHODS()
 
 #endif

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -256,11 +256,14 @@ void hash_combine(std::size_t& seed, const T& v);
 //! Inline members and functions
 #include "basic-inl.h"
 
+#include "basic-methods.inc"
+
 // Macro to define the type_code_id variable and its getter method
 #define IMPLEMENT_TYPEID(ID) \
 /*! Type_code_id shared by all instances */ \
 const static TypeID type_code_id = ID; \
 /*! Virtual function that gives the type_code_id of the object */ \
-virtual TypeID get_type_code() const { return type_code_id; };
+virtual TypeID get_type_code() const { return type_code_id; }; \
+SYMENGINE_INCLUDE_METHODS
 
 #endif

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -145,8 +145,6 @@ public:
     std::string __str__() const;
 
     //! Returns the derivative of 'self' w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
-
     virtual RCP<const Basic> diff2(const RCP<const Symbol> &x) const = 0;
 
     //! Substitutes 'subs_dict' into 'self'.

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -145,7 +145,7 @@ public:
     std::string __str__() const;
 
     //! Returns the derivative of 'self' w.r.t Symbol `x`
-    virtual RCP<const Basic> diff2(const RCP<const Symbol> &x) const = 0;
+    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const = 0;
 
     //! Substitutes 'subs_dict' into 'self'.
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -147,6 +147,8 @@ public:
     //! Returns the derivative of 'self' w.r.t Symbol `x`
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
+    virtual RCP<const Basic> diff2(const RCP<const Symbol> &x) const = 0;
+
     //! Substitutes 'subs_dict' into 'self'.
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 

--- a/symengine/complex.h
+++ b/symengine/complex.h
@@ -285,8 +285,6 @@ public:
     virtual RCP<const Number> rpow(const Number &other) const {
         throw std::runtime_error("Not implemented.");
     };
-
-    virtual void accept(Visitor &v) const;
 };
 
 } // SymEngine

--- a/symengine/complex_double.h
+++ b/symengine/complex_double.h
@@ -454,8 +454,6 @@ public:
             throw std::runtime_error("Not implemented.");
         }
     }
-
-    virtual void accept(Visitor &v) const;
 };
 
 RCP<const ComplexDouble> complex_double(std::complex<double> x);

--- a/symengine/complex_mpc.h
+++ b/symengine/complex_mpc.h
@@ -336,8 +336,6 @@ public:
             throw std::runtime_error("Not implemented.");
         }
     }
-
-    virtual void accept(Visitor &v) const;
 };
 
 inline RCP<const ComplexMPC> complex_mpc(mpc_class x) {

--- a/symengine/constants.cpp
+++ b/symengine/constants.cpp
@@ -34,11 +34,6 @@ int Constant::compare(const Basic &o) const
     return name_ < s.name_ ? -1 : 1;
 }
 
-RCP<const Basic> Constant::diff(const RCP<const Symbol> &x) const
-{
-    return zero;
-}
-
 RCP<const Integer> zero = integer(0);
 RCP<const Integer> one = integer(1);
 RCP<const Integer> minus_one = integer(-1);

--- a/symengine/constants.h
+++ b/symengine/constants.h
@@ -39,11 +39,6 @@ public:
     inline std::string get_name() const {
         return name_;
     }
-    /*! Differentiate w.r.t other symbol.
-     * \param x - Symbol to be differentiated with.
-     * \return `1` if `name_` are equal, else `0`
-     * */
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
     virtual vec_basic get_args() const { return {}; }
 };

--- a/symengine/constants.h
+++ b/symengine/constants.h
@@ -46,8 +46,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
     virtual vec_basic get_args() const { return {}; }
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! inline version to return `Constant`

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -1,0 +1,47 @@
+#include <symengine/basic.h>
+#include <symengine/symbol.h>
+#include <symengine/add.h>
+#include <symengine/integer.h>
+#include <symengine/rational.h>
+#include <symengine/complex.h>
+#include <symengine/mul.h>
+#include <symengine/pow.h>
+#include <symengine/functions.h>
+#include <symengine/constants.h>
+#include <symengine/visitor.h>
+#include <symengine/polynomial.h>
+#include <symengine/complex_double.h>
+#include <symengine/complex_mpc.h>
+
+namespace SymEngine {
+
+#define IMPLEMENT_DIFF(CLASS) \
+RCP<const Basic> CLASS::diff(const RCP<const Symbol> &x) const \
+{ \
+    return Derivative::create(rcp_from_this(), {x}); \
+}
+
+#define IMPLEMENT_DIFF0(CLASS) \
+RCP<const Basic> CLASS::diff(const RCP<const Symbol> &x) const \
+{ \
+    return zero; \
+}
+
+IMPLEMENT_DIFF(FunctionWrapper)
+IMPLEMENT_DIFF(UpperGamma)
+IMPLEMENT_DIFF(LowerGamma)
+IMPLEMENT_DIFF(Gamma)
+IMPLEMENT_DIFF(LeviCivita)
+IMPLEMENT_DIFF(KroneckerDelta)
+IMPLEMENT_DIFF(Dirichlet_eta)
+IMPLEMENT_DIFF(UnivariateSeries)
+
+IMPLEMENT_DIFF0(RealDouble)
+IMPLEMENT_DIFF0(ComplexDouble)
+IMPLEMENT_DIFF0(Complex)
+IMPLEMENT_DIFF0(Rational)
+IMPLEMENT_DIFF0(Integer)
+IMPLEMENT_DIFF0(NumberWrapper)
+
+
+} // SymEngine

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -381,13 +381,13 @@ static RCP<const Basic> diff(const CLASS &self, \
     }
 };
 
-#define DIFF2(CLASS) \
-RCP<const Basic> CLASS::diff2(const RCP<const Symbol> &x) const { \
+#define IMPLEMENT_DIFF(CLASS) \
+RCP<const Basic> CLASS::diff(const RCP<const Symbol> &x) const { \
     return DiffImplementation::diff(*this, x); \
 };
 
 
-#define SYMENGINE_ENUM(TypeID, Class) DIFF2(Class)
+#define SYMENGINE_ENUM(TypeID, Class) IMPLEMENT_DIFF(Class)
 #include "symengine/type_codes.inc"
 #undef SYMENGINE_ENUM
 

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -15,6 +15,44 @@
 
 namespace SymEngine {
 
+class DiffImplementation {
+public:
+    static RCP<const Basic> diff(const Basic &self,
+            const RCP<const Symbol> &x) {
+        return Derivative::create(self.rcp_from_this(), {x});
+    }
+
+    static RCP<const Basic> diff(const Number &self,
+            const RCP<const Symbol> &x) {
+        return zero;
+    }
+
+    static RCP<const Basic> diff(const Sin &self,
+            const RCP<const Symbol> &x) {
+        return mul(cos(self.get_arg()), self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Cos &self,
+            const RCP<const Symbol> &x) {
+        return mul(mul(minus_one, sin(self.get_arg())),
+                self.get_arg()->diff(x));
+    }
+
+    // ...and so on for all the other functions that want to return a specific
+    // derivative, instead of the general diff(const Basic &, ...) one.
+};
+
+#define DIFF2(CLASS) \
+RCP<const Basic> CLASS::diff2(const RCP<const Symbol> &x) const { \
+    return DiffImplementation::diff(*this, x); \
+};
+
+
+#define SYMENGINE_ENUM(TypeID, Class) DIFF2(Class)
+#include "symengine/type_codes.inc"
+#undef SYMENGINE_ENUM
+
+
 #define IMPLEMENT_DIFF(CLASS) \
 RCP<const Basic> CLASS::diff(const RCP<const Symbol> &x) const \
 { \

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -392,33 +392,4 @@ RCP<const Basic> CLASS::diff2(const RCP<const Symbol> &x) const { \
 #undef SYMENGINE_ENUM
 
 
-#define IMPLEMENT_DIFF(CLASS) \
-RCP<const Basic> CLASS::diff(const RCP<const Symbol> &x) const \
-{ \
-    return Derivative::create(rcp_from_this(), {x}); \
-}
-
-#define IMPLEMENT_DIFF0(CLASS) \
-RCP<const Basic> CLASS::diff(const RCP<const Symbol> &x) const \
-{ \
-    return zero; \
-}
-
-IMPLEMENT_DIFF(FunctionWrapper)
-IMPLEMENT_DIFF(UpperGamma)
-IMPLEMENT_DIFF(LowerGamma)
-IMPLEMENT_DIFF(Gamma)
-IMPLEMENT_DIFF(LeviCivita)
-IMPLEMENT_DIFF(KroneckerDelta)
-IMPLEMENT_DIFF(Dirichlet_eta)
-IMPLEMENT_DIFF(UnivariateSeries)
-
-IMPLEMENT_DIFF0(RealDouble)
-IMPLEMENT_DIFF0(ComplexDouble)
-IMPLEMENT_DIFF0(Complex)
-IMPLEMENT_DIFF0(Rational)
-IMPLEMENT_DIFF0(Integer)
-IMPLEMENT_DIFF0(NumberWrapper)
-
-
 } // SymEngine

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -15,16 +15,273 @@
 
 namespace SymEngine {
 
+extern RCP<const Basic> i2;
+
 class DiffImplementation {
 public:
+// Uncomment the following define in order to debug the methods:
+#define debug_methods
+#ifndef debug_methods
+
     static RCP<const Basic> diff(const Basic &self,
             const RCP<const Symbol> &x) {
         return Derivative::create(self.rcp_from_this(), {x});
     }
 
+#else
+    // Here we do not have a 'Basic' fallback, but rather must implement all
+    // virtual methods explicitly (if we miss one, the code will not compile).
+    // This is useful to check that we have implemented all methods that we
+    // wanted.
+
+#define DIFF0(CLASS) \
+static RCP<const Basic> diff(const CLASS &self, \
+        const RCP<const Symbol> &x) { \
+    return Derivative::create(self.rcp_from_this(), {x}); \
+}
+
+    DIFF0(UnivariateSeries)
+    DIFF0(KroneckerDelta)
+    DIFF0(Dirichlet_eta)
+    DIFF0(FunctionWrapper)
+    DIFF0(UpperGamma)
+    DIFF0(LowerGamma)
+    DIFF0(Gamma)
+    DIFF0(LeviCivita)
+
+#endif
+
+
     static RCP<const Basic> diff(const Number &self,
             const RCP<const Symbol> &x) {
         return zero;
+    }
+
+    static RCP<const Basic> diff(const Constant &self,
+            const RCP<const Symbol> &x) {
+        return zero;
+    }
+
+    static RCP<const Basic> diff(const Symbol &self,
+            const RCP<const Symbol> &x) {
+        if (x->get_name() == self.get_name())
+            return one;
+        else
+            return zero;
+    }
+
+    static RCP<const Basic> diff(const Log &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(one, self.get_arg()), self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Abs &self,
+            const RCP<const Symbol> &x) {
+        if (eq(*self.get_arg()->diff(x), *zero))
+            return zero;
+        else
+            return Derivative::create(self.rcp_from_this(), {x});
+    }
+
+    static RCP<const Basic> diff(const Zeta &self,
+            const RCP<const Symbol> &x) {
+        // TODO: check if it is differentiated wrt s
+        return mul(mul(mul(minus_one, self.get_s()),
+                zeta(add(self.get_s(), one), self.get_a())),
+                self.get_a()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ASech &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(minus_one, mul(sqrt(sub(one, pow(self.get_arg(), i2))),
+                self.get_arg())), self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ACoth &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(one, sub(one, pow(self.get_arg(), i2))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ATanh &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(one, sub(one, pow(self.get_arg(), i2))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ACosh &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(one, sqrt(sub(pow(self.get_arg(), i2), one))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ASinh &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(one, sqrt(add(pow(self.get_arg(), i2), one))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Coth &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(minus_one, pow(sinh(self.get_arg()), i2)),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Tanh &self,
+            const RCP<const Symbol> &x) {
+        return mul(sub(one, pow(tanh(self.get_arg()), i2)),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Cosh &self,
+            const RCP<const Symbol> &x) {
+        return mul(sinh(self.get_arg()), self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Sinh &self,
+            const RCP<const Symbol> &x) {
+        return mul(cosh(self.get_arg()), self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Subs &self,
+            const RCP<const Symbol> &x) {
+        RCP<const Basic> diff = zero, t;
+        if (self.get_dict().count(x) == 0) {
+            diff = self.get_arg()->diff(x)->subs(self.get_dict());
+        }
+        for (const auto &p: self.get_dict()) {
+            t = p.second->diff(x);
+            if (neq(*t, *zero)) {
+                if (is_a<Symbol>(*p.first)) {
+                    diff = add(diff, mul(t, self.get_arg()->diff(rcp_static_cast<const Symbol>(p.first))->subs(self.get_dict())));
+                } else {
+                    return Derivative::create(self.rcp_from_this(), {x});
+                }
+            }
+        }
+        return diff;
+    }
+
+    static RCP<const Basic> diff(const Derivative &self,
+            const RCP<const Symbol> &x) {
+        if (eq(*(self.get_arg()->diff(x)), *zero)) return zero;
+        vec_basic t = self.get_symbols();
+        t.push_back(x);
+        return Derivative::create(self.get_arg(), t);
+    }
+
+    static RCP<const Basic> diff(const FunctionSymbol &self,
+            const RCP<const Symbol> &x) {
+        RCP<const Basic> diff = zero, t;
+        RCP<const Basic> self_ = self.rcp_from_this();
+        RCP<const Symbol> s;
+        std::string name;
+        unsigned count  = 0;
+        bool found_x = false;
+        for (const auto &a : self.get_args()) {
+            if (eq(*a, *x)) {
+                found_x = true;
+                count++;
+            } else if (count < 2 and neq(*a->diff(x), *zero)) {
+                count++;
+            }
+        }
+        if (count == 1 and found_x) {
+            return Derivative::create(self_, {x});
+        }
+        for (unsigned i = 0; i < self.get_args().size(); i++) {
+            t = self.get_args()[i]->diff(x);
+            if (neq(*t, *zero)) {
+                name = "x";
+                do {
+                    name = "_" + name;
+                    s = symbol(name);
+                } while (has_symbol(*self_, s));
+                vec_basic v = self.get_args();
+                v[i] = s;
+                map_basic_basic m;
+                insert(m, v[i], self.get_args()[i]);
+                diff = add(diff, mul(t,
+                    make_rcp<const Subs>(Derivative::create(self.create(v),
+                            {v[i]}), m)));
+            }
+        }
+        return diff;
+    }
+
+    static RCP<const Basic> diff(const LambertW &self,
+            const RCP<const Symbol> &x) {
+        // check http://en.wikipedia.org/wiki/Lambert_W_function#Derivative
+        // for the equation
+        RCP<const Basic> lambertw_val = lambertw(self.get_arg());
+        return mul(div(lambertw_val, mul(self.get_arg(),
+                add(lambertw_val, one))), self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Add &self,
+            const RCP<const Symbol> &x) {
+        SymEngine::umap_basic_num d;
+        RCP<const Number> coef=zero, coef2;
+        RCP<const Basic> t;
+        for (auto &p: self.dict_) {
+            RCP<const Basic> term = p.first->diff(x);
+            if (is_a<Integer>(*term) && rcp_static_cast<const Integer>(term)->is_zero()) {
+                continue;
+            } else if (is_a_Number(*term)) {
+                iaddnum(outArg(coef),
+                        mulnum(p.second, rcp_static_cast<const Number>(term)));
+            } else if (is_a<Add>(*term)) {
+                for (auto &q: (rcp_static_cast<const Add>(term))->dict_)
+                    Add::dict_add_term(d, mulnum(q.second, p.second), q.first);
+                iaddnum(outArg(coef), mulnum(p.second, rcp_static_cast<const Add>(term)->coef_));
+            } else {
+                Add::as_coef_term(mul(p.second, term), outArg(coef2), outArg(t));
+                Add::dict_add_term(d, coef2, t);
+            }
+        }
+        return Add::from_dict(coef, std::move(d));
+    }
+
+    static RCP<const Basic> diff(const Mul &self,
+            const RCP<const Symbol> &x) {
+        RCP<const Number> overall_coef = zero;
+        umap_basic_num add_dict;
+        for (auto &p: self.dict_) {
+            RCP<const Number> coef = self.coef_;
+            RCP<const Basic> factor = pow(p.first, p.second)->diff(x);
+            if (is_a<Integer>(*factor) &&
+                    rcp_static_cast<const Integer>(factor)->is_zero()) continue;
+            map_basic_basic d = self.dict_;
+            d.erase(p.first);
+            if (is_a_Number(*factor)) {
+                imulnum(outArg(coef), rcp_static_cast<const Number>(factor));
+            } else if (is_a<Mul>(*factor)) {
+                RCP<const Mul> tmp = rcp_static_cast<const Mul>(factor);
+                imulnum(outArg(coef), tmp->coef_);
+                for (auto &q: tmp->dict_) {
+                    Mul::dict_add_term_new(outArg(coef), d, q.second, q.first);
+                }
+            } else {
+                RCP<const Basic> exp, t;
+                Mul::as_base_exp(factor, outArg(exp), outArg(t));
+                Mul::dict_add_term_new(outArg(coef), d, exp, t);
+            }
+            if (d.size() == 0) {
+                iaddnum(outArg(overall_coef), coef);
+            } else {
+                RCP<const Basic> mul = Mul::from_dict(one, std::move(d));
+                Add::dict_add_term(add_dict, coef, mul);
+            }
+        }
+        return Add::from_dict(overall_coef, std::move(add_dict));
+    }
+
+    static RCP<const Basic> diff(const Pow &self,
+            const RCP<const Symbol> &x) {
+        if (is_a_Number(*(self.get_exp())))
+            return mul(mul(self.get_exp(), pow(self.get_base(), sub(self.get_exp(), one))), self.get_base()->diff(x));
+        else
+            return mul(pow(self.get_base(), self.get_exp()), mul(self.get_exp(), log(self.get_base()))->diff(x));
     }
 
     static RCP<const Basic> diff(const Sin &self,
@@ -38,8 +295,90 @@ public:
                 self.get_arg()->diff(x));
     }
 
-    // ...and so on for all the other functions that want to return a specific
-    // derivative, instead of the general diff(const Basic &, ...) one.
+    static RCP<const Basic> diff(const Tan &self,
+            const RCP<const Symbol> &x) {
+        RCP<const Integer> two = integer(2);
+        return mul(add(one, pow(tan(self.get_arg()), two)),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Cot &self,
+            const RCP<const Symbol> &x) {
+        RCP<const Integer> two = integer(2);
+        return mul(mul(add(one, pow(cot(self.get_arg()), two)), minus_one),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Csc &self,
+            const RCP<const Symbol> &x) {
+        return mul(mul(mul(cot(self.get_arg()), csc(self.get_arg())),
+                    minus_one), self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const Sec &self,
+            const RCP<const Symbol> &x) {
+        return mul(mul(tan(self.get_arg()), sec(self.get_arg())),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ASin &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(one, sqrt(sub(one, pow(self.get_arg(), i2)))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ACos &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(minus_one, sqrt(sub(one, pow(self.get_arg(), i2)))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ASec &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(one, mul(pow(self.get_arg(), i2),
+                sqrt(sub(one, div(one, pow(self.get_arg(), i2)))))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ACsc &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(minus_one, mul(pow(self.get_arg(), i2),
+                sqrt(sub(one, div(one, pow(self.get_arg(), i2)))))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ATan &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(one, add(one, pow(self.get_arg(), i2))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ACot &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(minus_one, add(one, pow(self.get_arg(), i2))),
+                self.get_arg()->diff(x));
+    }
+
+    static RCP<const Basic> diff(const ATan2 &self,
+            const RCP<const Symbol> &x) {
+        return mul(div(pow(self.get_den(), i2), add(pow(self.get_den(), i2),
+            pow(self.get_num(), i2))), div(self.get_num(),
+            self.get_den())->diff(x));
+    }
+
+    static RCP<const Basic> diff(const UnivariatePolynomial &self,
+            const RCP<const Symbol> &x) {
+        if (self.get_var()->__eq__(*x)) {
+            map_uint_mpz d;
+            for (const auto &p : self.get_dict()) {
+                d[p.first - 1] = p.second * p.first;
+            }
+            return make_rcp<const UnivariatePolynomial>(self.get_var(),
+                    (--(d.end()))->first, std::move(d));
+        } else {
+            return zero;
+        }
+    }
 };
 
 #define DIFF2(CLASS) \

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -567,6 +567,9 @@ public:
     inline RCP<const Basic> get_arg() const {
         return arg_;
     }
+    inline const map_basic_basic& get_dict() const {
+        return dict_;
+    };
     virtual vec_basic get_variables() const;
     virtual vec_basic get_point() const;
     virtual vec_basic get_args() const;

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -75,8 +75,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized sin
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -99,8 +97,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized cos
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -123,8 +119,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized tan
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -146,8 +140,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized cot
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -169,8 +161,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized csc
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -192,8 +182,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized sec
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -214,8 +202,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized asin
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -237,8 +223,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acos
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -260,8 +244,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized asec
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -283,8 +265,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acsc
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -306,8 +286,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized atan
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -329,8 +307,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acot
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -364,8 +340,6 @@ public:
     inline RCP<const Basic> get_den() const {
         return den_;
     }
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
     virtual vec_basic get_args() const { return {num_, den_}; }
 };
@@ -400,8 +374,6 @@ public:
     virtual vec_basic get_args() const { return {arg_}; }
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 };
 
 //! Create a new LambertW instance:
@@ -444,8 +416,6 @@ public:
     virtual vec_basic get_args() const { return {s_, a_}; }
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &s, const RCP<const Basic> &a) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 };
 
 //! Create a new Zeta instance:
@@ -506,8 +476,6 @@ public:
     virtual vec_basic get_args() const { return arg_; }
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
     virtual RCP<const Basic> create(const vec_basic &x) const;
 };
@@ -572,7 +540,6 @@ public:
         return args;
     }
     bool is_canonical(const RCP<const Basic> &arg, const vec_basic &x) const;
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 };
 
@@ -605,7 +572,6 @@ public:
     virtual vec_basic get_args() const;
 
     bool is_canonical(const RCP<const Basic> &arg, const map_basic_basic &x) const;
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 };
 
@@ -643,8 +609,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized sinh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
     //! expands sinh in terms of exp function
@@ -668,8 +632,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized cosh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
     //! expands cosh in terms of exp function
@@ -693,8 +655,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized tanh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
     //! expands tanh in terms of exp function
@@ -718,8 +678,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized coth
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
     //! expands coth in terms of exp function
@@ -743,8 +701,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized asinh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -766,8 +722,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acosh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -789,8 +743,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized atanh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -812,8 +764,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acoth
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -835,8 +785,6 @@ public:
     virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized asech
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
@@ -1009,7 +957,6 @@ public:
     bool is_canonical(const RCP<const Basic> &arg) const;
     inline RCP<const Basic> get_arg() const { return arg_; }
     virtual vec_basic get_args() const { return {arg_}; }
-    RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 };
 
 //! Canonicalize Abs:

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -79,8 +79,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized sin
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize Sin:
@@ -105,8 +103,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized cos
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize Cos:
@@ -131,8 +127,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized tan
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 //! Canonicalize Tan:
 RCP<const Basic> tan(const RCP<const Basic> &arg);
@@ -156,8 +150,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized cot
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 //! Canonicalize Cot:
 RCP<const Basic> cot(const RCP<const Basic> &arg);
@@ -181,8 +173,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized csc
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 //! Canonicalize Csc:
 RCP<const Basic> csc(const RCP<const Basic> &arg);
@@ -206,8 +196,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized sec
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 //! Canonicalize Sec:
 RCP<const Basic> sec(const RCP<const Basic> &arg);
@@ -230,8 +218,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized asin
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ASin:
@@ -255,8 +241,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acos
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ACos:
@@ -280,8 +264,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized asec
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ASec:
@@ -305,8 +287,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acsc
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ACsc:
@@ -330,8 +310,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized atan
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ATan:
@@ -355,8 +333,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acot
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ACot:
@@ -392,8 +368,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
     virtual vec_basic get_args() const { return {num_, den_}; }
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ATan2:
@@ -428,8 +402,6 @@ public:
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! Differentiate w.r.t Symbol `x`
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Create a new LambertW instance:
@@ -474,8 +446,6 @@ public:
     bool is_canonical(const RCP<const Basic> &s, const RCP<const Basic> &a) const;
     //! Differentiate w.r.t Symbol `x`
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Create a new Zeta instance:
@@ -507,8 +477,6 @@ public:
     bool is_canonical(const RCP<const Basic> &s) const;
     //! Rewrites in the form of zeta
     RCP<const Basic> rewrite_as_zeta() const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Create a new Dirichlet_eta instance:
@@ -541,8 +509,6 @@ public:
     //! Differentiate w.r.t Symbol `x`
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
-
-    virtual void accept(Visitor &v) const;
     virtual RCP<const Basic> create(const vec_basic &x) const;
 };
 
@@ -562,7 +528,6 @@ public:
     FunctionWrapper(std::string name, const vec_basic &arg);
     FunctionWrapper(std::string name, const RCP<const Basic> &arg);
     virtual RCP<const Number> eval(long bits) const;
-    virtual void accept(Visitor &v) const;
 };
 
 /*! Derivative operator
@@ -609,8 +574,6 @@ public:
     bool is_canonical(const RCP<const Basic> &arg, const vec_basic &x) const;
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 /*! Subs operator
@@ -644,8 +607,6 @@ public:
     bool is_canonical(const RCP<const Basic> &arg, const map_basic_basic &x) const;
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 
@@ -688,8 +649,6 @@ public:
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
     //! expands sinh in terms of exp function
     virtual RCP<const Basic> expand_as_exp() const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize Sinh:
@@ -715,8 +674,6 @@ public:
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
     //! expands cosh in terms of exp function
     virtual RCP<const Basic> expand_as_exp() const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize Cosh:
@@ -742,8 +699,6 @@ public:
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
     //! expands tanh in terms of exp function
     virtual RCP<const Basic> expand_as_exp() const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize Tanh:
@@ -769,8 +724,6 @@ public:
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
     //! expands coth in terms of exp function
     virtual RCP<const Basic> expand_as_exp() const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize Coth:
@@ -794,8 +747,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized asinh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ASinh:
@@ -819,8 +770,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acosh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ACosh:
@@ -844,8 +793,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized atanh
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ATanh:
@@ -869,8 +816,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized acoth
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ACoth:
@@ -894,8 +839,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! \return Canonicalized asech
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize ASech:
@@ -925,8 +868,6 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &i, const RCP<const Basic> &j) const;
     virtual vec_basic get_args() const { return {i_, j_}; }
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize KroneckerDelta:
@@ -957,8 +898,6 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
     virtual vec_basic get_args() const { return arg_; }
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize LeviCivita:
@@ -992,8 +931,6 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     virtual vec_basic get_args() const { return {arg_}; }
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize Gamma:
@@ -1019,8 +956,6 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &s, const RCP<const Basic> &x) const;
     virtual vec_basic get_args() const { return {s_, x_}; }
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize LowerGamma:
@@ -1047,8 +982,6 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &s, const RCP<const Basic> &x) const;
     virtual vec_basic get_args() const { return {s_, x_}; }
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize UpperGamma:
@@ -1077,8 +1010,6 @@ public:
     inline RCP<const Basic> get_arg() const { return arg_; }
     virtual vec_basic get_args() const { return {arg_}; }
     RCP<const Basic> diff(const RCP<const Symbol> &x) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Canonicalize Abs:

--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -134,8 +134,6 @@ public:
     virtual RCP<const Number> rpow(const Number &other) const {
         throw std::runtime_error("Not implemented.");
     };
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! less operator (<) for Integers

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -435,44 +435,6 @@ void Mul::power_num(const Ptr<RCP<const Number>> &coef, map_basic_basic &d,
     }
 }
 
-RCP<const Basic> Mul::diff(const RCP<const Symbol> &x) const
-{
-    RCP<const Number> overall_coef = zero;
-    umap_basic_num add_dict;
-    for (const auto &p: dict_) {
-        RCP<const Number> coef = coef_;
-        RCP<const Basic> factor = pow(p.first, p.second)->diff(x);
-        if (is_a_Number(*factor) and
-                rcp_static_cast<const Number>(factor)->is_zero()) {
-            // overall_coef += factor is done to coerce overall_coef to the type of factor
-            iaddnum(outArg(overall_coef), rcp_static_cast<const Number>(factor));
-            continue;
-        }
-        map_basic_basic d = dict_;
-        d.erase(p.first);
-        if (is_a_Number(*factor)) {
-            imulnum(outArg(coef), rcp_static_cast<const Number>(factor));
-        } else if (is_a<Mul>(*factor)) {
-            RCP<const Mul> tmp = rcp_static_cast<const Mul>(factor);
-            imulnum(outArg(coef), tmp->coef_);
-            for (const auto &q: tmp->dict_) {
-                Mul::dict_add_term_new(outArg(coef), d, q.second, q.first);
-            }
-        } else {
-            RCP<const Basic> exp, t;
-            Mul::as_base_exp(factor, outArg(exp), outArg(t));
-            Mul::dict_add_term_new(outArg(coef), d, exp, t);
-        }
-        if (d.size() == 0) {
-            iaddnum(outArg(overall_coef), coef);
-        } else {
-            RCP<const Basic> mul = Mul::from_dict(one, std::move(d));
-            Add::dict_add_term(add_dict, coef, mul);
-        }
-    }
-    return Add::from_dict(overall_coef, std::move(add_dict));
-}
-
 RCP<const Basic> Mul::subs(const map_basic_basic &subs_dict) const
 {
     RCP<const Mul> self = rcp_from_this_cast<const Mul>();

--- a/symengine/mul.h
+++ b/symengine/mul.h
@@ -61,8 +61,6 @@ public:
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     virtual vec_basic get_args() const;
-
-    virtual void accept(Visitor &v) const;
 };
 //! Multiplication
 RCP<const Basic> mul(const RCP<const Basic> &a,

--- a/symengine/mul.h
+++ b/symengine/mul.h
@@ -56,8 +56,6 @@ public:
     //! \return true if both `coef` and `dict` are in canonical form
     bool is_canonical(const RCP<const Number> &coef,
             const map_basic_basic& dict) const;
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     virtual vec_basic get_args() const;

--- a/symengine/number.cpp
+++ b/symengine/number.cpp
@@ -8,9 +8,4 @@
 
 namespace SymEngine {
 
-RCP<const Basic> Number::diff(const RCP<const Symbol> &x) const
-{
-    return zero;
-}
-
 } // SymEngine

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -117,7 +117,6 @@ public:
     IMPLEMENT_TYPEID(NUMBER_WRAPPER)
     virtual std::string __str__() const { throw std::runtime_error("Not Implemented."); };
     virtual RCP<const Number> eval(long bits)  const { throw std::runtime_error("Not Implemented."); };
-    virtual void accept(Visitor &v) const;
 };
 
 //! A class that will evaluate functions numerically.

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -46,8 +46,6 @@ public:
     //! Power
     virtual RCP<const Number> pow(const Number &other) const = 0;
     virtual RCP<const Number> rpow(const Number &other) const = 0;
-    //! Differentiation w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
     virtual vec_basic get_args() const { return {}; }
 

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -123,18 +123,6 @@ mpz_class UnivariatePolynomial::max_coef() const {
     return curr;
 }
 
-RCP<const Basic> UnivariatePolynomial::diff(const RCP<const Symbol> &x) const
-{
-    if (var_->__eq__(*x)) {
-        map_uint_mpz d;
-        for (const auto &p : dict_) {
-            d[p.first - 1] = p.second * p.first;
-        }
-        return make_rcp<const UnivariatePolynomial>(var_, (--(d.end()))->first, std::move(d));
-    } else
-        return zero;
-}
-
 mpz_class UnivariatePolynomial::eval(const mpz_class &x) const {
     //TODO: Use Horner's Scheme
     mpz_class ans = 0;

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -78,6 +78,13 @@ public:
 
     virtual vec_basic get_args() const;
 
+    inline RCP<const Symbol> get_var() const {
+        return var_;
+    }
+    inline const map_uint_mpz& get_dict() const {
+        return dict_;
+    };
+
 }; //UnivariatePolynomial
 
 //! Adding two UnivariatePolynomial a and b

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -80,8 +80,6 @@ public:
 
     virtual vec_basic get_args() const;
 
-    virtual void accept(Visitor &v) const;
-
 }; //UnivariatePolynomial
 
 //! Adding two UnivariatePolynomial a and b

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -56,8 +56,6 @@ public:
     static void dict_add_term(map_uint_mpz &d,
             const mpz_class &coef, const unsigned int &n);
     mpz_class max_coef() const;
-    //! Differentiates w.r.t symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     //! Evaluates the UnivariatePolynomial at value x
     mpz_class eval(const mpz_class &x) const;
     //! Evaluates the UnivariatePolynomial at value 2**x

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -278,14 +278,6 @@ void multinomial_coefficients_mpz(int m, int n, map_vec_mpz &r)
     }
 }
 
-RCP<const Basic> Pow::diff(const RCP<const Symbol> &x) const
-{
-    if (is_a_Number(*exp_))
-        return mul(mul(exp_, pow(base_, sub(exp_, one))), base_->diff(x));
-    else
-        return mul(pow(base_, exp_), mul(exp_, log(base_))->diff(x));
-}
-
 RCP<const Basic> Pow::subs(const map_basic_basic &subs_dict) const
 {
     RCP<const Pow> self = rcp_from_this_cast<const Pow>();
@@ -372,11 +364,6 @@ RCP<const Basic> Log::subs(const map_basic_basic &subs_dict) const
     } else {
         return log(arg_new);
     }
-}
-
-RCP<const Basic> Log::diff(const RCP<const Symbol> &x) const
-{
-    return mul(div(one, arg_), arg_->diff(x));
 }
 
 RCP<const Basic> log(const RCP<const Basic> &arg)

--- a/symengine/pow.h
+++ b/symengine/pow.h
@@ -38,8 +38,6 @@ public:
     inline RCP<const Basic> get_base() const { return base_; }
     //! \return `exp` of `base**exp`
     inline RCP<const Basic> get_exp() const { return exp_; }
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     virtual vec_basic get_args() const;
@@ -85,8 +83,6 @@ public:
     //! \return `arg` of `log(arg)`
     inline RCP<const Basic> get_arg() const { return arg_; }
     virtual vec_basic get_args() const { return {arg_}; }
-    //! Differentiate w.r.t Symbol `x`
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 };
 

--- a/symengine/pow.h
+++ b/symengine/pow.h
@@ -43,8 +43,6 @@ public:
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     virtual vec_basic get_args() const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! \return Pow from `a` and `b`
@@ -90,8 +88,6 @@ public:
     //! Differentiate w.r.t Symbol `x`
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! Returns the Natural Logarithm from argument `arg`

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -231,8 +231,6 @@ public:
     virtual RCP<const Number> rpow(const Number &other) const {
         throw std::runtime_error("Not implemented.");
     };
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! returns the `num` and `den` of rational `rat` as `RCP<const Integer>`

--- a/symengine/real_double.h
+++ b/symengine/real_double.h
@@ -49,7 +49,7 @@ public:
     //! \return `true` if this number is an exact number
     inline virtual bool is_exact() const { return false; }
     //! Get `Evaluate` singleton to evaluate numerically
-    inline virtual Evaluate& get_eval() const;
+    virtual Evaluate& get_eval() const;
 
     //! \return `true` when equals to 0
     virtual bool is_zero() const { return this->i == 0.0; }

--- a/symengine/real_double.h
+++ b/symengine/real_double.h
@@ -389,8 +389,6 @@ public:
             throw std::runtime_error("Not implemented.");
         }
     }
-
-    virtual void accept(Visitor &v) const;
 };
 
 RCP<const RealDouble> real_double(double x);

--- a/symengine/real_mpfr.h
+++ b/symengine/real_mpfr.h
@@ -307,8 +307,6 @@ public:
             throw std::runtime_error("Not implemented.");
         }
     }
-
-    virtual void accept(Visitor &v) const;
 };
 
 inline RCP<const RealMPFR> real_mpfr(mpfr_class x) {

--- a/symengine/series.h
+++ b/symengine/series.h
@@ -50,8 +50,6 @@ public:
 
     std::string __str__() const;
     virtual vec_basic get_args() const { return {}; }
-    virtual void accept(Visitor &v) const;
-
 };
 
 

--- a/symengine/symbol.cpp
+++ b/symengine/symbol.cpp
@@ -30,12 +30,4 @@ int Symbol::compare(const Basic &o) const
     return name_ < s.name_ ? -1 : 1;
 }
 
-RCP<const Basic> Symbol::diff(const RCP<const Symbol> &x) const
-{
-    if (x->name_ == this->name_)
-        return one;
-    else
-        return zero;
-}
-
 } // SymEngine

--- a/symengine/symbol.h
+++ b/symengine/symbol.h
@@ -36,11 +36,6 @@ public:
     inline std::string get_name() const {
         return name_;
     }
-    /*! Differentiate w.r.t other symbol.
-     * \param x - Symbol to be differentiated with.
-     * \return `1` if `name_` are equal, else `0`
-     * */
-    virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
     virtual vec_basic get_args() const { return {}; }
 };

--- a/symengine/symbol.h
+++ b/symengine/symbol.h
@@ -43,8 +43,6 @@ public:
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
 
     virtual vec_basic get_args() const { return {}; }
-
-    virtual void accept(Visitor &v) const;
 };
 
 //! inline version to return `Symbol`


### PR DESCRIPTION
For now, I just removed `accept` and `diff`. This will work for everything, like `subs`, etc.

This works similar to the visitor pattern, except that only a single virtual function call is used.

By using the @isuruf's trick with the `bvisit` inline methods, this PR implements all derivatives as `DiffImplementation::diff` static methods.

Performance should not be affected by this PR.