### PR TITLE
fixed small bug in lambertw

### DIFF
--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1444,7 +1444,7 @@ RCP<const Basic> lambertw(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *zero)) return zero;
     if (eq(*arg, *E)) return one;
-    if (eq(*arg, *div(one, E))) return minus_one;
+    if (eq(*arg, *div(neg(one), E))) return minus_one;
     if (eq(*arg, *div(log(i2), im2))) return mul(minus_one, log(i2));
     return make_rcp<const LambertW>(arg);
 }

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -1733,7 +1733,7 @@ TEST_CASE("Lambertw: functions", "[functions]")
     r2 = zero;
     REQUIRE(eq(*r1, *r2));
 
-    r1 = lambertw(exp(im1));
+    r1 = lambertw(neg(exp(im1)));
     r2 = im1;
     REQUIRE(eq(*r1, *r2));
 


### PR DESCRIPTION
LambertW(-e^(-1)) is -1. Was previously incorrect.
Fixes #853 