### PR TITLE
Remove PATH_SUFFIXES from find_path

### DIFF
--- a/cmake/LibFindMacros.cmake
+++ b/cmake/LibFindMacros.cmake
@@ -49,7 +49,5 @@ function (libfind_include HEADER pkg)
     find_path(${PKG}_INCLUDE_DIR
         NAMES
             ${HEADER}
-        PATH_SUFFIXES
-            ${pkg}
     )
 endfunction()


### PR DESCRIPTION
That variable doesn't seem to be needed: https://cmake.org/cmake/help/v3.0/command/find_path.html