### PR TITLE
Fix OS X warning

### DIFF
--- a/symengine/tests/basic/test_parser.cpp
+++ b/symengine/tests/basic/test_parser.cpp
@@ -40,6 +40,7 @@ using SymEngine::parse;
 using SymEngine::max;
 using SymEngine::min;
 using SymEngine::loggamma;
+using SymEngine::gamma;
 
 TEST_CASE("Parsing: integers, basic operations", "[parser]")
 {


### PR DESCRIPTION
Since gamma is not imported from SymEngine, compiler thinks it is a deprecated
function in OS X math library, but ADL finds the correct SymEngine function