### PR TITLE
Adding C wrappers

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -15,6 +15,7 @@
 #include <symengine/visitor.h>
 #include <symengine/printer.h>
 
+
 using SymEngine::Basic;
 using SymEngine::RCP;
 using SymEngine::zero;
@@ -260,6 +261,21 @@ void basic_expand(basic s, const basic a)
 {
     s->m = SymEngine::expand(a->m);
 }
+
+void basic_cot(basic s, const basic a)
+ {
+     s->m = SymEngine::cot(a->m);
+ }
+
+ void basic_csc(basic s, const basic a)
+ {
+     s->m = SymEngine::csc(a->m);
+ }
+ 
+void basic_sec(basic s, const basic a)
+ {
+     s->m = SymEngine::sec(a->m);
+ }
 
 char* basic_str(const basic s)
 {

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -163,6 +163,12 @@ int basic_neq(const basic a, const basic b);
 void basic_abs(basic s, const basic a);
 //! Expands the expr a and assigns to s.
 void basic_expand(basic s, const basic a);
+//! Assigns s = cot(a).
+void basic_cot(basic s, const basic a);
+//! Assigns s = sec(a).
+void basic_sec(basic s, const basic a);
+//! Assigns s = cosec(a).
+void basic_csc(basic s, const basic a);
 
 //! Returns a new char pointer to the string representation of s.
 char* basic_str(const basic s);


### PR DESCRIPTION
I'm adding c wrappers for sec(),cot() and cosec(). 
I will be adding tests for the same  into   `symengine/tests/cwrapper/test_cwrapper.c`  soon.