### PR TITLE
Flint univariate series expansion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,11 @@ if (WITH_PRIMESIEVE)
     set(PKGS ${PKGS} "PRIMESIEVE")
 endif()
 
+# FLINT
+set(WITH_FLINT no
+    CACHE BOOL "Build with Flint")
+set(HAVE_SYMENGINE_FLINT False)
+
 # ARB
 set(WITH_ARB no
     CACHE BOOL "Build with Arb")
@@ -150,6 +155,19 @@ set(WITH_MPC no
     CACHE BOOL "Build with MPC")
 set(HAVE_SYMENGINE_MPC False)
 
+if (WITH_FLINT)
+    find_package(FLINT REQUIRED)
+    include_directories(${FLINT_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${FLINT_TARGETS})
+    set(HAVE_SYMENGINE_FLINT True)
+    set(PKGS ${PKGS} "FLINT")
+
+    # Workaround for https://github.com/fredrik-johansson/arb/issues/24
+    include_directories(${FLINT_INCLUDE_DIRS}/flint)
+
+    set(WITH_MPFR yes)
+endif()
+
 if (WITH_ARB)
     find_package(FLINT REQUIRED)
     include_directories(${FLINT_INCLUDE_DIRS})
@@ -159,6 +177,8 @@ if (WITH_ARB)
     # Workaround for https://github.com/fredrik-johansson/arb/issues/24
     include_directories(${FLINT_INCLUDE_DIRS}/flint)
 
+    set(WITH_FLINT yes)
+    set(HAVE_SYMENGINE_FLINT True)
     set(WITH_MPFR yes)
 
     find_package(ARB REQUIRED)
@@ -384,6 +404,7 @@ configure_file(cmake/SymEngineConfigVersion.cmake.in SymEngineConfigVersion.cmak
 
 install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/SymEngineConfig.cmake"
               ${PROJECT_BINARY_DIR}/SymEngineConfigVersion.cmake
+              cmake/FindFLINT.cmake
               cmake/FindARB.cmake
               cmake/FindBFD.cmake
               cmake/FindECM.cmake
@@ -461,6 +482,12 @@ message("WITH_PRIMESIEVE: ${WITH_PRIMESIEVE}")
 if (WITH_PRIMESIEVE)
     message("PRIMESIEVE_INCLUDE_DIRS: ${PRIMESIEVE_INCLUDE_DIRS}")
     message("PRIMESIEVE_LIBRARIES: ${PRIMESIEVE_LIBRARIES}")
+endif()
+
+message("WITH_FLINT: ${WITH_FLINT}")
+if (WITH_FLINT)
+    message("FLINT_INCLUDE_DIRS: ${FLINT_INCLUDE_DIRS}")
+    message("FLINT_LIBRARIES: ${FLINT_LIBRARIES}")
 endif()
 
 message("WITH_ARB: ${WITH_ARB}")

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ their default values indicated below:
         -DWITH_SYMENGINE_THREAD_SAFE:BOOL=OFF \       # Build with thread safety
         -DWITH_ECM:BOOL=OFF \                         # Build with GMP-ECM library for integer factorization
         -DWITH_PRIMESIEVE:BOOL=OFF \                  # Install with Primesieve library
+        -DWITH_FLINT:BOOL=OFF \                       # Install with Flint library
         -DWITH_ARB:BOOL=OFF \                         # Install with ARB library
         -DWITH_TCMALLOC:BOOL=OFF \                    # Install with TCMalloc linked
         -DWITH_OPENMP:BOOL=OFF \                      # Install with OpenMP enabled

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -50,9 +50,14 @@ target_link_libraries(expand7 symengine)
 add_executable(series series.cpp)
 target_link_libraries(series symengine)
 
+if (WITH_FLINT)
+    add_executable(series_expansion_sincos_flint series_expansion_sincos_flint.cpp)
+    target_link_libraries(series_expansion_sincos_flint symengine)
+endif()
+
 if (WITH_PIRANHA)
-    add_executable(series_expansion_sincos series_expansion_sincos.cpp)
-    target_link_libraries(series_expansion_sincos symengine)
+    add_executable(series_expansion_sincos_piranha series_expansion_sincos_piranha.cpp)
+    target_link_libraries(series_expansion_sincos_piranha symengine)
 
     add_executable(series_expansion_sinp series_expansion_sinp.cpp)
     target_link_libraries(series_expansion_sinp symengine)

--- a/benchmarks/series_expansion_sincos_flint.cpp
+++ b/benchmarks/series_expansion_sincos_flint.cpp
@@ -1,6 +1,7 @@
 #include <symengine/symengine_config.h>
 
-#ifdef HAVE_SYMENGINE_PIRANHA
+#ifdef HAVE_SYMENGINE_FLINT
+#include <symengine/series_flint.h>
 
 #include <iostream>
 #include <chrono>
@@ -13,7 +14,10 @@
 using SymEngine::Basic;
 using SymEngine::Symbol;
 using SymEngine::symbol;
+using SymEngine::integer;
+using SymEngine::add;
 using SymEngine::mul;
+using SymEngine::pow;
 using SymEngine::sin;
 using SymEngine::cos;
 using SymEngine::RCP;
@@ -26,10 +30,11 @@ int main(int argc, char* argv[])
 
     RCP<const Symbol> x = symbol("x");
     int N = 1000;
-    auto ex = mul(sin(x), cos(x));
+    auto arg = add(x, pow(x, integer(2)));
+    auto ex = mul(sin(arg), cos(arg));
 
     auto t1 = std::chrono::high_resolution_clock::now();
-    auto res = series(ex, x, N);
+    auto res = SymEngine::URatPSeriesFlint::series(ex, "x", N);
     auto t2 = std::chrono::high_resolution_clock::now();
     //std::cout << *res[N-1] << std::endl;
     std::cout
@@ -39,7 +44,5 @@ int main(int argc, char* argv[])
     return 0;
 }
 #else
-
-int main(int, char*[]) {}
-
+int main() {}
 #endif

--- a/benchmarks/series_expansion_sincos_piranha.cpp
+++ b/benchmarks/series_expansion_sincos_piranha.cpp
@@ -1,0 +1,48 @@
+#include <symengine/symengine_config.h>
+
+#ifdef HAVE_SYMENGINE_PIRANHA
+#include <symengine/series_piranha.h>
+
+#include <iostream>
+#include <chrono>
+
+#include <symengine/functions.h>
+#include <symengine/symbol.h>
+#include <symengine/mul.h>
+#include <symengine/series.h>
+
+using SymEngine::Basic;
+using SymEngine::Symbol;
+using SymEngine::symbol;
+using SymEngine::integer;
+using SymEngine::add;
+using SymEngine::mul;
+using SymEngine::pow;
+using SymEngine::sin;
+using SymEngine::cos;
+using SymEngine::RCP;
+using SymEngine::series;
+using SymEngine::rcp_dynamic_cast;
+
+int main(int argc, char* argv[])
+{
+    SymEngine::print_stack_on_segfault();
+
+    RCP<const Symbol> x = symbol("x");
+    int N = 200;
+    auto arg = add(x, pow(x, integer(2)));
+    auto ex = mul(sin(arg), cos(arg));
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+    auto res = SymEngine::URatPSeriesPiranha::series(ex, "x", N);
+    auto t2 = std::chrono::high_resolution_clock::now();
+    //std::cout << *res[N-1] << std::endl;
+    std::cout
+        << std::chrono::duration_cast<std::chrono::milliseconds>(t2-t1).count()
+        << "ms" << std::endl;
+
+    return 0;
+}
+#else
+int main() {}
+#endif

--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -49,6 +49,10 @@ if (WITH_MPC)
     set(SRC ${SRC} eval_mpc.cpp complex_mpc.cpp)
 endif()
 
+if (WITH_FLINT)
+    set(SRC ${SRC} series_flint.cpp)
+endif()
+
 if (WITH_ARB)
     set(SRC ${SRC} eval_arb.cpp)
 endif()
@@ -66,7 +70,7 @@ set(HEADERS
     visitor.h    eval_double.h    diophantine.h cwrapper.h  printer.h  real_double.h
     eval_mpfr.h  eval_arb.h       eval_mpc.h     complex_double.h         series_visitor.h
     real_mpfr.h  complex_mpc.h    type_codes.inc lambda_double.h series.h series_piranha.h
-    series_generic.h              basic-methods.inc
+    basic-methods.inc   series_flint.h  series_generic.h
 )
 
 # Configure SymEngine using our CMake options:

--- a/symengine/series.h
+++ b/symengine/series.h
@@ -54,10 +54,10 @@ public:
             if (var_ != o.var_) {
                 throw std::runtime_error("Multivariate Series not implemented");
             }
-            return make_rcp<Series>(p_ + o.p_, var_, deg);
+            return make_rcp<Series>(Poly(p_ + o.p_), var_, deg);
         } else if (other.get_type_code() < Series::type_code_id){
             Poly p = Series::series(other.rcp_from_this(), var_, degree_)->p_;
-            return make_rcp<Series>(p_ + p, var_, degree_);
+            return make_rcp<Series>(Poly(p_ + p), var_, degree_);
         } else {
             return other.add(*this);
         }
