### PR TITLE
Improve clang-format

### DIFF
--- a/bin/test_format_local.sh
+++ b/bin/test_format_local.sh
@@ -1,22 +1,36 @@
+#!/bin/bash
+
+NAME=`basename "$0"`
+
 if [ ! -f ".clang-format" ]; then
     echo ".clang-format file not found!"
     exit 1
 fi
 
-if [ "$(uname)" == "Darwin" ]; then
-    # Do something under Mac OS X platform
-    CLANG="clang-format"
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    # Do something under GNU/Linux platform
-    CLANG="clang-format-3.7"
-elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
-    # Do something under Windows NT platform
-    CLANG="clang-format.exe"
-fi
+CLANG_FORMAT="clang-format"
+
+which "clang-format-3.7" > /dev/null && CLANG_FORMAT="clang-format-3.7"
 
 FILES=`git ls-files | grep -E "\.(cpp|h|hpp)$" | grep -Ev "symengine/utilities" | grep -Ev "cmake/"`
 
 for FILE in $FILES; do
-    echo Formatting $FILE
-    $CLANG -i $FILE
+    if [ "$NAME" != "pre-commit" ]; then
+        # if this is not a pre-commit hook format code inplace
+        $CLANG_FORMAT -i $FILE
+    else
+        staged_file=`git show :$FILE`
+        formatted_file=`cat << EOF | $CLANG_FORMAT
+$staged_file
+EOF`
+        if [ "$staged_file" != "$formatted_file" ]; then
+            actual_file=`cat $FILE`
+            if [ "$actual_file" != "$staged_file" ]; then
+                echo "WARNING: $FILE is not formatted properly. Cannot fix formatting as there are unstaged changes"
+            else
+                echo "Fixing formatting of $FILE automatically"
+                $CLANG_FORMAT -i $FILE
+                git add $FILE
+            fi
+        fi
+    fi
 done

--- a/bin/travis_clang.sh
+++ b/bin/travis_clang.sh
@@ -6,7 +6,7 @@ echo "TEST_CLANG_FORMAT=${TEST_CLANG_FORMAT}"
 if [[ "${TEST_CLANG_FORMAT}" == "yes" ]]; then
 
     RETURN=0
-    CLANG="clang-format-3.7"
+    CLANG_FORMAT="clang-format-3.7"
 
     if [ ! -f ".clang-format" ]; then
         echo ".clang-format file not found!"
@@ -18,15 +18,22 @@ if [[ "${TEST_CLANG_FORMAT}" == "yes" ]]; then
     for FILE in $FILES; do
         echo "Processing: $FILE"
 
-        $CLANG $FILE | cmp  $FILE >/dev/null
+        $CLANG_FORMAT $FILE | cmp  $FILE >/dev/null
 
         if [ $? -ne 0 ]; then
             echo "[!] INCORRECT FORMATTING! $FILE" >&2
+            $CLANG_FORMAT -i $FILE
             RETURN=1
         fi
 
     done
 
+    if [ $RETURN -ne 0 ]; then
+        echo "Apply the following diff for correct formatting"
+        echo "###########################################################################"
+        git diff | cat
+        echo "###########################################################################"
+    fi
     exit $RETURN
 fi
 


### PR DESCRIPTION
Now travis-ci prints the diff of the correct format
bin/test_format_local.sh can be used as a pre-commit git hook