### PR TITLE
revert commit 1617f970; Add::as_two_terms() needed by symengine.py

### DIFF
--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -295,6 +295,16 @@ RCP<const Basic> sub(const RCP<const Basic> &a, const RCP<const Basic> &b)
     return add(a, mul(minus_one, b));
 }
 
+void Add::as_two_terms(const Ptr<RCP<const Basic>> &a,
+            const Ptr<RCP<const Basic>> &b) const
+{
+    auto p = dict_.begin();
+    *a = mul(p->first, p->second);
+    umap_basic_num d = dict_;
+    d.erase(p->first);
+    *b = Add::from_dict(coef_, std::move(d));
+}
+
 RCP<const Basic> Add::subs(const map_basic_basic &subs_dict) const
 {
     RCP<const Add> self = rcp_from_this_cast<const Add>();

--- a/symengine/add.h
+++ b/symengine/add.h
@@ -50,6 +50,9 @@ public:
     */
     static void coef_dict_add_term(const Ptr<RCP<const Number>> &coef, umap_basic_num &d,
             const RCP<const Number> &c, const RCP<const Basic> &term);
+    //! Converts the add dict into two appropriate instances
+    void as_two_terms(const Ptr<RCP<const Basic>> &a,
+            const Ptr<RCP<const Basic>> &b) const;
     //! Converts into the form of coefficient and term
     static void as_coef_term(const RCP<const Basic> &self,
         const Ptr<RCP<const Number>> &coef, const Ptr<RCP<const Basic>> &term);

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -119,6 +119,12 @@ TEST_CASE("Add: basic", "[basic]")
     REQUIRE(vec_basic_eq_perm(r->get_args(), {mul(integer(2), x), y}));
     REQUIRE(not vec_basic_eq_perm(r->get_args(), {mul(integer(3), x), y}));
 
+    RCP<const Basic> term1, term2;
+    RCP<const Add> a1 = rcp_static_cast<const Add>(add(r, r));
+    a1->as_two_terms(outArg(term1), outArg(term2));
+    RCP<const Add> a2 = rcp_static_cast<const Add>(add(term1, term2));
+    REQUIRE(eq(*a1, *a2));
+
     r = add(mul(integer(5), x), integer(5));
     REQUIRE(vec_basic_eq_perm(r->get_args(), {mul(integer(5), x), integer(5)}));
 


### PR DESCRIPTION
I propose to fix compile problems in symengine.py by putting back the removed function