@@ -102,7 +102,7 @@ public:
         } else {
             return other.rpow(*this);
         }
-        p = Series::series_exp(p * Series::series_log(p_, Series::var(var_), deg),
+        p = Series::series_exp(Poly(p * Series::series_log(p_, Series::var(var_), deg)),
                                Series::var(var_), deg);
         return make_rcp<Series>(p, var_, deg);
     }
@@ -110,7 +110,7 @@ public:
     virtual RCP<const Number> rpow(const Number &other) const {
         if (other.get_type_code() < Series::type_code_id){
             Poly p = Series::series(other.rcp_from_this(), var_, degree_)->p_;
-            p = Series::series_exp(p_ * Series::series_log(p, Series::var(var_), degree_),
+            p = Series::series_exp(Poly(p_ * Series::series_log(p, Series::var(var_), degree_)),
                                    Series::var(var_), degree_);
             return make_rcp<Series>(p, var_, degree_);
         } else {

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -25,10 +25,11 @@ unsigned int str_hash(const char* s, unsigned int seed = 0)
 }
 
 std::size_t URatPSeriesFlint::__hash__() const {
-    std::size_t seed = URATPSERIESPIRANHA;
+    std::hash<std::string> str_hash;
+    std::size_t seed = URATPSERIESFLINT;
     hash_combine(seed, var_);
     hash_combine(seed, degree_);
-    hash_combine(seed, str_hash(p_.to_string().c_str(), seed));
+    hash_combine(seed, str_hash(p_.to_string()));
     return seed;
 }
 

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -14,16 +14,6 @@ RCP<const URatPSeriesFlint> URatPSeriesFlint::series(const RCP<const Basic> &t, 
     return visitor.series(t);
 }
 
-unsigned int str_hash(const char* s, unsigned int seed = 0)
-{
-    unsigned int hash = seed;
-    while (*s)
-    {
-        hash = hash * 101  +  *s++;
-    }
-    return hash;
-}
-
 std::size_t URatPSeriesFlint::__hash__() const {
     std::hash<std::string> str_hash;
     std::size_t seed = URATPSERIESFLINT;

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -1,0 +1,172 @@
+#include <symengine/series_flint.h>
+#include <symengine/series_visitor.h>
+
+#ifdef HAVE_SYMENGINE_FLINT
+namespace SymEngine {
+
+URatPSeriesFlint::URatPSeriesFlint(fp_t p, const std::string varname, const unsigned degree)
+        : SeriesBase(std::move(p), varname, degree) {
+
+}
+RCP<const URatPSeriesFlint> URatPSeriesFlint::series(const RCP<const Basic> &t, const std::string &x, unsigned int prec) {
+    fp_t p("2  0 1");
+    SeriesVisitor<fp_t, flint::fmpqxx, URatPSeriesFlint> visitor(p, x, prec);
+    return visitor.series(t);
+}
+
+unsigned int str_hash(const char* s, unsigned int seed = 0)
+{
+    unsigned int hash = seed;
+    while (*s)
+    {
+        hash = hash * 101  +  *s++;
+    }
+    return hash;
+}
+
+std::size_t URatPSeriesFlint::__hash__() const {
+    std::size_t seed = URATPSERIESPIRANHA;
+    hash_combine(seed, var_);
+    hash_combine(seed, degree_);
+    hash_combine(seed, str_hash(p_.to_string().c_str(), seed));
+    return seed;
+}
+
+RCP<const Basic> URatPSeriesFlint::as_basic() const
+{
+    RCP<const Symbol> x = symbol(var_);
+    umap_basic_num dict_;
+    mpq_class gc;
+    for (int n=0; n<degree_; n++) {
+        const flint::fmpqxx fc(p_.get_coeff(n));
+        if (not fc.is_zero()) {
+            fmpq_get_mpq(gc.get_mpq_t(), fc._data().inner);
+            gc.canonicalize();
+            RCP<const Number> basic;
+            if (gc.get_den() == 1)
+                basic = integer(gc.get_num());
+            else
+                basic = Rational::from_mpq(gc);
+            auto term = SymEngine::mul(SymEngine::pow(x, SymEngine::integer(n)), basic);
+            Add::coef_dict_add_term(outArg(basic), dict_, one, term);
+        }
+    }
+    return std::move(Add::from_dict(one, std::move(dict_)));
+}
+
+umap_int_basic URatPSeriesFlint::as_dict() const
+{
+    umap_int_basic map;
+    mpq_class gc;
+    for (int n=0; n<degree_; n++) {
+        const flint::fmpqxx fc(p_.get_coeff(n));
+        if (not fc.is_zero()) {
+            fmpq_get_mpq(gc.get_mpq_t(), fc._data().inner);
+            gc.canonicalize();
+            RCP<const Number> basic;
+            if (gc.get_den() == 1)
+                basic = integer(gc.get_num());
+            else
+                basic = Rational::from_mpq(gc);
+            map[n] = basic;
+        }
+    }
+    return map;
+}
+
+RCP<const Basic> URatPSeriesFlint::get_coeff(int n) const
+{
+    const flint::fmpqxx fc(p_.get_coeff(n));
+    mpq_class gc;
+    fmpq_get_mpq(gc.get_mpq_t(), fc._data().inner);
+    gc.canonicalize();
+    if (gc.get_den() == 1)
+        return integer(gc.get_num());
+    else
+        return Rational::from_mpq(gc);
+}
+
+int URatPSeriesFlint::compare(const Basic &o) const {
+    SYMENGINE_ASSERT(is_a<URatPSeriesFlint>(o))
+    const URatPSeriesFlint &s = static_cast<const URatPSeriesFlint &>(o);
+    if (var_ != s.var_)
+        return (var_ < s.var_) ? -1 : 1;
+    if (degree_ != s.degree_)
+        return (degree_ < s.degree_) ? -1 : 1;
+    if (p_ == s.p_)
+        return 0;
+    return (p_ < s.p_) ? -1 : 1;
+}
+
+flint::fmpzxx URatPSeriesFlint::convert(const Integer &x) {
+    flint::fmpzxx r;
+    fmpz_set_mpz(r._data().inner, x.as_mpz().get_mpz_t());
+    return r;
+}
+
+flint::fmpqxx URatPSeriesFlint::convert(const mpq_class &x) {
+    flint::fmpqxx r;
+    flint::fmpzxx i1;
+    fmpz_set_mpz(i1._data().inner, x.get_num_mpz_t());
+    flint::fmpzxx i2;
+    fmpz_set_mpz(i2._data().inner, x.get_den_mpz_t());
+    r.num() = i1;
+    r.den() = i2;
+    return r;
+}
+
+fp_t URatPSeriesFlint::var(const std::string &s) {
+    fp_t r("2  0 1");
+    return r;
+}
+
+flint::fmpqxx URatPSeriesFlint::convert(const Rational &x) {
+    return convert(x.as_mpq());
+}
+
+flint::fmpqxx URatPSeriesFlint::convert(const Number &x) {
+    throw std::runtime_error("Not Implemented");
+}
+
+fp_t URatPSeriesFlint::pow(const fp_t &s, int n, unsigned prec) {
+    if (n > 0)
+        return fp_t(s.pow(unsigned(n)));
+    else if (n < 0)
+        return fp_t(s.inv_series(prec).pow(unsigned(-n)));
+    return fp_t(1);
+}
+
+unsigned URatPSeriesFlint::ldegree(const fp_t &s) {
+    long i = 0;
+    while (i <= s.degree())
+        if (not s.get_coeff(i++).is_zero())
+            return i-1;
+    return 0;
+}
+
+flint::fmpqxx URatPSeriesFlint::root(flint::fmpqxx &c, unsigned n) {
+    flint::fmpqxx cl_rat = c, cl_root;
+    cl_rat.canonicalise();
+    cl_root.num() = cl_rat.num().root(n);
+    if (cl_rat.den() == 1)
+        cl_root.den() = 1;
+    else
+        cl_root.den() = cl_rat.den().root(n);
+    return cl_root;
+}
+
+fp_t URatPSeriesFlint::diff(const fp_t &s, const fp_t &var) {
+    return fp_t(s.derivative());
+}
+
+fp_t URatPSeriesFlint::integrate(const fp_t &s, const fp_t &var) {
+    return fp_t(s.integral());
+}
+
+fp_t URatPSeriesFlint::subs(const fp_t &s, const fp_t &var, const fp_t &r, unsigned prec) {
+    return fp_t(s(r));
+}
+
+}
+#endif // HAVE_SYMENGINE_FLINT
+

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -1,0 +1,156 @@
+#ifndef SYMENGINE_SERIES_FLINT_H
+#define SYMENGINE_SERIES_FLINT_H
+
+#include <symengine/series.h>
+#include <symengine/rational.h>
+#include <symengine/expression.h>
+
+#ifdef HAVE_SYMENGINE_FLINT
+#include <flint/fmpq_polyxx.h>
+
+namespace SymEngine {
+
+using fp_t = flint::fmpq_polyxx;
+// Univariate Rational Coefficient Power SeriesBase using Flint
+class URatPSeriesFlint : public SeriesBase<fp_t, flint::fmpqxx, URatPSeriesFlint> {
+public:
+    URatPSeriesFlint(const fp_t p, const std::string varname, const unsigned degree);
+    IMPLEMENT_TYPEID(URATPSERIESFLINT)
+    virtual int compare(const Basic &o) const;
+    virtual std::size_t __hash__() const;
+    virtual RCP<const Basic> as_basic() const;
+    virtual umap_int_basic as_dict() const;
+    virtual RCP<const Basic> get_coeff(int) const;
+    
+    static RCP<const URatPSeriesFlint> series(const RCP<const Basic> &t, const std::string &x, unsigned int prec);
+    static flint::fmpzxx convert(const Integer &x);
+    static flint::fmpqxx convert(const mpq_class &x);
+    static fp_t var(const std::string &s);
+    static flint::fmpqxx convert(const Rational &x);
+    static flint::fmpqxx convert(const Number &x);
+    static inline fp_t mul(const fp_t &s, const fp_t &r, unsigned prec) {
+        return fp_t(flint::mullow(s, r, prec));
+    }
+    static fp_t pow(const fp_t &s, int n, unsigned prec);
+    static unsigned ldegree(const fp_t &s);
+    static inline flint::fmpqxx find_cf(const fp_t &s, const fp_t &var, unsigned deg) {
+        return flint::fmpqxx((s.get_coeff(deg)));
+    }
+    static flint::fmpqxx root(flint::fmpqxx &c, unsigned n);
+    static fp_t diff(const fp_t &s, const fp_t &var);
+    static fp_t integrate(const fp_t &s, const fp_t &var);
+    static fp_t subs(const fp_t &s, const fp_t &var, const fp_t &r, unsigned prec);
+
+    static inline fp_t series_invert(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        if (not s.get_coeff(0).is_zero())
+            return fp_t(flint::inv_series(s, prec));
+        else
+            throw std::runtime_error("Flint cannot handle Laurent polynomials");
+    }
+    static inline fp_t series_reverse(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(flint::revert_series(s, prec));
+    }
+    static inline fp_t series_log(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(log_series(s, prec));
+    }
+    static inline fp_t series_exp(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(exp_series(s, prec));
+    }
+    static inline fp_t series_tan(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(tan_series(s, prec));
+    }
+    static inline fp_t series_cos(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(cos_series(s, prec));
+    }
+    static inline fp_t series_sin(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(sin_series(s, prec));
+    }
+    static inline fp_t series_atan(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(atan_series(s, prec));
+    }
+    static inline fp_t series_atanh(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(atanh_series(s, prec));
+    }
+    static inline fp_t series_asin(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(asin_series(s, prec));
+    }
+    static inline fp_t series_asinh(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(asinh_series(s, prec));
+    }
+    static inline fp_t series_acos(const fp_t &s, const fp_t& var, unsigned int prec) {
+        throw std::runtime_error("acos() not implemented");
+    }
+    static inline fp_t series_sinh(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(sinh_series(s, prec));
+    }
+    static inline fp_t series_cosh(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(cosh_series(s, prec));
+    }
+    static inline fp_t series_tanh(const fp_t &s, const fp_t& var, unsigned int   prec) {
+        return fp_t(tanh_series(s, prec));
+    }
+    static inline fp_t series_lambertw(const fp_t &s, const fp_t& var, unsigned int prec) {
+        flint::fmpqxx c(s.get_coeff(0));
+        if (not c.is_zero())
+            throw std::logic_error("lambertw(const) not Implemented");
+
+        fp_t p1;
+        p1.set_zero();
+
+        auto steps = step_list(prec);
+        for (const auto step : steps) {
+            const fp_t e(series_exp(p1, var, step));
+            const fp_t p2(mul(e, p1, step) - s);
+            const fp_t p3(series_invert(mul(e, fp_t(p1 + fp_t(1)), step), var, step));
+            p1 -= mul(p2, p3, step);
+        }
+        return p1;
+    }
+
+    static inline fp_t series_nthroot(const fp_t &s, int n, const fp_t &var, unsigned int prec) {
+        fp_t one;
+        one.set_one();
+        if (n == 0)
+            return one;
+        if (n == 1)
+            return s;
+        if (n == -1)
+            return series_invert(s, var, prec);
+
+        const short ldeg = ldegree(s);
+        if (ldeg % n != 0) {
+            throw std::runtime_error("Puiseux series not implemented.");
+        }
+        fp_t ss = s;
+        if (ldeg != 0) {
+            ss = s * pow(var, -ldeg, prec);
+        }
+        flint::fmpqxx ct = find_cf(ss, var, 0);
+        bool do_inv = false;
+        if (n < 0) {
+            n = -n;
+            do_inv = true;
+        }
+
+        flint::fmpqxx ctroot = root(ct, n);
+        fp_t res_p = one, sn = fp_t(ss / ct);
+        auto steps = step_list(prec);
+        for (const auto step : steps) {
+            fp_t t = mul(pow(res_p, n + 1, step), sn, step);
+            res_p += (res_p - t) / n;
+        }
+        if (ldeg != 0) {
+            res_p *= pow(var, ldeg / n, prec);
+        }
+        if (do_inv)
+            return fp_t(res_p * ctroot);
+        else
+            return fp_t(series_invert(res_p, var, prec) * ctroot);
+    }
+
+};
+} // SymEngine
+
+#endif // HAVE_SYMENGINE_FLINT
+
+#endif //SYMENGINE_SERIES_FLINT_H

--- a/symengine/series_visitor.h
+++ b/symengine/series_visitor.h
@@ -14,7 +14,7 @@ private:
     const std::string varname;
     const unsigned prec;
 public:
-    inline SeriesVisitor(const Poly var_, const std::string varname_, const unsigned prec_)
+    inline SeriesVisitor(const Poly &var_, const std::string &varname_, const unsigned prec_)
             : var(var_), varname(varname_), prec(prec_) {
 
     }
@@ -82,7 +82,7 @@ public:
         } else if (eq(*E, *base)) {
             p = Series::series_exp(apply(exp), var, prec);
         } else {
-            p = Series::series_exp(apply(exp) * Series::series_log(apply(base), var, prec), var, prec);
+            p = Series::series_exp(Poly(apply(exp) * Series::series_log(apply(base), var, prec)), var, prec);
         }
     }
 

--- a/symengine/symengine_config.h.in
+++ b/symengine/symengine_config.h.in
@@ -13,6 +13,9 @@
 /* Define if you want to enable PRIMESIEVE support in SymEngine */
 #cmakedefine HAVE_SYMENGINE_PRIMESIEVE
 
+/* Define if you want to enable Flint support in SymEngine */
+#cmakedefine HAVE_SYMENGINE_FLINT
+
 /* Define if you want to enable ARB support in SymEngine */
 #cmakedefine HAVE_SYMENGINE_ARB
 

--- a/symengine/tests/basic/CMakeLists.txt
+++ b/symengine/tests/basic/CMakeLists.txt
@@ -30,6 +30,12 @@ if (WITH_PIRANHA)
     add_test(test_series_expansion_URatP ${PROJECT_BINARY_DIR}/test_series_expansion_URatP)
 endif()
 
+if (WITH_FLINT)
+    add_executable(test_series_expansion_URatF test_series_expansion_URatF.cpp)
+    target_link_libraries(test_series_expansion_URatF symengine catch)
+    add_test(test_series_expansion_URatF ${PROJECT_BINARY_DIR}/test_series_expansion_URatF)
+endif()
+
 add_executable(test_functions test_functions.cpp)
 target_link_libraries(test_functions symengine catch)
 add_test(test_functions ${PROJECT_BINARY_DIR}/test_functions)

--- a/symengine/tests/basic/test_series_expansion_URatF.cpp
+++ b/symengine/tests/basic/test_series_expansion_URatF.cpp
@@ -1,0 +1,261 @@
+#include <symengine/symengine_config.h>
+
+#include "catch.hpp"
+#include <iostream>
+#include <chrono>
+
+#include <symengine/symengine_rcp.h>
+#include <symengine/functions.h>
+#include <symengine/integer.h>
+#include <symengine/rational.h>
+#include <symengine/symbol.h>
+#include <symengine/add.h>
+#include <symengine/pow.h>
+
+using SymEngine::Basic;
+using SymEngine::Integer;
+using SymEngine::integer;
+using SymEngine::Rational;
+using SymEngine::rational;
+using SymEngine::Symbol;
+using SymEngine::Number;
+using SymEngine::symbol;
+using SymEngine::Add;
+using SymEngine::make_rcp;
+using SymEngine::RCP;
+using SymEngine::add;
+using SymEngine::sin;
+using SymEngine::cos;
+using SymEngine::umap_short_basic;
+
+#ifdef HAVE_SYMENGINE_FLINT
+#include <symengine/series_flint.h>
+
+using SymEngine::URatPSeriesFlint;
+using SymEngine::fp_t;
+#define series_coeff(EX,SYM,PREC,COEFF) SymEngine::URatPSeriesFlint::series(EX,SYM->get_name(),PREC)->get_coeff(COEFF)
+
+static RCP<const Number> fmpqxx2sym (flint::fmpqxx fc)
+{
+    mpq_class gc;
+    fmpq_get_mpq(gc.get_mpq_t(), fc._data().inner);
+    gc.canonicalize();
+    if (gc.get_den() == 1)
+        return integer(gc.get_num());
+    else
+        return Rational::from_mpq(gc);
+}
+
+static RCP<const Number> invseries_coeff (const RCP<const Basic>& ex, const RCP<const Symbol>& sym, unsigned int prec, int n)
+{
+    auto ser =  URatPSeriesFlint::series(ex, sym->get_name(), prec);
+    auto serrev = URatPSeriesFlint::series_reverse(ser->p_, fp_t(sym->get_name().c_str()),prec);
+    return fmpqxx2sym(flint::fmpqxx(serrev.get_coeff(n)));
+}
+
+static bool expand_check_pairs(const RCP<const Basic> &ex, const RCP<const Symbol> &x, int prec, const umap_short_basic& pairs)
+{
+    auto ser = SymEngine::URatPSeriesFlint::series(ex, x->get_name(), prec);
+    for (auto it : pairs) {
+        //std::cerr << it.first << ", " << *(it.second) << "::" << *(v1.at(it.first)) << std::endl;
+        if (not it.second->__eq__(*(ser->get_coeff(it.first))))
+            return false;
+        }
+    return true;
+}
+
+TEST_CASE("Expression series expansion: Add ", "[Expansion of Add]")
+{
+    RCP<const Symbol> x = symbol("x"), y = symbol("y");
+    auto z = add(integer(1), x);
+    z = sub(z, pow(x, integer(2)));
+    z = add(z, pow(x, integer(4)));
+
+    auto vb = umap_short_basic{{0, integer(1)}, {1, integer(1)}, {2, integer(-1)}, {4, integer(1)}};
+    REQUIRE(expand_check_pairs(z, x, 5, vb));
+    auto vb1 = umap_short_basic{{0, integer(1)}, {1, integer(1)}, {2, integer(-1)}};
+    REQUIRE(expand_check_pairs(z, x, 3, vb1));
+}
+
+TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    auto z1 = sin(x);
+    auto z2 = cos(x);
+    auto z3 = add(sin(x), cos(x));
+    auto z4 = mul(sin(x), cos(x));
+    auto z5 = sin(atan(x));
+    auto z6 = cos(div(x, sub(one, x)));
+
+    REQUIRE(series_coeff(z1, x, 10, 9)->__eq__(*rational(1, 362880)));
+    auto res = umap_short_basic{{0, integer(1)}, {2, rational(-1, 2)}};
+    REQUIRE(expand_check_pairs(z2, x, 3, res));
+    REQUIRE(series_coeff(z3, x, 9, 8)->__eq__(*rational(1, 40320)));
+    REQUIRE(series_coeff(z4, x, 12, 11)->__eq__(*rational(-4, 155925)));
+    REQUIRE(series_coeff(z5, x, 30, 27)->__eq__(*rational(-1300075, 8388608)));
+    REQUIRE(series_coeff(z6, x, 15, 11)->__eq__(*rational(-125929, 362880)));
+}
+
+TEST_CASE("Expression series expansion: division, inversion ", "[Expansion of 1/ex]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    RCP<const Integer> two = integer(2);
+    RCP<const Integer> three = integer(3);
+    auto ex1 = div(one, sub(one, x));                   // 1/(1-x)
+    auto ex2 = div(x, sub(sub(one, x), pow(x, two)));   // x/(1-x-x^2)
+    auto ex3 = div(pow(x, three), sub(one, mul(pow(x, two), two))); // x^3/(1-2x^2)
+    auto ex4 = div(one, sub(one, sin(x)));              // 1/(1-sin(x))
+    auto ex5 = div(one, x);
+    auto ex6 = div(one, mul(x, sub(one, x)));
+    auto res1 = umap_short_basic{{-1, integer(1)}};
+    auto res2 = umap_short_basic{{-1, integer(1)}, {0, integer(1)}};
+
+    REQUIRE(series_coeff(ex1, x, 100, 99)->__eq__(*integer(1)));
+    REQUIRE(series_coeff(ex2, x, 100, 35)->__eq__(*integer(9227465)));
+    REQUIRE(series_coeff(ex3, x, 100, 49)->__eq__(*integer(8388608)));
+    REQUIRE(series_coeff(ex4, x, 20, 10)->__eq__(*rational(1382, 14175)));
+    //! TODO: REQUIRE(expand_check_pairs(ex5, x, 8, res1));
+    //! TODO: REQUIRE(expand_check_pairs(ex6, x, 8, res2));
+}
+
+TEST_CASE("Expression series expansion: roots", "[Expansion of root(ex)]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Number> q12 = rational(1, 2);
+    RCP<const Number> qm23 = rational(-2, 3);
+    RCP<const Integer> one = integer(1);
+    RCP<const Integer> four = integer(4);
+    auto ex1 = pow(sub(four, x), q12);
+    auto ex2 = pow(sub(one, x), qm23);
+    auto ex3 = sqrt(sub(one, x));
+    auto ex4 = pow(cos(x), q12);
+    auto ex5 = pow(cos(x), qm23);
+    auto ex6 = sqrt(cos(x));
+
+    REQUIRE(series_coeff(ex1, x, 8, 6)->__eq__(*rational(-21, 2097152)));
+    REQUIRE(series_coeff(ex2, x, 12, 10)->__eq__(*rational(1621477, 4782969)));
+    REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(-2431, 262144)));
+    REQUIRE(series_coeff(ex4, x, 100, 8)->__eq__(*rational(-559, 645120)));
+    REQUIRE(series_coeff(ex5, x, 20, 10)->__eq__(*rational(701, 127575)));
+    REQUIRE(series_coeff(ex6, x, 10, 8)->__eq__(*rational(-559, 645120)));
+}
+
+TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    RCP<const Integer> two = integer(2);
+    RCP<const Integer> three = integer(3);
+    auto ex1 = log(add(one, x));
+    auto ex2 = log(cos(x));
+    auto ex3 = log(div(one, sub(one, x)));
+    auto ex4 = exp(x);
+    auto ex5 = exp(log(add(x, one)));
+    auto ex6 = log(exp(x));
+    auto ex7 = exp(sin(x));
+    auto ex8 = pow(cos(x), sin(x));
+
+    REQUIRE(series_coeff(ex1, x, 100, 98)->__eq__(*rational(-1, 98)));
+    REQUIRE(series_coeff(ex2, x, 20, 12)->__eq__(*rational(-691, 935550)));
+    REQUIRE(series_coeff(ex3, x, 100, 48)->__eq__(*rational(1, 48)));
+    REQUIRE(series_coeff(ex4, x, 20, 9)->__eq__(*rational(1, 362880)));
+    auto res1 = umap_short_basic{{0, integer(1)}, {1, integer(1)}};
+    auto res2 = umap_short_basic{{1, integer(1)}};
+    REQUIRE(expand_check_pairs(ex5, x, 20, res1));
+    REQUIRE(expand_check_pairs(ex6, x, 20, res2));
+    REQUIRE(series_coeff(ex7, x, 20, 10)->__eq__(*rational(-2951, 3628800)));
+    REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*rational(1381, 2661120)));
+}
+
+TEST_CASE("Expression series expansion: reversion ", "[Expansion of f^-1]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> two = integer(2);
+    RCP<const Integer> three = integer(3);
+    auto ex1 = sub(x, pow(x, two));
+    auto ex2 = sub(x, pow(x, three));
+    auto ex3 = sin(x);
+    auto ex4 = mul(x, exp(x));
+
+    REQUIRE(invseries_coeff(ex1, x, 20, 15)->__eq__(*integer(2674440)));
+    REQUIRE(invseries_coeff(ex2, x, 20, 15)->__eq__(*integer(7752)));
+    REQUIRE(invseries_coeff(ex3, x, 20, 15)->__eq__(*rational(143, 10240)));
+    REQUIRE(invseries_coeff(ex4, x, 20, 10)->__eq__(*rational(-156250, 567)));
+}
+
+TEST_CASE("Expression series expansion: atan, tan, asin, cot, sec, csc", "[Expansion of tan, atan, asin, cot, sec, csc]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    auto ex1 = atan(x);
+    auto ex2 = atan(div(x, sub(one, x)));
+    auto ex3 = tan(x);
+    auto ex4 = tan(div(x, sub(one, x)));
+    auto ex5 = asin(x);
+    auto ex6 = asin(div(x, sub(one, x)));
+    auto ex7 = cot(x);
+    auto ex8 = cot(sin(x));
+    auto res1 = umap_short_basic{{-1, integer(1)}, {1, rational(-1, 3)}};
+    auto res2 = umap_short_basic{{-1, integer(1)}, {7, rational(-1051, 1814400)}};
+    auto ex9 = sec(x);
+    auto ex10 = csc(x);
+
+    REQUIRE(series_coeff(ex1, x, 20, 19)->__eq__(*rational(-1, 19)));
+    REQUIRE(series_coeff(ex2, x, 40, 33)->__eq__(*rational(65536, 33)));
+    REQUIRE(series_coeff(ex3, x, 20, 13)->__eq__(*rational(21844, 6081075)));
+    REQUIRE(series_coeff(ex4, x, 20, 12)->__eq__(*rational(1303712, 14175)));
+    REQUIRE(series_coeff(ex5, x, 20, 15)->__eq__(*rational(143, 10240)));
+    REQUIRE(series_coeff(ex6, x, 20, 16)->__eq__(*rational(1259743, 2048)));
+    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex7, "x", 10), std::runtime_error);
+    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex8, "x", 10), std::runtime_error);
+    REQUIRE(series_coeff(ex9, x, 20, 8)->__eq__(*rational(277, 8064)));
+    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex10, "x", 10), std::runtime_error);
+}
+
+TEST_CASE("Expression series expansion: sinh, cosh, tanh, asinh, atanh", "[Expansion of sinh, cosh, tanh, asinh, atanh]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    auto ex1 = sinh(x);
+    auto ex2 = sinh(div(x, sub(one, x)));
+    auto ex3 = cosh(x);
+    auto ex4 = cosh(div(x, sub(one, x)));
+    auto ex5 = tanh(x);
+    auto ex6 = tanh(div(x, sub(one, x)));
+    auto ex7 = atanh(x);
+    auto ex8 = atanh(div(x, sub(one, x)));
+    auto ex9 = asinh(x);
+    auto ex10 = asinh(div(x, sub(one, x)));
+
+    REQUIRE(series_coeff(ex1, x, 10, 9)->__eq__(*rational(1, 362880)));
+    REQUIRE(series_coeff(ex2, x, 20, 10)->__eq__(*rational(325249, 40320)));
+    REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(1, 3628800)));
+    REQUIRE(series_coeff(ex4, x, 20, 11)->__eq__(*rational(3756889, 362880)));
+    REQUIRE(series_coeff(ex5, x, 20, 13)->__eq__(*rational(21844, 6081075)));
+    REQUIRE(series_coeff(ex6, x, 20, 14)->__eq__(*rational(225979, 66825)));
+    REQUIRE(series_coeff(ex7, x, 100, 99)->__eq__(*rational(1, 99)));
+    REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*integer(2048)));
+    REQUIRE(series_coeff(ex9, x, 20, 15)->__eq__(*rational(-143, 10240)));
+    REQUIRE(series_coeff(ex10, x, 20, 16)->__eq__(*rational(-3179, 2048)));
+}
+
+TEST_CASE("Expression series expansion: lambertw ", "[Expansion of lambertw]")
+{
+    RCP<const Symbol> x = symbol("x");
+    auto ex1 = lambertw(x);
+    auto ex2 = lambertw(sin(x));
+
+    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex1, "x", 10), std::runtime_error);
+    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex2, "x", 10), std::runtime_error);
+}
+
+#else
+TEST_CASE("Check error when expansion called without Flint ", "[Expansion without Piranha]")
+{
+    RCP<const Symbol> x = symbol("x");
+    auto ex1 = lambertw(x);
+    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex1, "x", 10), std::runtime_error);
+}
+#endif

--- a/symengine/type_codes.inc
+++ b/symengine/type_codes.inc
@@ -13,6 +13,9 @@ SYMENGINE_ENUM(REAL_DOUBLE, RealDouble)
 SYMENGINE_ENUM(URATPSERIESPIRANHA, URatPSeriesPiranha)
 SYMENGINE_ENUM(UPSERIESPIRANHA, UPSeriesPiranha)
 #endif
+#if defined(HAVE_SYMENGINE_FLINT) || defined(SYMENGINE_INCLUDE_ALL)
+SYMENGINE_ENUM(URATPSERIESFLINT, URatPSeriesFlint)
+#endif
 SYMENGINE_ENUM(NUMBER_WRAPPER, NumberWrapper)
 // 'NUMBER_WRAPPER' returns the number of subclasses of Number.
 // All subclasses of Number must be added before it. Do not assign

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -24,6 +24,7 @@
 #include <symengine/series_generic.h>
 #include <symengine/series.h>
 #include <symengine/series_piranha.h>
+#include <symengine/series_flint.h>
 
 namespace SymEngine {
 


### PR DESCRIPTION
Flint polys cannot do `cot()`, `csc()`, and `lambert_w()` because they cannot handle Laurent polys.