### PR TITLE
Constants in C wrappers

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -66,6 +66,46 @@ void basic_free_heap(basic_struct *s)
     delete s;
 }
 
+void basic_const_set(basic s, char* c)
+{
+    s->m = SymEngine::constant(std::string(c));
+}
+
+void basic_const_zero(basic s)
+{
+    s->m = SymEngine::zero;
+}
+
+void basic_const_one(basic s)
+{
+    s->m = SymEngine::one;
+}
+
+void basic_const_minus_one(basic s)
+{
+    s->m = SymEngine::minus_one;
+}
+
+void basic_const_I(basic s)
+{
+    s->m = SymEngine::I;
+}
+
+void basic_const_pi(basic s)
+{
+    s->m = SymEngine::pi;
+}
+
+void basic_const_E(basic s)
+{
+    s->m = SymEngine::E;
+}
+
+void basic_const_EulerGamma(basic s)
+{
+    s->m = SymEngine::EulerGamma;
+}
+
 TypeID basic_get_type(const basic s) {
     return static_cast<TypeID>(s->m->get_type_code());
 }

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -84,6 +84,19 @@ void basic_free_stack(basic s);
 basic_struct* basic_new_heap();
 void basic_free_heap(basic_struct *s);
 
+//! Use these functions to get the commonly used constants as basic.
+//! Assigns to s a SymEngine constant with name c
+void basic_const_set(basic s, char* c);
+
+void basic_const_zero(basic s);
+void basic_const_one(basic s);
+void basic_const_minus_one(basic s);
+void basic_const_I(basic s);
+
+void basic_const_pi(basic s);
+void basic_const_E(basic s);
+void basic_const_EulerGamma(basic s);
+
 //! Assign value of b to a.
 void basic_assign(basic a, const basic b);
 

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -383,6 +383,75 @@ void test_subs() {
     basic_free_stack(z);
 }
 
+void test_constants() {
+    basic z, o, mo, i;
+    basic_new_stack(z);
+    basic_new_stack(o);
+    basic_new_stack(mo);
+    basic_new_stack(i);
+
+    integer_set_si(z, 0);
+    integer_set_si(o, 1);
+    integer_set_si(mo, -1);
+    complex_set(i, z, o);
+
+    basic zero, one, minus_one, iota;
+    basic_new_stack(zero);
+    basic_new_stack(one);
+    basic_new_stack(minus_one);
+    basic_new_stack(iota);
+
+    basic_const_zero(zero);
+    basic_const_one(one);
+    basic_const_minus_one(minus_one);
+    basic_const_I(iota);
+
+    SYMENGINE_C_ASSERT(basic_eq(z, zero));
+    SYMENGINE_C_ASSERT(basic_eq(o, one));
+    SYMENGINE_C_ASSERT(basic_eq(mo, minus_one));
+    SYMENGINE_C_ASSERT(basic_eq(i, iota));
+
+    basic_free_stack(z);
+    basic_free_stack(zero);
+    basic_free_stack(o);
+    basic_free_stack(one);
+    basic_free_stack(mo);
+    basic_free_stack(minus_one);
+    basic_free_stack(i);
+    basic_free_stack(iota);
+
+    basic custom, pi, e, euler_gamma;
+    basic_new_stack(custom);
+    basic_new_stack(pi);
+    basic_new_stack(e);
+    basic_new_stack(euler_gamma);
+
+    basic_const_set(custom, "custom");
+    basic_const_pi(pi);
+    basic_const_E(e);
+    basic_const_EulerGamma(euler_gamma);
+
+    char* s;
+    s = basic_str(custom);
+    SYMENGINE_C_ASSERT(strcmp(s, "custom") == 0);
+    basic_str_free(s);
+    s = basic_str(pi);
+    SYMENGINE_C_ASSERT(strcmp(s, "pi") == 0);
+    basic_str_free(s);
+    s = basic_str(e);
+    SYMENGINE_C_ASSERT(strcmp(s, "E") == 0);
+    basic_str_free(s);
+    s = basic_str(euler_gamma);
+    SYMENGINE_C_ASSERT(strcmp(s, "EulerGamma") == 0);
+    basic_str_free(s);
+
+    basic_free_stack(custom);
+    basic_free_stack(pi);
+    basic_free_stack(e);
+    basic_free_stack(euler_gamma);
+
+}
+
 int main(int argc, char* argv[])
 {
     test_cwrapper();
@@ -399,5 +468,6 @@ int main(int argc, char* argv[])
     test_hash();
     test_subs();
     test_subs2();
+    test_constants();
     return 0;
 }


### PR DESCRIPTION
I have experimented on how the interface for the SymEngine's constants from C should be.

The logic was the `basic_struct*` that we obtain from these functions should not be available for referencing to any other `basic_struct`, i.e. it should be `const`. Some changes needed to be made to support that.

@certik @isuruf Please have a look.