### PR TITLE
Univariate Poly structure redo

### DIFF
--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -5,7 +5,9 @@
 #include <symengine/pow.h>
 #include <symengine/complex.h>
 #include <symengine/functions.h>
+#include <symengine/polynomial.h>
 
+using SymEngine::is_a;
 
 namespace SymEngine {
 
@@ -247,13 +249,14 @@ RCP<const Basic> add(const RCP<const Basic> &a, const RCP<const Basic> &b)
     SymEngine::umap_basic_num d;
     RCP<const Number> coef;
     RCP<const Basic> t;
-    if (SymEngine::is_a<Add>(*a) and SymEngine::is_a<Add>(*b)) {
+
+    if (is_a<Add>(*a) and is_a<Add>(*b)) {
         coef = (rcp_static_cast<const Add>(a))->coef_;
         d = (rcp_static_cast<const Add>(a))->dict_;
         for (const auto &p: (rcp_static_cast<const Add>(b))->dict_)
             Add::dict_add_term(d, p.second, p.first);
         iaddnum(outArg(coef), rcp_static_cast<const Add>(b)->coef_);
-    } else if (SymEngine::is_a<Add>(*a)) {
+    } else if (is_a<Add>(*a)) {
         coef = (rcp_static_cast<const Add>(a))->coef_;
         d = (rcp_static_cast<const Add>(a))->dict_;
         if (is_a_Number(*b)) {
@@ -263,7 +266,7 @@ RCP<const Basic> add(const RCP<const Basic> &a, const RCP<const Basic> &b)
             Add::as_coef_term(b, outArg(coef2), outArg(t));
             Add::dict_add_term(d, coef2, t);
         }
-    } else if (SymEngine::is_a<Add>(*b)) {
+    } else if (is_a<Add>(*b)) {
         coef = (rcp_static_cast<const Add>(b))->coef_;
         d = (rcp_static_cast<const Add>(b))->dict_;
         if (is_a_Number(*a)) {
@@ -273,6 +276,8 @@ RCP<const Basic> add(const RCP<const Basic> &a, const RCP<const Basic> &b)
             Add::as_coef_term(a, outArg(coef2), outArg(t));
             Add::dict_add_term(d, coef2, t);
         }
+    } else if (is_a<UnivariateIntPolynomial>(*a) and is_a<UnivariateIntPolynomial>(*b)) {
+        return add_poly(rcp_static_cast<const UnivariateIntPolynomial>(a), rcp_static_cast<const UnivariateIntPolynomial>(b));
     } else {
         Add::as_coef_term(a, outArg(coef), outArg(t));
         Add::dict_add_term(d, coef, t);
@@ -291,7 +296,10 @@ RCP<const Basic> add(const RCP<const Basic> &a, const RCP<const Basic> &b)
 }
 
 RCP<const Basic> sub(const RCP<const Basic> &a, const RCP<const Basic> &b)
-{
+{   
+    if (is_a<UnivariateIntPolynomial>(*a) and is_a<UnivariateIntPolynomial>(*b))
+        return sub_poly(rcp_static_cast<const UnivariateIntPolynomial>(a), rcp_static_cast<const UnivariateIntPolynomial>(b));
+
     return add(a, mul(minus_one, b));
 }
 

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -208,34 +208,34 @@ bool UnivariateIntPolynomial::is_pow() const {
     return false;
 }
 
-RCP<const UnivariateIntPolynomial> add_poly(const UnivariateIntPolynomial &a, const UnivariateIntPolynomial &b) {
+RCP<const UnivariateIntPolynomial> add_poly(const RCP<const UnivariateIntPolynomial> &a, const RCP<const UnivariateIntPolynomial> &b) {
     map_uint_mpz dict;
-    for (const auto &it : a.dict_)
+    for (const auto &it : a->dict_)
         dict[it.first] = it.second;
-    for (const auto &it : b.dict_)
+    for (const auto &it : b->dict_)
         dict[it.first] += it.second;
 
-    RCP<const UnivariateIntPolynomial> c = UnivariateIntPolynomial::from_dict(a.var_, std::move(dict));
+    RCP<const UnivariateIntPolynomial> c = UnivariateIntPolynomial::from_dict(a->var_, std::move(dict));
     return c;
 }
 
-RCP<const UnivariateIntPolynomial> neg_poly(const UnivariateIntPolynomial &a) {
+RCP<const UnivariateIntPolynomial> neg_poly(const RCP<const UnivariateIntPolynomial> &a) {
     map_uint_mpz dict;
-    for (const auto &it : a.dict_)
+    for (const auto &it : a->dict_)
         dict[it.first] = -1 * it.second;
 
-    RCP<const UnivariateIntPolynomial> c = UnivariateIntPolynomial::from_dict(a.var_, std::move(dict));
+    RCP<const UnivariateIntPolynomial> c = UnivariateIntPolynomial::from_dict(a->var_, std::move(dict));
     return c;
 }
 
-RCP<const UnivariateIntPolynomial> sub_poly(const UnivariateIntPolynomial &a, const UnivariateIntPolynomial &b) {
+RCP<const UnivariateIntPolynomial> sub_poly(const RCP<const UnivariateIntPolynomial> &a, const RCP<const UnivariateIntPolynomial> &b) {
     map_uint_mpz dict;
-    for (const auto &it : a.dict_)
+    for (const auto &it : a->dict_)
         dict[it.first] = it.second;
-    for (const auto &it : b.dict_)
+    for (const auto &it : b->dict_)
         dict[it.first] -= it.second;
 
-    RCP<const UnivariateIntPolynomial> c = UnivariateIntPolynomial::from_dict(a.var_, std::move(dict));
+    RCP<const UnivariateIntPolynomial> c = UnivariateIntPolynomial::from_dict(a->var_, std::move(dict));
     return c;
 }
 
@@ -258,11 +258,11 @@ RCP<const UnivariateIntPolynomial> mul_poly(RCP<const UnivariateIntPolynomial> a
 
     int sign = 1;
     if ((--(a->dict_.end()))->second < 0) {
-        a = neg_poly(*a);
+        a = neg_poly(a);
         sign = -1 * sign;
     }
     if ((--(b->dict_.end()))->second < 0) {
-        b = neg_poly(*b);
+        b = neg_poly(b);
         sign = -1 * sign;
     }
 
@@ -296,7 +296,7 @@ RCP<const UnivariateIntPolynomial> mul_poly(RCP<const UnivariateIntPolynomial> a
     }
 
     if (sign == -1)
-        return neg_poly(*UnivariateIntPolynomial::from_vec(a->var_, v));
+        return neg_poly(UnivariateIntPolynomial::from_vec(a->var_, v));
     else
         return UnivariateIntPolynomial::from_vec(a->var_, v);
 }

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -250,23 +250,23 @@ unsigned int bit_length(T t){
     return count;
 }
 
-RCP<const UnivariateIntPolynomial> mul_poly(RCP<const UnivariateIntPolynomial> a, RCP<const UnivariateIntPolynomial> b) {
-    //TODO: Use `const RCP<const UnivariateIntPolynomial> &a` for input arguments,
-    //      even better is use `const UnivariateIntPolynomial &a`
+RCP<const UnivariateIntPolynomial> mul_poly(const RCP<const UnivariateIntPolynomial> &a, const RCP<const UnivariateIntPolynomial> &b) {
+
     unsigned int da = a->degree_;
     unsigned int db = b->degree_;
+    RCP<const UnivariateIntPolynomial> a_n = a, b_n = b;
 
     int sign = 1;
     if ((--(a->dict_.end()))->second < 0) {
-        a = neg_poly(a);
+        a_n = neg_poly(a);
         sign = -1 * sign;
     }
     if ((--(b->dict_.end()))->second < 0) {
-        b = neg_poly(b);
+        b_n = neg_poly(b);
         sign = -1 * sign;
     }
 
-    integer_class p = std::max(a->max_coef(), b->max_coef());
+    integer_class p = std::max(a_n->max_coef(), b_n->max_coef());
 
     unsigned int N = bit_length(std::min(da + 1, db + 1)) + bit_length(p) + 1;
 
@@ -274,8 +274,8 @@ RCP<const UnivariateIntPolynomial> mul_poly(RCP<const UnivariateIntPolynomial> a
     a1 <<= N;
     integer_class a2 = a1 / 2;
     integer_class mask = a1 - 1;
-    integer_class sa = a->eval_bit(N);
-    integer_class sb = b->eval_bit(N);
+    integer_class sa = a_n->eval_bit(N);
+    integer_class sb = b_n->eval_bit(N);
     integer_class r = sa*sb;
 
     std::vector<integer_class> v;
@@ -296,9 +296,9 @@ RCP<const UnivariateIntPolynomial> mul_poly(RCP<const UnivariateIntPolynomial> a
     }
 
     if (sign == -1)
-        return neg_poly(UnivariateIntPolynomial::from_vec(a->var_, v));
+        return neg_poly(UnivariateIntPolynomial::from_vec(a_n->var_, v));
     else
-        return UnivariateIntPolynomial::from_vec(a->var_, v);
+        return UnivariateIntPolynomial::from_vec(a_n->var_, v);
 }
 
 } // SymEngine

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -87,11 +87,11 @@ public:
 }; //UnivariateIntPolynomial
 
 //! Adding two UnivariateIntPolynomial a and b
-RCP<const UnivariateIntPolynomial> add_poly(const UnivariateIntPolynomial &a, const UnivariateIntPolynomial &b);
+RCP<const UnivariateIntPolynomial> add_poly(const RCP<const UnivariateIntPolynomial> &a, const RCP<const UnivariateIntPolynomial> &b);
 //! Negative of a UnivariateIntPolynomial
-RCP<const UnivariateIntPolynomial> neg_poly(const UnivariateIntPolynomial &a);
+RCP<const UnivariateIntPolynomial> neg_poly(const RCP<const UnivariateIntPolynomial> &a);
 //! Subtracting two UnivariateIntPolynomial a and b
-RCP<const UnivariateIntPolynomial> sub_poly(const UnivariateIntPolynomial &a, const UnivariateIntPolynomial &b);
+RCP<const UnivariateIntPolynomial> sub_poly(const RCP<const UnivariateIntPolynomial> &a, const RCP<const UnivariateIntPolynomial> &b);
 //! Multiplying two UnivariateIntPolynomial a and b
 RCP<const UnivariateIntPolynomial> mul_poly(RCP<const UnivariateIntPolynomial> a, RCP<const UnivariateIntPolynomial> b);
 

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -93,7 +93,7 @@ RCP<const UnivariateIntPolynomial> neg_poly(const RCP<const UnivariateIntPolynom
 //! Subtracting two UnivariateIntPolynomial a and b
 RCP<const UnivariateIntPolynomial> sub_poly(const RCP<const UnivariateIntPolynomial> &a, const RCP<const UnivariateIntPolynomial> &b);
 //! Multiplying two UnivariateIntPolynomial a and b
-RCP<const UnivariateIntPolynomial> mul_poly(RCP<const UnivariateIntPolynomial> a, RCP<const UnivariateIntPolynomial> b);
+RCP<const UnivariateIntPolynomial> mul_poly(const RCP<const UnivariateIntPolynomial> &a, const RCP<const UnivariateIntPolynomial> &b);
 
 inline RCP<const UnivariateIntPolynomial> univariate_int_polynomial(RCP<const Symbol> i, map_uint_mpz&& dict)
 {

--- a/symengine/series_generic.cpp
+++ b/symengine/series_generic.cpp
@@ -130,7 +130,7 @@ RCP<const UnivariateSeries> add_uni_series (const UnivariateSeries& a, const Uni
 
 RCP<const UnivariateSeries> neg_uni_series (const UnivariateSeries& a)
 {
-    return make_rcp<const UnivariateSeries>(a.var_, a.prec_, std::move(neg_poly(*a.poly_)));
+    return make_rcp<const UnivariateSeries>(a.var_, a.prec_, std::move(neg_poly(a.poly_)));
 }
 
 RCP<const UnivariateSeries> sub_uni_series (const UnivariateSeries& a, const UnivariateSeries& b)

--- a/symengine/tests/basic/test_polynomial.cpp
+++ b/symengine/tests/basic/test_polynomial.cpp
@@ -6,6 +6,7 @@
 #include <symengine/mul.h>
 #include <symengine/pow.h>
 #include <symengine/dict.h>
+#include <symengine/add.h>
 
 using SymEngine::UnivariateIntPolynomial;
 using SymEngine::univariate_int_polynomial;
@@ -22,6 +23,7 @@ using SymEngine::zero;
 using SymEngine::integer;
 using SymEngine::vec_basic_eq_perm;
 using SymEngine::integer_class;
+using SymEngine::add;
 
 using namespace SymEngine::literals;
 
@@ -38,37 +40,29 @@ TEST_CASE("Constructor of UnivariateIntPolynomial", "[UnivariateIntPolynomial]")
 TEST_CASE("Adding two UnivariateIntPolynomial", "[UnivariateIntPolynomial]")
 {
     RCP<const Symbol> x  = symbol("x");
-    map_uint_mpz adict_ = {{0, 1_z}, {1, 2_z}, {2, 1_z}};
-    map_uint_mpz bdict_ = {{0, 2_z}, {1, 3_z}, {2, 4_z}};
-    const UnivariateIntPolynomial a(x, 2, std::move(adict_));
-    const UnivariateIntPolynomial b(x, 2, std::move(bdict_));
-
+    RCP<const UnivariateIntPolynomial> a = univariate_int_polynomial(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UnivariateIntPolynomial> b = univariate_int_polynomial(x, {{0, 2_z}, {1, 3_z}, {2, 4_z}});
     RCP<const Basic> c = add_poly(a, b);
-    //std::cout<<c->__str__();
+
     REQUIRE(c->__str__() == "5*x**2 + 5*x + 3");
 }
 
 TEST_CASE("Negative of a UnivariateIntPolynomial", "[UnivariateIntPolynomial]")
 {
     RCP<const Symbol> x  = symbol("x");
-    map_uint_mpz adict_ = {{0, 1_z}, {1, 2_z}, {2, 1_z}};
-    const UnivariateIntPolynomial a(x, 2, std::move(adict_));
+    RCP<const UnivariateIntPolynomial> a = univariate_int_polynomial(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     RCP<const UnivariateIntPolynomial> b = neg_poly(a);
-    //std::cout<<b->__str__()<<std::endl;
     REQUIRE(b->__str__() == "-x**2 - 2*x - 1");
 }
 
 TEST_CASE("Subtracting two UnivariateIntPolynomial", "[UnivariateIntPolynomial]")
 {
     RCP<const Symbol> x  = symbol("x");
-    map_uint_mpz adict_ = {{0, 1_z}, {1, 2_z}, {2, 1_z}};
-    map_uint_mpz bdict_ = {{0, 2_z}, {1, 3_z}, {2, 4_z}};
-    const UnivariateIntPolynomial a(x, 2, std::move(adict_));
-    const UnivariateIntPolynomial b(x, 2, std::move(bdict_));
+    RCP<const UnivariateIntPolynomial> a = univariate_int_polynomial(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UnivariateIntPolynomial> b = univariate_int_polynomial(x, {{0, 2_z}, {1, 3_z}, {2, 4_z}});
 
     RCP<const Basic> c = sub_poly(b, a);
-    //std::cout<<c->__str__();
     REQUIRE(c->__str__() == "3*x**2 + x + 1");
 }
 

--- a/symengine/tests/basic/test_polynomial.cpp
+++ b/symengine/tests/basic/test_polynomial.cpp
@@ -42,8 +42,14 @@ TEST_CASE("Adding two UnivariateIntPolynomial", "[UnivariateIntPolynomial]")
     RCP<const Symbol> x  = symbol("x");
     RCP<const UnivariateIntPolynomial> a = univariate_int_polynomial(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
     RCP<const UnivariateIntPolynomial> b = univariate_int_polynomial(x, {{0, 2_z}, {1, 3_z}, {2, 4_z}});
-    RCP<const Basic> c = add_poly(a, b);
+    RCP<const Basic> c;
 
+    // using add() returns RCP<const Basic> (must be casted if to be used further as a poly)
+    c = add(a, b);
+    REQUIRE(c->__str__() == "5*x**2 + 5*x + 3");
+
+    // using add_poly() returns RCP<const UnivariateIntPoly>
+    c = add_poly(a, b);
     REQUIRE(c->__str__() == "5*x**2 + 5*x + 3");
 }
 
@@ -62,7 +68,14 @@ TEST_CASE("Subtracting two UnivariateIntPolynomial", "[UnivariateIntPolynomial]"
     RCP<const UnivariateIntPolynomial> a = univariate_int_polynomial(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
     RCP<const UnivariateIntPolynomial> b = univariate_int_polynomial(x, {{0, 2_z}, {1, 3_z}, {2, 4_z}});
 
-    RCP<const Basic> c = sub_poly(b, a);
+    RCP<const Basic> c;
+
+    // using sub() returns RCP<const Basic> (must be casted if to be used further as a poly)
+    c = sub(b, a);
+    REQUIRE(c->__str__() == "3*x**2 + x + 1");
+
+    // using sub_poly() returns RCP<const UnivariateIntPoly>
+    c = sub_poly(b, a);
     REQUIRE(c->__str__() == "3*x**2 + x + 1");
 }
 
@@ -73,9 +86,7 @@ TEST_CASE("Multiplication of two UnivariateIntPolynomial", "[UnivariateIntPolyno
     RCP<const UnivariateIntPolynomial> b = univariate_int_polynomial(x, {{0, -1_z}, {1, -2_z}, {2, -1_z}});
 
     RCP<const UnivariateIntPolynomial> c = mul_poly(a, a);
-    //std::cout<<c->__str__();
     RCP<const UnivariateIntPolynomial> d = mul_poly(a, b);
-    //std::cout<<c->__str__();
 
     REQUIRE(c->__str__() == "x**4 + 4*x**3 + 6*x**2 + 4*x + 1");
     REQUIRE(d->__str__() == "-x**4 - 4*x**3 - 6*x**2 - 4*x - 1");
@@ -106,9 +117,7 @@ TEST_CASE("Derivative of UnivariateIntPolynomial", "[UnivariateIntPolynomial]")
     RCP<const UnivariateIntPolynomial> a = univariate_int_polynomial(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE(a->diff(x)->__str__() == "2*x + 2");
-	//std::cout<<a->diff(x)->__str__()<<std::endl;
     REQUIRE(a->diff(y)->__str__() == "0");
-	//std::cout<<a->diff(y)->__str__()<<std::endl;
 }
 
 TEST_CASE("Bool checks specific UnivariateIntPolynomial cases", "[UnivariateIntPolynomial]")
@@ -152,7 +161,5 @@ TEST_CASE("Univariate Polynomial expand", "[UnivariateIntPolynomial][expand]")
     RCP<const Basic> c = expand(b);
 
     REQUIRE(b->__str__() == "(x**3 + x**2 + x)**3");
-    //std::cout<<b->__str__()<<std::endl;
     REQUIRE(c->__str__() == "x**9 + 3*x**8 + 6*x**7 + 7*x**6 + 6*x**5 + 3*x**4 + x**3");
-    //std::cout<<c->__str__()<<std::endl;
 }


### PR DESCRIPTION
Currently, the `UnivariateIntPoly` strcuture and functions did not match the type of functions as used in rest of SymEngine. Fixed that.
Mainly
`func(classT &a, classT &b)` to
`func(RCP<classT> &a, RCP<classT> &b)`

Also, had a question about including `add_poly` as a part of `add`. I have done so in my PR, but calling add on two polys will return a `RCP<Basic>` and this will have to be casted to `RCP<UniPoly>`, if further poly functions are to use it. I was wondering if we could overload `add()` so as to return `RCP<UniPoly>` directly? 

@Sumith1896 @isuruf 

Edit : major changes to ensue