### PR TITLE
Added lint checks in a separate script

### DIFF
--- a/bin/run_lint.sh
+++ b/bin/run_lint.sh
@@ -34,3 +34,11 @@ else
     exit -1;
 fi
 
+# check space around `=` and `==`
+if ! egrep "^[^(//)]*[^\ (operator)]=[=][^\ ]" -nr --include=\*.{cpp,h,inc}  --exclude-dir=*teuchos* $SOURCE_DIR ; then
+    echo Space around = and == check passed;
+else
+    echo Space around = and == check failed;
+    exit -1;
+fi
+

--- a/bin/run_lint.sh
+++ b/bin/run_lint.sh
@@ -1,0 +1,36 @@
+# This is a temporary fix till the python script is prepared (#764).
+# To be used locally while development.
+export SOURCE_DIR=`pwd`
+
+# check trailing whitespace:
+if !  egrep " $" -nr --include=\*.{cpp,h,inc}  --exclude-dir=*teuchos* $SOURCE_DIR ; then
+    echo No trailing whitespace;
+else
+    echo No trailing whitespace check failed;
+    exit -1;
+fi
+
+# check space after comma
+if !  egrep "^([^(//)])*((,[^\ \n])|(,\ \ +))" -nr --include=\*.{cpp,h,inc}  --exclude-dir=*teuchos* $SOURCE_DIR ; then
+    echo Space after comma check passed;
+else
+    echo Space after comma check failed;
+    exit -1;
+fi
+
+# check space between `)` and `{`
+if !  egrep "(\)\{)|(\)\ \ +\{)" -nr --include=\*.{cpp,h,inc}  --exclude-dir=*teuchos* $SOURCE_DIR ; then
+    echo \"\)-space-\{\" check passed;
+else
+    echo \"\)-space-\{\" check failed;
+    exit -1;
+fi
+
+# check space after `if`
+if ! egrep "((^if)|(\ if))((\()|(\ \ +\())" -nr --include=\*.{cpp,h,inc}  --exclude-dir=*teuchos* $SOURCE_DIR ; then
+    echo \"if-space\" check passed;
+else
+    echo \"if-space\" check failed;
+    exit -1;
+fi
+

--- a/symengine/series_generic.h
+++ b/symengine/series_generic.h
@@ -55,7 +55,7 @@ public:
 };
 
 
-inline RCP<const UnivariateSeries> univariate_series(RCP<const Symbol> i,       unsigned int prec, const map_uint_mpz& dict)
+inline RCP<const UnivariateSeries> univariate_series(RCP<const Symbol> i, unsigned int prec, const map_uint_mpz& dict)
 {
     return make_rcp<const UnivariateSeries>(i, prec, dict);
 }

--- a/symengine/series_piranha.h
+++ b/symengine/series_piranha.h
@@ -14,7 +14,7 @@
 
 namespace SymEngine {
 
-using pp_t = piranha::polynomial<piranha::rational,piranha::monomial<short>>;
+using pp_t = piranha::polynomial<piranha::rational, piranha::monomial<short>>;
 // Univariate Rational Coefficient Power SeriesBase using Piranha
 class URatPSeriesPiranha : public SeriesBase<pp_t, piranha::rational, URatPSeriesPiranha> {
 public:
@@ -39,7 +39,7 @@ public:
     static pp_t subs(const pp_t &s, const pp_t &var, const pp_t &r, unsigned prec);
 };
 
-using p_expr = piranha::polynomial<Expression,piranha::monomial<int>>;
+using p_expr = piranha::polynomial<Expression, piranha::monomial<int>>;
 // Univariate Rational Coefficient Power SeriesBase using Piranha
 class UPSeriesPiranha : public SeriesBase<p_expr, Expression, UPSeriesPiranha> {
 public:

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -1152,7 +1152,7 @@ TEST_CASE("Acos: functions", "[functions]")
     REQUIRE(eq(*r1, *r2));
 
     r1 = acos(div(im1, i2));
-    r2 = mul(i2, div(pi,  i3));
+    r2 = mul(i2, div(pi, i3));
     REQUIRE(eq(*r1, *r2));
 
     r1 = acos(div(sqrt(i2), i2));
@@ -1193,7 +1193,7 @@ TEST_CASE("Asec: functions", "[functions]")
     REQUIRE(eq(*r1, *r2));
 
     r1 = asec(div(i2, im1));
-    r2 = mul(i2, div(pi,  i3));
+    r2 = mul(i2, div(pi, i3));
     REQUIRE(eq(*r1, *r2));
 
     r1 = asec(sqrt(i2));

--- a/symengine/tests/basic/test_series_expansion_UP.cpp
+++ b/symengine/tests/basic/test_series_expansion_UP.cpp
@@ -28,7 +28,7 @@ using SymEngine::umap_short_basic;
 #ifdef HAVE_SYMENGINE_PIRANHA
 #include <symengine/series_piranha.h>
 
-#define series_coeff(EX,SYM,PREC,COEFF) SymEngine::UPSeriesPiranha::series(EX,SYM->get_name(),PREC)->p_.find_cf({COEFF}).get_basic()
+#define series_coeff(EX, SYM, PREC, COEFF) SymEngine::UPSeriesPiranha::series(EX, SYM->get_name(), PREC)->p_.find_cf({COEFF}).get_basic()
 using SymEngine::UPSeriesPiranha;
 
 static bool expand_check_pairs(const RCP<const Basic> &ex, const RCP<const Symbol> &x, int prec, const umap_short_basic& pairs)

--- a/symengine/tests/basic/test_series_expansion_URatP.cpp
+++ b/symengine/tests/basic/test_series_expansion_URatP.cpp
@@ -31,7 +31,7 @@ using SymEngine::umap_short_basic;
 #ifdef HAVE_SYMENGINE_PIRANHA
 #include <symengine/series_piranha.h>
 
-#define series_coeff(EX,SYM,PREC,COEFF) prat2synum(SymEngine::URatPSeriesPiranha::series(EX,SYM->get_name(),PREC)->p_.find_cf({COEFF}))
+#define series_coeff(EX, SYM, PREC, COEFF) prat2synum(SymEngine::URatPSeriesPiranha::series(EX, SYM->get_name(), PREC)->p_.find_cf({COEFF}))
 using SymEngine::URatPSeriesPiranha;
 
 static inline RCP<const Number> prat2synum(const piranha::rational& p_rat)

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -955,7 +955,7 @@ TEST_CASE("test_determinant(): matrices", "[matrices]")
     M = DenseMatrix(4, 4, {integer(3), integer(-2), integer(0), integer(5),
                            integer(-2), integer(1), integer(-2), integer(2),
                            integer(0), integer(-2), integer(5), integer(0),
-                           integer(5),  integer(0), integer(3), integer(4)});
+                           integer(5), integer(0), integer(3), integer(4)});
     REQUIRE(eq(*det_bareis(M), *integer(-289)));
     REQUIRE(eq(*det_berkowitz(M), *integer(-289)));
 
