### PR TITLE
Prevent clang-format from sorting includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,6 +46,7 @@ PenaltyBreakString: 2123
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
+SortIncludes: false
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements


### PR DESCRIPTION
Required for clang-format 3.8 or higher/
Changing the order of includes causes errors in some cases. 
Addresses #905 

@isuruf @certik 
