### PR TITLE
Working whitespace check

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -106,10 +106,4 @@ export LD_LIBRARY_PATH=$our_install_dir/lib:$LD_LIBRARY_PATH
 echo "Checking whether all header files are installed:"
 python $SOURCE_DIR/symengine/utilities/tests/test_make_install.py $our_install_dir/include/symengine/ $SOURCE_DIR/symengine
 
-# check trailing whitespace:
-if !  egrep " $" -nr --include=\*.{cpp,h,inc}  --exclude-dir=*{teuchos,/build/}* $SOURCE_DIR ; then
-    echo No trailing whitespace;
-else
-    exit -1;
-fi
-# TODO: Add similar grep checks for space after comma,, space after `if`, space between `)` and `{` also
+git diff HEAD@{50} --check #test for whitespaces

--- a/symengine/mp_wrapper.h
+++ b/symengine/mp_wrapper.h
@@ -10,7 +10,7 @@
 #endif
 
 #define SYMENGINE_UI(f) f ## _ui
-#define SYMENGINE_SI(f) f ## _si 
+#define SYMENGINE_SI(f) f ## _si
 
 #define SYMENGINE_MPZ_WRAPPER_IMPLEMENT_RELATIONAL(op, func, val, rev_op) \
 template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value,int>::type = 0> \
@@ -529,7 +529,7 @@ public:
 
     template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value,int>::type = 0>
     inline friend mpz_wrapper operator-(const T b, const mpz_wrapper &a)
-    { 
+    {
         mpz_wrapper res;
         mpz_ui_sub(res.get_mpz_t(), b, a.get_mpz_t());
         return res;
@@ -545,7 +545,7 @@ public:
         mpz_neg(res.get_mpz_t(), mp);
         return res;
     }
-    
+
     inline mpz_wrapper operator++()
     {
         mpz_add_ui(mp, mp, 1);
@@ -568,7 +568,7 @@ public:
         --(*this);
         return orig;
     }
-    
+
     //! < operator
     SYMENGINE_MPZ_WRAPPER_IMPLEMENT_RELATIONAL(<, mpz_cmp, 0, >)
     //! <= operator


### PR DESCRIPTION
I googled a lot about this issue.
As a good practice it is advised to use [Git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
The default `pre-commit` hook is sufficient for whitespace check.
We can write a bash or python script to activate `pre-commit` hook (It just needs `mv .git/hooks/pre-commit.sample .git/hooks/pre-commit`). *Need suggestions on that!*

And adding this: `git diff HEAD^1 --check` in travis will serve our purpose. As it will exit the travis build if it finds trailing whitespace in recently modified code.

[Instance](https://travis-ci.org/nishnik/symengine/builds/112823175) where travis build fails due to trailing whitespace.
[Instance](https://travis-ci.org/nishnik/symengine/builds/112830342) when it runs fine when there aren't any whitespace. One job fails because piranha has been updated. Unrelated to this PR.