@@ -980,7 +980,7 @@ TEST_CASE("test_determinant(): matrices", "[matrices]")
         integer(2), integer(0), integer(1), integer(1), integer(4),
         integer(2), integer(1), integer(1), integer(-1), integer(3),
         integer(3), integer(2), integer(-1), integer(1), integer(8),
-        integer(1), integer(1),  integer(1), integer(0), integer(6)});
+        integer(1), integer(1), integer(1), integer(0), integer(6)});
     REQUIRE(eq(*det_bareis(M), *integer(-55)));
     REQUIRE(eq(*det_berkowitz(M), *integer(-55)));
 


### PR DESCRIPTION
The tests still for these because of `-Wl,--no-as-needed` part:
```bash
/home/travis/build/abinashmeher999/symengine/benchmarks/expand6_ginac.cpp:4:// $ g++ -std=c++0x -o expand6_ginac -Wl,--no-as-needed `pkg-config --cflags --libs ginac` expand6_ginac.cpp

/home/travis/build/abinashmeher999/symengine/benchmarks/expand7_ginac.cpp:4:// $ g++ -std=c++0x -o expand6_ginac -Wl,--no-as-needed `pkg-config --cflags --libs ginac` expand6_ginac.cpp

/home/travis/build/abinashmeher999/symengine/benchmarks/lwbench_ginac.cpp:4:// $ g++ -std=c++0x -o lwbench_ginac -Wl,--no-as-needed `pkg-config --cflags --libs ginac` lwbench_ginac.cpp

/home/travis/build/abinashmeher999/symengine/benchmarks/matrix_add1_ginac.cpp:4:// $ g++ -o matrix_add1_ginac -Wl,--no-as-needed `pkg-config --cflags --libs ginac` matrix_add1_ginac.cpp

/home/travis/build/abinashmeher999/symengine/benchmarks/matrix_add2_ginac.cpp:4:// $ g++ -o matrix_add2_ginac -Wl,--no-as-needed `pkg-config --cflags --libs ginac` matrix_add2_ginac.cpp

/home/travis/build/abinashmeher999/symengine/benchmarks/matrix_mul1_ginac.cpp:4:// $ g++ -o matrix_mul1_ginac -Wl,--no-as-needed `pkg-config --cflags --libs ginac` matrix_mul1_ginac.cpp

/home/travis/build/abinashmeher999/symengine/benchmarks/matrix_mul2_ginac.cpp:4:// $ g++ -o matrix_mul2_ginac -Wl,--no-as-needed `pkg-config --cflags --libs ginac` matrix_mul2_ginac.cpp

/home/travis/build/abinashmeher999/symengine/benchmarks/symbench_ginac.cpp:4:// $ g++ -std=c++0x -o symbench_ginac -Wl,--no-as-needed `pkg-config --cflags --libs ginac` symbench_ginac.cpp
```
I am not able to figure out how to ignore these. I can ignore `--` after a comma, but then again it will also ignore `,--i` like sequences.