### PR TITLE
Refactor subs into a visitor and add msubs

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -74,7 +74,7 @@ set(HEADERS
     visitor.h    eval_double.h    diophantine.h cwrapper.h  printer.h  real_double.h
     eval_mpfr.h  eval_arb.h       eval_mpc.h     complex_double.h         series_visitor.h
     real_mpfr.h  complex_mpc.h    type_codes.inc lambda_double.h series.h series_piranha.h
-    basic-methods.inc   series_flint.h  series_generic.h sets.h  derivative.h
+    basic-methods.inc   series_flint.h  series_generic.h sets.h  derivative.h   subs.h
 )
 
 # Configure SymEngine using our CMake options:

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -324,43 +324,6 @@ void Add::as_two_terms(const Ptr<RCP<const Basic>> &a,
     *b = Add::from_dict(coef_, std::move(d));
 }
 
-RCP<const Basic> Add::subs(const map_basic_basic &subs_dict) const
-{
-    RCP<const Add> self = rcp_from_this_cast<const Add>();
-    auto it = subs_dict.find(self);
-    if (it != subs_dict.end())
-        return it->second;
-
-    SymEngine::umap_basic_num d;
-    RCP<const Number> coef;
-
-    it = subs_dict.find(coef_);
-    if (it != subs_dict.end()) {
-        coef = zero;
-        coef_dict_add_term(outArg(coef), d, one, it->second);
-    } else {
-        coef = coef_;
-    }
-
-    for (const auto &p : dict_) {
-        auto it = subs_dict.find(Add::from_dict(zero, {{p.first, p.second}}));
-        if (it != subs_dict.end()) {
-            coef_dict_add_term(outArg(coef), d, one, it->second);
-        } else {
-            it = subs_dict.find(p.second);
-            if (it != subs_dict.end()) {
-                coef_dict_add_term(outArg(coef), d, one,
-                                   mul(it->second, p.first->subs(subs_dict)));
-            } else {
-                coef_dict_add_term(outArg(coef), d, p.second,
-                                   p.first->subs(subs_dict));
-            }
-        }
-    }
-
-    return Add::from_dict(coef, std::move(d));
-}
-
 vec_basic Add::get_args() const
 {
     vec_basic args;

--- a/symengine/add.h
+++ b/symengine/add.h
@@ -67,8 +67,6 @@ public:
     //! \return `true` if it is in canonical form
     bool is_canonical(const RCP<const Number> &coef,
                       const umap_basic_num &dict) const;
-    //! Substitutes the dict
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     virtual vec_basic get_args() const;
 };

--- a/symengine/basic-inl.h
+++ b/symengine/basic-inl.h
@@ -41,6 +41,11 @@ inline bool is_a_sub(const Basic &b)
     return dynamic_cast<const T *>(&b) != nullptr;
 }
 
+inline bool is_same_type(const Basic &a, const Basic &b)
+{
+    return a.get_type_code() == b.get_type_code();
+}
+
 //! `<<` Operator
 inline std::ostream &operator<<(std::ostream &out, const SymEngine::Basic &p)
 {

--- a/symengine/basic.cpp
+++ b/symengine/basic.cpp
@@ -10,6 +10,7 @@
 #include <symengine/functions.h>
 #include <symengine/polynomial.h>
 #include <symengine/printer.h>
+#include <symengine/subs.h>
 
 namespace SymEngine
 {
@@ -37,12 +38,8 @@ std::string Basic::__str__() const
 
 RCP<const Basic> Basic::subs(const map_basic_basic &subs_dict) const
 {
-    RCP<const Basic> self = rcp_from_this();
-    auto it = subs_dict.find(self);
-    if (it == subs_dict.end())
-        return self;
-    else
-        return it->second;
+    SubsVisitor s(subs_dict);
+    return s.apply(*this);
 }
 
 RCP<const Basic> Basic::diff(const RCP<const Symbol> &x) const

--- a/symengine/basic.cpp
+++ b/symengine/basic.cpp
@@ -38,8 +38,7 @@ std::string Basic::__str__() const
 
 RCP<const Basic> Basic::subs(const map_basic_basic &subs_dict) const
 {
-    SubsVisitor s(subs_dict);
-    return s.apply(*this);
+    return SymEngine::subs(this->rcp_from_this(), subs_dict);
 }
 
 RCP<const Basic> Basic::diff(const RCP<const Symbol> &x) const

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -234,6 +234,9 @@ bool is_a(const Basic &b);
 template <class T>
 bool is_a_sub(const Basic &b);
 
+//! Returns true if `a` and `b` are exactly the same type `T`.
+bool is_same_type(const Basic &a, const Basic &b);
+
 //! Expands `self`
 RCP<const Basic> expand(const RCP<const Basic> &self);
 void as_numer_denom(const RCP<const Basic> &x,

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -155,7 +155,7 @@ public:
     std::string __str__() const;
 
     //! Substitutes 'subs_dict' into 'self'.
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     //! expands the special function in terms of exp function
     virtual RCP<const Basic> expand_as_exp() const

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -257,30 +257,6 @@ bool inverse_lookup(umap_basic_basic &d, const RCP<const Basic> &t,
     }
 }
 
-std::size_t TrigFunction::__hash__() const
-{
-    std::size_t seed = this->get_type_code();
-    hash_combine<Basic>(seed, *arg_);
-    return seed;
-}
-
-RCP<const Basic> TrigFunction::create(const RCP<const Basic> &arg) const
-{
-    throw std::runtime_error("Should be implemented by the inherited class");
-}
-
-RCP<const Basic> TrigFunction::subs(const map_basic_basic &subs_dict) const
-{
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> arg = arg_->subs(subs_dict);
-    if (arg == arg_)
-        return rcp_from_this();
-    else
-        return this->create(arg);
-}
-
 Sin::Sin(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
     SYMENGINE_ASSERT(is_canonical(arg))
@@ -302,21 +278,6 @@ bool Sin::is_canonical(const RCP<const Basic> &arg) const
         return false;
     }
     return true;
-}
-
-bool Sin::__eq__(const Basic &o) const
-{
-    if (is_a<Sin>(o)
-        and eq(*get_arg(), *(static_cast<const Sin &>(o).get_arg())))
-        return true;
-    return false;
-}
-
-int Sin::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Sin>(o))
-    const Sin &s = static_cast<const Sin &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> sin(const RCP<const Basic> &arg)
@@ -390,21 +351,6 @@ bool Cos::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool Cos::__eq__(const Basic &o) const
-{
-    if (is_a<Cos>(o)
-        and eq(*get_arg(), *(static_cast<const Cos &>(o).get_arg())))
-        return true;
-    return false;
-}
-
-int Cos::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Cos>(o))
-    const Cos &s = static_cast<const Cos &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> cos(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *zero))
@@ -472,22 +418,6 @@ bool Tan::is_canonical(const RCP<const Basic> &arg) const
         return false;
     }
     return true;
-}
-
-bool Tan::__eq__(const Basic &o) const
-{
-    if (is_a<Tan>(o)
-        and eq(*get_arg(), *(static_cast<const Tan &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int Tan::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Tan>(o))
-    const Tan &s = static_cast<const Tan &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> tan(const RCP<const Basic> &arg)
@@ -560,22 +490,6 @@ bool Cot::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool Cot::__eq__(const Basic &o) const
-{
-    if (is_a<Cot>(o)
-        and eq(*get_arg(), *(static_cast<const Cot &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int Cot::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Cot>(o))
-    const Cot &s = static_cast<const Cot &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> cot(const RCP<const Basic> &arg)
 {
     if (is_a_Number(*arg)
@@ -645,21 +559,6 @@ bool Csc::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool Csc::__eq__(const Basic &o) const
-{
-    if (is_a<Csc>(o)
-        and eq(*get_arg(), *(static_cast<const Csc &>(o).get_arg())))
-        return true;
-    return false;
-}
-
-int Csc::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Csc>(o))
-    const Csc &s = static_cast<const Csc &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> csc(const RCP<const Basic> &arg)
 {
     if (is_a_Number(*arg)
@@ -726,21 +625,6 @@ bool Sec::is_canonical(const RCP<const Basic> &arg) const
         return false;
     }
     return true;
-}
-
-bool Sec::__eq__(const Basic &o) const
-{
-    if (is_a<Sec>(o)
-        and eq(*get_arg(), *(static_cast<const Sec &>(o).get_arg())))
-        return true;
-    return false;
-}
-
-int Sec::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Sec>(o))
-    const Sec &s = static_cast<const Sec &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> sec(const RCP<const Basic> &arg)
@@ -903,22 +787,6 @@ bool ASin::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool ASin::__eq__(const Basic &o) const
-{
-    if (is_a<ASin>(o)
-        and eq(*get_arg(), *(static_cast<const ASin &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ASin::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ASin>(o))
-    const ASin &s = static_cast<const ASin &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> asin(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *zero))
@@ -960,22 +828,6 @@ bool ACos::is_canonical(const RCP<const Basic> &arg) const
         return false;
     }
     return true;
-}
-
-bool ACos::__eq__(const Basic &o) const
-{
-    if (is_a<ACos>(o)
-        and eq(*get_arg(), *(static_cast<const ACos &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ACos::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ACos>(o))
-    const ACos &s = static_cast<const ACos &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> acos(const RCP<const Basic> &arg)
@@ -1020,22 +872,6 @@ bool ASec::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool ASec::__eq__(const Basic &o) const
-{
-    if (is_a<ASec>(o)
-        and eq(*get_arg(), *(static_cast<const ASec &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ASec::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ASec>(o))
-    const ASec &s = static_cast<const ASec &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> asec(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *one))
@@ -1077,22 +913,6 @@ bool ACsc::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool ACsc::__eq__(const Basic &o) const
-{
-    if (is_a<ACsc>(o)
-        and eq(*get_arg(), *(static_cast<const ASec &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ACsc::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ACsc>(o))
-    const ACsc &s = static_cast<const ACsc &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> acsc(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *one))
@@ -1132,22 +952,6 @@ bool ATan::is_canonical(const RCP<const Basic> &arg) const
         return false;
     }
     return true;
-}
-
-bool ATan::__eq__(const Basic &o) const
-{
-    if (is_a<ATan>(o)
-        and eq(*get_arg(), *(static_cast<const ATan &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ATan::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ATan>(o))
-    const ATan &s = static_cast<const ATan &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> atan(const RCP<const Basic> &arg)
@@ -1193,22 +997,6 @@ bool ACot::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool ACot::__eq__(const Basic &o) const
-{
-    if (is_a<ACot>(o)
-        and eq(*get_arg(), *(static_cast<const ACot &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ACot::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ACot>(o))
-    const ACot &s = static_cast<const ACot &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> acot(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *zero))
@@ -1232,7 +1020,7 @@ RCP<const Basic> acot(const RCP<const Basic> &arg)
 }
 
 ATan2::ATan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
-    : num_{num}, den_{den}
+    : TwoArgFunction(num, den)
 {
     SYMENGINE_ASSERT(is_canonical(num, den))
 }
@@ -1250,31 +1038,10 @@ bool ATan2::is_canonical(const RCP<const Basic> &num,
         return true;
 }
 
-bool ATan2::__eq__(const Basic &o) const
+RCP<const Basic> ATan2::create(const RCP<const Basic> &a,
+                               const RCP<const Basic> &b) const
 {
-    if (is_a<ATan2>(o)) {
-        const ATan2 &s = static_cast<const ATan2 &>(o);
-        if (eq(*num_, *(s.get_num())) and eq(*den_, *(s.get_den())))
-            return true;
-        else
-            return false;
-    } else
-        return false;
-}
-
-int ATan2::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ATan2>(o))
-    const ATan2 &s = static_cast<const ATan2 &>(o);
-    return div(num_, den_)->__cmp__(*div(s.num_, s.den_));
-}
-
-std::size_t ATan2::__hash__() const
-{
-    std::size_t seed = ATAN2;
-    hash_combine<Basic>(seed, *num_);
-    hash_combine<Basic>(seed, *den_);
-    return seed;
+    return atan2(a, b);
 }
 
 RCP<const Basic> atan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
@@ -1402,7 +1169,7 @@ RCP<const Basic> ACsc::create(const RCP<const Basic> &arg) const
 }
 
 /* ---------------------------- */
-LambertW::LambertW(const RCP<const Basic> &arg) : arg_{arg}
+LambertW::LambertW(const RCP<const Basic> &arg) : OneArgFunction{arg}
 {
     SYMENGINE_ASSERT(is_canonical(arg))
 }
@@ -1420,25 +1187,9 @@ bool LambertW::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-std::size_t LambertW::__hash__() const
+RCP<const Basic> LambertW::create(const RCP<const Basic> &arg) const
 {
-    std::size_t seed = LAMBERTW;
-    hash_combine<Basic>(seed, *arg_);
-    return seed;
-}
-
-bool LambertW::__eq__(const Basic &o) const
-{
-    if (is_a<LambertW>(o)
-        and eq(*arg_, *(static_cast<const LambertW &>(o).arg_)))
-        return true;
-    return false;
-}
-
-int LambertW::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<LambertW>(o))
-    return arg_->__cmp__(*(static_cast<const LambertW &>(o).arg_));
+    return lambertw(arg);
 }
 
 RCP<const Basic> lambertw(const RCP<const Basic> &arg)
@@ -1795,31 +1546,6 @@ RCP<const Basic> Subs::subs(const map_basic_basic &subs_dict) const
     }
 }
 
-std::size_t HyperbolicFunction::__hash__() const
-{
-    std::size_t seed = this->get_type_code();
-    hash_combine<Basic>(seed, *arg_);
-    return seed;
-}
-
-RCP<const Basic> HyperbolicFunction::create(const RCP<const Basic> &arg) const
-{
-    throw std::runtime_error("Should be implemented by the inherited class");
-}
-
-RCP<const Basic>
-HyperbolicFunction::subs(const map_basic_basic &subs_dict) const
-{
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> arg = arg_->subs(subs_dict);
-    if (arg == arg_)
-        return rcp_from_this();
-    else
-        return this->create(arg);
-}
-
 Sinh::Sinh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
     SYMENGINE_ASSERT(is_canonical(arg))
@@ -1840,22 +1566,6 @@ bool Sinh::is_canonical(const RCP<const Basic> &arg) const
     if (could_extract_minus(*arg))
         return false;
     return true;
-}
-
-bool Sinh::__eq__(const Basic &o) const
-{
-    if (is_a<Sinh>(o)
-        and eq(*get_arg(), *(static_cast<const Sinh &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int Sinh::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Sinh>(o))
-    const Sinh &s = static_cast<const Sinh &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> sinh(const RCP<const Basic> &arg)
@@ -1901,22 +1611,6 @@ bool Csch::is_canonical(const RCP<const Basic> &arg) const
     if (could_extract_minus(*arg))
         return false;
     return true;
-}
-
-bool Csch::__eq__(const Basic &o) const
-{
-    if (is_a<Csch>(o)
-        and eq(*get_arg(), *(static_cast<const Csch &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int Csch::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Csch>(o))
-    const Csch &s = static_cast<const Csch &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> csch(const RCP<const Basic> &arg)
@@ -1968,22 +1662,6 @@ bool Cosh::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool Cosh::__eq__(const Basic &o) const
-{
-    if (is_a<Cosh>(o)
-        and eq(*get_arg(), *(static_cast<const Cosh &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int Cosh::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Cosh>(o))
-    const Cosh &s = static_cast<const Cosh &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> cosh(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *zero))
@@ -2027,22 +1705,6 @@ bool Sech::is_canonical(const RCP<const Basic> &arg) const
     if (could_extract_minus(*arg))
         return false;
     return true;
-}
-
-bool Sech::__eq__(const Basic &o) const
-{
-    if (is_a<Sech>(o)
-        and eq(*get_arg(), *(static_cast<const Sech &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int Sech::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Sech>(o))
-    const Sech &s = static_cast<const Sech &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> sech(const RCP<const Basic> &arg)
@@ -2092,22 +1754,6 @@ bool Tanh::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool Tanh::__eq__(const Basic &o) const
-{
-    if (is_a<Tanh>(o)
-        and eq(*get_arg(), *(static_cast<const Tanh &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int Tanh::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Tanh>(o))
-    const Tanh &s = static_cast<const Tanh &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> tanh(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *zero))
@@ -2153,22 +1799,6 @@ bool Coth::is_canonical(const RCP<const Basic> &arg) const
     if (could_extract_minus(*arg))
         return false;
     return true;
-}
-
-bool Coth::__eq__(const Basic &o) const
-{
-    if (is_a<Coth>(o)
-        and eq(*get_arg(), *(static_cast<const Coth &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int Coth::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Coth>(o))
-    const Coth &s = static_cast<const Coth &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> coth(const RCP<const Basic> &arg)
@@ -2220,22 +1850,6 @@ bool ASinh::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool ASinh::__eq__(const Basic &o) const
-{
-    if (is_a<ASinh>(o)
-        and eq(*get_arg(), *(static_cast<const ASinh &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ASinh::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ASinh>(o))
-    const ASinh &s = static_cast<const ASinh &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> asinh(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *zero))
@@ -2280,22 +1894,6 @@ bool ACsch::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool ACsch::__eq__(const Basic &o) const
-{
-    if (is_a<ACsch>(o)
-        and eq(*get_arg(), *(static_cast<const ACsch &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ACsch::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ACsch>(o))
-    const ACsch &s = static_cast<const ACsch &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> acsch(const RCP<const Basic> &arg)
 {
     if (eq(*arg, *one))
@@ -2324,22 +1922,6 @@ bool ACosh::is_canonical(const RCP<const Basic> &arg) const
         return false;
     }
     return true;
-}
-
-bool ACosh::__eq__(const Basic &o) const
-{
-    if (is_a<ACosh>(o)
-        and eq(*get_arg(), *(static_cast<const ACosh &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ACosh::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ACosh>(o))
-    const ACosh &s = static_cast<const ACosh &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> acosh(const RCP<const Basic> &arg)
@@ -2374,22 +1956,6 @@ bool ATanh::is_canonical(const RCP<const Basic> &arg) const
     if (could_extract_minus(*arg))
         return false;
     return true;
-}
-
-bool ATanh::__eq__(const Basic &o) const
-{
-    if (is_a<ATanh>(o)
-        and eq(*get_arg(), *(static_cast<const ATanh &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ATanh::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ATanh>(o))
-    const ATanh &s = static_cast<const ATanh &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> atanh(const RCP<const Basic> &arg)
@@ -2430,22 +1996,6 @@ bool ACoth::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-bool ACoth::__eq__(const Basic &o) const
-{
-    if (is_a<ACoth>(o)
-        and eq(*get_arg(), *(static_cast<const ACoth &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ACoth::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ACoth>(o))
-    const ACoth &s = static_cast<const ACoth &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
-}
-
 RCP<const Basic> acoth(const RCP<const Basic> &arg)
 {
     if (is_a_Number(*arg)) {
@@ -2474,22 +2024,6 @@ bool ASech::is_canonical(const RCP<const Basic> &arg) const
     if (eq(*arg, *one))
         return false;
     return true;
-}
-
-bool ASech::__eq__(const Basic &o) const
-{
-    if (is_a<ASech>(o)
-        and eq(*get_arg(), *(static_cast<const ASech &>(o).get_arg())))
-        return true;
-    else
-        return false;
-}
-
-int ASech::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<ASech>(o))
-    const ASech &s = static_cast<const ASech &>(o);
-    return get_arg()->__cmp__(*(s.get_arg()));
 }
 
 RCP<const Basic> asech(const RCP<const Basic> &arg)
@@ -2562,9 +2096,9 @@ RCP<const Basic> ASech::create(const RCP<const Basic> &arg) const
 
 KroneckerDelta::KroneckerDelta(const RCP<const Basic> &i,
                                const RCP<const Basic> &j)
-    : i_{i}, j_{j}
+    : TwoArgFunction(i, j)
 {
-    SYMENGINE_ASSERT(is_canonical(i_, j_))
+    SYMENGINE_ASSERT(is_canonical(i, j))
 }
 
 bool KroneckerDelta::is_canonical(const RCP<const Basic> &i,
@@ -2581,43 +2115,10 @@ bool KroneckerDelta::is_canonical(const RCP<const Basic> &i,
     }
 }
 
-bool KroneckerDelta::__eq__(const Basic &o) const
+RCP<const Basic> KroneckerDelta::create(const RCP<const Basic> &a,
+                                        const RCP<const Basic> &b) const
 {
-    if (is_a<KroneckerDelta>(o)
-        and eq(*i_, *(static_cast<const KroneckerDelta &>(o).i_))
-        and eq(*j_, *(static_cast<const KroneckerDelta &>(o).j_)))
-        return true;
-    else
-        return false;
-}
-
-int KroneckerDelta::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<KroneckerDelta>(o))
-    const KroneckerDelta &s = static_cast<const KroneckerDelta &>(o);
-    return i_->__cmp__(*(s.i_));
-}
-
-std::size_t KroneckerDelta::__hash__() const
-{
-    std::size_t seed = KRONECKERDELTA;
-    hash_combine<Basic>(seed, *i_);
-    hash_combine<Basic>(seed, *j_);
-    return seed;
-}
-
-RCP<const Basic> KroneckerDelta::subs(const map_basic_basic &subs_dict) const
-{
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> i = i_->subs(subs_dict);
-    RCP<const Basic> j = j_->subs(subs_dict);
-    if (i == i_ and j == j_) {
-        return rcp_from_this();
-    } else {
-        return kronecker_delta(i, j);
-    }
+    return kronecker_delta(a, b);
 }
 
 RCP<const Basic> kronecker_delta(const RCP<const Basic> &i,
@@ -2650,9 +2151,9 @@ bool has_dup(const vec_basic &arg)
     return false;
 }
 
-LeviCivita::LeviCivita(const vec_basic &&arg) : arg_{std::move(arg)}
+LeviCivita::LeviCivita(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
-    SYMENGINE_ASSERT(is_canonical(arg_))
+    SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 
 bool LeviCivita::is_canonical(const vec_basic &arg) const
@@ -2673,29 +2174,9 @@ bool LeviCivita::is_canonical(const vec_basic &arg) const
     }
 }
 
-bool LeviCivita::__eq__(const Basic &o) const
+RCP<const Basic> LeviCivita::create(const vec_basic &a) const
 {
-    if (is_a<LeviCivita>(o)
-        and vec_basic_eq(arg_, static_cast<const LeviCivita &>(o).arg_))
-        return true;
-    else
-        return false;
-}
-
-int LeviCivita::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<LeviCivita>(o))
-    const LeviCivita &s = static_cast<const LeviCivita &>(o);
-    return vec_basic_compare(arg_, s.arg_);
-}
-
-std::size_t LeviCivita::__hash__() const
-{
-    std::size_t seed = LEVICIVITA;
-    for (const auto &p : arg_) {
-        hash_combine<Basic>(seed, *p);
-    }
-    return seed;
+    return levi_civita(a);
 }
 
 RCP<const Basic> eval_levicivita(const vec_basic &arg, int len)
@@ -2732,14 +2213,15 @@ RCP<const Basic> levi_civita(const vec_basic &arg)
     }
 }
 
-Zeta::Zeta(const RCP<const Basic> &s, const RCP<const Basic> &a) : s_{s}, a_{a}
+Zeta::Zeta(const RCP<const Basic> &s, const RCP<const Basic> &a)
+    : TwoArgFunction(s, a)
 {
-    SYMENGINE_ASSERT(is_canonical(s_, a_))
+    SYMENGINE_ASSERT(is_canonical(s, a))
 }
 
-Zeta::Zeta(const RCP<const Basic> &s) : s_{s}, a_{one}
+Zeta::Zeta(const RCP<const Basic> &s) : TwoArgFunction(s, one)
 {
-    SYMENGINE_ASSERT(is_canonical(s_, a_))
+    SYMENGINE_ASSERT(is_canonical(s, one))
 }
 
 bool Zeta::is_canonical(const RCP<const Basic> &s,
@@ -2757,26 +2239,10 @@ bool Zeta::is_canonical(const RCP<const Basic> &s,
     return true;
 }
 
-std::size_t Zeta::__hash__() const
+RCP<const Basic> Zeta::create(const RCP<const Basic> &a,
+                              const RCP<const Basic> &b) const
 {
-    std::size_t seed = ZETA;
-    hash_combine<Basic>(seed, *s_);
-    hash_combine<Basic>(seed, *a_);
-    return seed;
-}
-
-bool Zeta::__eq__(const Basic &o) const
-{
-    if (is_a<Zeta>(o) and eq(*s_, *(static_cast<const Zeta &>(o).s_))
-        and eq(*a_, *(static_cast<const Zeta &>(o).a_)))
-        return true;
-    return false;
-}
-
-int Zeta::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Zeta>(o))
-    return s_->__cmp__(*(static_cast<const Zeta &>(o).s_));
+    return zeta(a, b);
 }
 
 RCP<const Basic> zeta(const RCP<const Basic> &s, const RCP<const Basic> &a)
@@ -2815,9 +2281,9 @@ RCP<const Basic> zeta(const RCP<const Basic> &s)
     return zeta(s, one);
 }
 
-Dirichlet_eta::Dirichlet_eta(const RCP<const Basic> &s) : s_{s}
+Dirichlet_eta::Dirichlet_eta(const RCP<const Basic> &s) : OneArgFunction(s)
 {
-    SYMENGINE_ASSERT(is_canonical(s_))
+    SYMENGINE_ASSERT(is_canonical(s))
 }
 
 bool Dirichlet_eta::is_canonical(const RCP<const Basic> &s) const
@@ -2829,30 +2295,14 @@ bool Dirichlet_eta::is_canonical(const RCP<const Basic> &s) const
     return true;
 }
 
-std::size_t Dirichlet_eta::__hash__() const
-{
-    std::size_t seed = DIRICHLET_ETA;
-    hash_combine<Basic>(seed, *s_);
-    return seed;
-}
-
-bool Dirichlet_eta::__eq__(const Basic &o) const
-{
-    if (is_a<Dirichlet_eta>(o)
-        and eq(*s_, *(static_cast<const Dirichlet_eta &>(o).s_)))
-        return true;
-    return false;
-}
-
-int Dirichlet_eta::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Dirichlet_eta>(o))
-    return s_->__cmp__(*(static_cast<const Dirichlet_eta &>(o).s_));
-}
-
 RCP<const Basic> Dirichlet_eta::rewrite_as_zeta() const
 {
-    return mul(sub(one, pow(i2, sub(one, s_))), zeta(s_));
+    return mul(sub(one, pow(i2, sub(one, get_arg()))), zeta(get_arg()));
+}
+
+RCP<const Basic> Dirichlet_eta::create(const RCP<const Basic> &arg) const
+{
+    return dirichlet_eta(arg);
 }
 
 RCP<const Basic> dirichlet_eta(const RCP<const Basic> &s)
@@ -2877,24 +2327,9 @@ bool Erf::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-std::size_t Erf::__hash__() const
+RCP<const Basic> Erf::create(const RCP<const Basic> &arg) const
 {
-    std::size_t seed = ERF;
-    hash_combine<Basic>(seed, *arg_);
-    return seed;
-}
-
-bool Erf::__eq__(const Basic &o) const
-{
-    if (is_a<Erf>(o) and eq(*arg_, *(static_cast<const Erf &>(o).arg_)))
-        return true;
-    return false;
-}
-
-int Erf::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Erf>(o))
-    return arg_->__cmp__(*(static_cast<const Erf &>(o).arg_));
+    return erf(arg);
 }
 
 RCP<const Basic> erf(const RCP<const Basic> &arg)
@@ -2909,21 +2344,9 @@ RCP<const Basic> erf(const RCP<const Basic> &arg)
     return make_rcp<Erf>(arg);
 }
 
-RCP<const Basic> Erf::subs(const map_basic_basic &subs_dict) const
+Gamma::Gamma(const RCP<const Basic> &arg) : OneArgFunction{arg}
 {
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> arg = arg_->subs(subs_dict);
-    if (arg == arg_)
-        return rcp_from_this();
-    else
-        return erf(arg);
-}
-
-Gamma::Gamma(const RCP<const Basic> &arg) : arg_{arg}
-{
-    SYMENGINE_ASSERT(is_canonical(arg_))
+    SYMENGINE_ASSERT(is_canonical(arg))
 }
 
 bool Gamma::is_canonical(const RCP<const Basic> &arg) const
@@ -2941,36 +2364,9 @@ bool Gamma::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-std::size_t Gamma::__hash__() const
+RCP<const Basic> Gamma::create(const RCP<const Basic> &arg) const
 {
-    std::size_t seed = GAMMA;
-    hash_combine<Basic>(seed, *arg_);
-    return seed;
-}
-
-bool Gamma::__eq__(const Basic &o) const
-{
-    if (is_a<Gamma>(o) and eq(*arg_, *(static_cast<const Gamma &>(o).arg_)))
-        return true;
-    return false;
-}
-
-int Gamma::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Gamma>(o))
-    return arg_->__cmp__(*(static_cast<const Gamma &>(o).arg_));
-}
-
-RCP<const Basic> Gamma::subs(const map_basic_basic &subs_dict) const
-{
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> arg = arg_->subs(subs_dict);
-    if (arg == arg_)
-        return rcp_from_this();
-    else
-        return gamma(arg);
+    return gamma(arg);
 }
 
 RCP<const Basic> gamma_positive_int(const RCP<const Basic> &arg)
@@ -3038,9 +2434,9 @@ RCP<const Basic> gamma(const RCP<const Basic> &arg)
 }
 
 LowerGamma::LowerGamma(const RCP<const Basic> &s, const RCP<const Basic> &x)
-    : s_{s}, x_{x}
+    : TwoArgFunction(s, x)
 {
-    SYMENGINE_ASSERT(is_canonical(s_, x_))
+    SYMENGINE_ASSERT(is_canonical(s, x))
 }
 
 bool LowerGamma::is_canonical(const RCP<const Basic> &s,
@@ -3056,46 +2452,10 @@ bool LowerGamma::is_canonical(const RCP<const Basic> &s,
     return true;
 }
 
-std::size_t LowerGamma::__hash__() const
+RCP<const Basic> LowerGamma::create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const
 {
-    std::size_t seed = LOWERGAMMA;
-    hash_combine<Basic>(seed, *s_);
-    hash_combine<Basic>(seed, *x_);
-    return seed;
-}
-
-bool LowerGamma::__eq__(const Basic &o) const
-{
-    if (is_a<LowerGamma>(o)
-        and eq(*s_, *(static_cast<const LowerGamma &>(o).s_))
-        and eq(*x_, *(static_cast<const LowerGamma &>(o).x_)))
-        return true;
-    return false;
-}
-
-int LowerGamma::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<LowerGamma>(o))
-    const LowerGamma &lg = static_cast<const LowerGamma &>(o);
-    if (neq(*s_, *(lg.s_))) {
-        return s_->__cmp__(*(static_cast<const LowerGamma &>(o).s_));
-    } else {
-        return x_->__cmp__(*(static_cast<const LowerGamma &>(o).x_));
-    }
-}
-
-RCP<const Basic> LowerGamma::subs(const map_basic_basic &subs_dict) const
-{
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> s = s_->subs(subs_dict);
-    RCP<const Basic> x = x_->subs(subs_dict);
-    if (x == x_ and s == s_) {
-        return rcp_from_this();
-    } else {
-        return lowergamma(s, x);
-    }
+    return lowergamma(a, b);
 }
 
 RCP<const Basic> lowergamma(const RCP<const Basic> &s,
@@ -3131,9 +2491,9 @@ RCP<const Basic> lowergamma(const RCP<const Basic> &s,
 }
 
 UpperGamma::UpperGamma(const RCP<const Basic> &s, const RCP<const Basic> &x)
-    : s_{s}, x_{x}
+    : TwoArgFunction(s, x)
 {
-    SYMENGINE_ASSERT(is_canonical(s_, x_))
+    SYMENGINE_ASSERT(is_canonical(s, x))
 }
 
 bool UpperGamma::is_canonical(const RCP<const Basic> &s,
@@ -3149,46 +2509,10 @@ bool UpperGamma::is_canonical(const RCP<const Basic> &s,
     return true;
 }
 
-std::size_t UpperGamma::__hash__() const
+RCP<const Basic> UpperGamma::create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const
 {
-    std::size_t seed = UPPERGAMMA;
-    hash_combine<Basic>(seed, *s_);
-    hash_combine<Basic>(seed, *x_);
-    return seed;
-}
-
-bool UpperGamma::__eq__(const Basic &o) const
-{
-    if (is_a<UpperGamma>(o)
-        and eq(*s_, *(static_cast<const UpperGamma &>(o).s_))
-        and eq(*x_, *(static_cast<const UpperGamma &>(o).x_)))
-        return true;
-    return false;
-}
-
-int UpperGamma::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<UpperGamma>(o))
-    const UpperGamma &ug = static_cast<const UpperGamma &>(o);
-    if (neq(*s_, *(ug.s_))) {
-        return s_->__cmp__(*(static_cast<const UpperGamma &>(o).s_));
-    } else {
-        return x_->__cmp__(*(static_cast<const UpperGamma &>(o).x_));
-    }
-}
-
-RCP<const Basic> UpperGamma::subs(const map_basic_basic &subs_dict) const
-{
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> s = s_->subs(subs_dict);
-    RCP<const Basic> x = x_->subs(subs_dict);
-    if (s == s_ and x == x_) {
-        return rcp_from_this();
-    } else {
-        return uppergamma(s, x);
-    }
+    return uppergamma(a, b);
 }
 
 RCP<const Basic> uppergamma(const RCP<const Basic> &s,
@@ -3239,42 +2563,14 @@ bool LogGamma::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-std::size_t LogGamma::__hash__() const
-{
-    std::size_t seed = LOGGAMMA;
-    hash_combine<Basic>(seed, *arg_);
-    return seed;
-}
-
-bool LogGamma::__eq__(const Basic &o) const
-{
-    if (is_a<LogGamma>(o)
-        and eq(*arg_, *(static_cast<const LogGamma &>(o).arg_)))
-        return true;
-    return false;
-}
-
-int LogGamma::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<LogGamma>(o))
-    return arg_->__cmp__(*(static_cast<const LogGamma &>(o).arg_));
-}
-
 RCP<const Basic> LogGamma::rewrite_as_gamma() const
 {
-    return log(gamma(arg_));
+    return log(gamma(get_arg()));
 }
 
-RCP<const Basic> LogGamma::subs(const map_basic_basic &subs_dict) const
+RCP<const Basic> LogGamma::create(const RCP<const Basic> &arg) const
 {
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> arg = arg_->subs(subs_dict);
-    if (arg == arg_)
-        return rcp_from_this();
-    else
-        return loggamma(arg);
+    return loggamma(arg);
 }
 
 RCP<const Basic> loggamma(const RCP<const Basic> &arg)
@@ -3319,52 +2615,16 @@ bool Beta::is_canonical(const RCP<const Basic> &x, const RCP<const Basic> &y)
     return true;
 }
 
-std::size_t Beta::__hash__() const
-{
-    std::size_t seed = BETA;
-    hash_combine<Basic>(seed, *x_);
-    hash_combine<Basic>(seed, *y_);
-    return seed;
-}
-
-bool Beta::__eq__(const Basic &o) const
-{
-    if (is_a<Beta>(o)) {
-        if (eq(*x_, *(static_cast<const Beta &>(o).x_))
-            and eq(*y_, *(static_cast<const Beta &>(o).y_))) {
-            return true;
-        }
-    }
-    return false;
-}
-
-int Beta::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Beta>(o))
-    const Beta &b = static_cast<const Beta &>(o);
-    if (eq(*x_, *(b.x_))) {
-        return y_->__cmp__(*(static_cast<const Beta &>(o).y_));
-    }
-    return x_->__cmp__(*(static_cast<const Beta &>(o).x_));
-}
-
 RCP<const Basic> Beta::rewrite_as_gamma() const
 {
-    return div(mul(gamma(x_), gamma(y_)), add(x_, y_));
+    return div(mul(gamma(get_arg1()), gamma(get_arg2())),
+               add(get_arg1(), get_arg2()));
 }
 
-RCP<const Basic> Beta::subs(const map_basic_basic &subs_dict) const
+RCP<const Basic> Beta::create(const RCP<const Basic> &a,
+                              const RCP<const Basic> &b) const
 {
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> x = x_->subs(subs_dict);
-    RCP<const Basic> y = y_->subs(subs_dict);
-    if ((x == x_ and y == y_) or (x == y_ and y == x_)) {
-        return rcp_from_this();
-    } else {
-        return beta(x, y);
-    }
+    return beta(a, b);
 }
 
 RCP<const Basic> beta(const RCP<const Basic> &x, const RCP<const Basic> &y)
@@ -3461,61 +2721,26 @@ bool PolyGamma::is_canonical(const RCP<const Basic> &n,
     return true;
 }
 
-std::size_t PolyGamma::__hash__() const
-{
-    std::size_t seed = POLYGAMMA;
-    hash_combine<Basic>(seed, *n_);
-    hash_combine<Basic>(seed, *x_);
-    return seed;
-}
-
-bool PolyGamma::__eq__(const Basic &o) const
-{
-    if (is_a<PolyGamma>(o) and eq(*x_, *(static_cast<const PolyGamma &>(o).x_))
-        and eq(*n_, *(static_cast<const PolyGamma &>(o).n_)))
-        return true;
-    return false;
-}
-
-int PolyGamma::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<PolyGamma>(o))
-    const PolyGamma &pg = static_cast<const PolyGamma &>(o);
-    if (neq(*n_, *(pg.n_))) {
-        return n_->__cmp__(*(pg.n_));
-    } else {
-        return x_->__cmp__(*(pg.x_));
-    }
-}
-
 RCP<const Basic> PolyGamma::rewrite_as_zeta() const
 {
-    if (not is_a<Integer>(*n_)) {
+    if (not is_a<Integer>(*get_arg1())) {
         return rcp_from_this();
     }
-    RCP<const Integer> n = rcp_static_cast<const Integer>(n_);
+    RCP<const Integer> n = rcp_static_cast<const Integer>(get_arg1());
     if (not(n->is_positive())) {
         return rcp_from_this();
     }
     if ((n->as_int() & 1) == 0) {
-        return neg(mul(factorial(n->as_int()), zeta(add(n_, one), x_)));
+        return neg(mul(factorial(n->as_int()), zeta(add(n, one), get_arg2())));
     } else {
-        return mul(factorial(n->as_int()), zeta(add(n_, one), x_));
+        return mul(factorial(n->as_int()), zeta(add(n, one), get_arg2()));
     }
 }
 
-RCP<const Basic> PolyGamma::subs(const map_basic_basic &subs_dict) const
+RCP<const Basic> PolyGamma::create(const RCP<const Basic> &a,
+                                   const RCP<const Basic> &b) const
 {
-    auto it = subs_dict.find(rcp_from_this());
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> n1 = n_->subs(subs_dict);
-    RCP<const Basic> x1 = x_->subs(subs_dict);
-    if (n1 == n_ and x1 == x_) {
-        return rcp_from_this();
-    } else {
-        return polygamma(n1, x1);
-    }
+    return polygamma(a, b);
 }
 
 RCP<const Basic> polygamma(const RCP<const Basic> &n_,
@@ -3574,9 +2799,9 @@ RCP<const Basic> polygamma(const RCP<const Basic> &n_,
     return make_rcp<const PolyGamma>(n_, x_);
 }
 
-Abs::Abs(const RCP<const Basic> &arg) : arg_{arg}
+Abs::Abs(const RCP<const Basic> &arg) : OneArgFunction(arg)
 {
-    SYMENGINE_ASSERT(is_canonical(arg_))
+    SYMENGINE_ASSERT(is_canonical(arg))
 }
 
 bool Abs::is_canonical(const RCP<const Basic> &arg) const
@@ -3595,24 +2820,9 @@ bool Abs::is_canonical(const RCP<const Basic> &arg) const
     return true;
 }
 
-std::size_t Abs::__hash__() const
+RCP<const Basic> Abs::create(const RCP<const Basic> &arg) const
 {
-    std::size_t seed = ABS;
-    hash_combine<Basic>(seed, *arg_);
-    return seed;
-}
-
-bool Abs::__eq__(const Basic &o) const
-{
-    if (is_a<Abs>(o) and eq(*arg_, *(static_cast<const Abs &>(o).arg_)))
-        return true;
-    return false;
-}
-
-int Abs::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Abs>(o))
-    return arg_->__cmp__(*(static_cast<const Abs &>(o).arg_));
+    return abs(arg);
 }
 
 RCP<const Basic> abs(const RCP<const Basic> &arg)
@@ -3647,9 +2857,9 @@ RCP<const Basic> abs(const RCP<const Basic> &arg)
     return make_rcp<const Abs>(arg);
 }
 
-Max::Max(const vec_basic &&arg) : arg_{std::move(arg)}
+Max::Max(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
-    SYMENGINE_ASSERT(is_canonical(arg_))
+    SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 
 bool Max::is_canonical(const vec_basic &arg) const
@@ -3671,29 +2881,9 @@ bool Max::is_canonical(const vec_basic &arg) const
     return non_number_exists; // all arguments cant be numbers
 }
 
-bool Max::__eq__(const Basic &o) const
+RCP<const Basic> Max::create(const vec_basic &a) const
 {
-    if (is_a<Max>(o)
-        and vec_basic_eq_perm(arg_, static_cast<const Max &>(o).arg_))
-        return true;
-    else
-        return false;
-}
-
-int Max::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Max>(o))
-    const Max &s = static_cast<const Max &>(o);
-    return vec_basic_compare(arg_, s.arg_);
-}
-
-std::size_t Max::__hash__() const
-{
-    std::size_t seed = MAX;
-    for (const auto &p : arg_) {
-        hash_combine<Basic>(seed, *p);
-    }
-    return seed;
+    return max(a);
 }
 
 RCP<const Basic> max(const vec_basic &arg)
@@ -3765,9 +2955,9 @@ RCP<const Basic> max(const vec_basic &arg)
     }
 }
 
-Min::Min(const vec_basic &&arg) : arg_{std::move(arg)}
+Min::Min(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
-    SYMENGINE_ASSERT(is_canonical(arg_))
+    SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 
 bool Min::is_canonical(const vec_basic &arg) const
@@ -3789,29 +2979,9 @@ bool Min::is_canonical(const vec_basic &arg) const
     return non_number_exists; // all arguments cant be numbers
 }
 
-bool Min::__eq__(const Basic &o) const
+RCP<const Basic> Min::create(const vec_basic &a) const
 {
-    if (is_a<Min>(o)
-        and vec_basic_eq_perm(arg_, static_cast<const Min &>(o).arg_))
-        return true;
-    else
-        return false;
-}
-
-int Min::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Min>(o))
-    const Min &s = static_cast<const Min &>(o);
-    return vec_basic_compare(arg_, s.arg_);
-}
-
-std::size_t Min::__hash__() const
-{
-    std::size_t seed = MIN;
-    for (const auto &p : arg_) {
-        hash_combine<Basic>(seed, *p);
-    }
-    return seed;
+    return min(a);
 }
 
 RCP<const Basic> min(const vec_basic &arg)

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -42,19 +42,6 @@ public:
     }
     //! Method to construct classes with canonicalization
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const = 0;
-    //! Substitute with `subs_dict`
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const
-    {
-        auto it = subs_dict.find(rcp_from_this());
-        if (it != subs_dict.end())
-            return it->second;
-        RCP<const Basic> t = get_arg()->subs(subs_dict);
-        if (t == get_arg()) {
-            return rcp_from_this();
-        } else {
-            return create(t);
-        }
-    }
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
@@ -108,20 +95,6 @@ public:
     //! Method to construct classes with canonicalization
     virtual RCP<const Basic> create(const RCP<const Basic> &a,
                                     const RCP<const Basic> &b) const = 0;
-    //! Substitute with `subs_dict`
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const
-    {
-        auto it = subs_dict.find(rcp_from_this());
-        if (it != subs_dict.end())
-            return it->second;
-        RCP<const Basic> t = a_->subs(subs_dict);
-        RCP<const Basic> s = b_->subs(subs_dict);
-        if (t == a_ and s == b_) {
-            return rcp_from_this();
-        } else {
-            return create(t, s);
-        }
-    }
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
@@ -175,18 +148,6 @@ public:
     }
     //! Method to construct classes with canonicalization
     virtual RCP<const Basic> create(const vec_basic &v) const = 0;
-    //! Substitute with `subs_dict`
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const
-    {
-        auto it = subs_dict.find(rcp_from_this());
-        if (it != subs_dict.end())
-            return it->second;
-        vec_basic v = arg_;
-        for (auto &elem : v) {
-            elem = elem->subs(subs_dict);
-        }
-        return create(v);
-    }
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
@@ -571,7 +532,6 @@ public:
     }
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
     virtual RCP<const Basic> create(const vec_basic &x) const;
 };
 
@@ -644,7 +604,6 @@ public:
     }
     bool is_canonical(const RCP<const Basic> &arg,
                       const multiset_basic &x) const;
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 };
 
 /*! Subs operator
@@ -684,7 +643,6 @@ public:
 
     bool is_canonical(const RCP<const Basic> &arg,
                       const map_basic_basic &x) const;
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 };
 
 class HyperbolicFunction : public OneArgFunction

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -17,29 +17,201 @@ class Function : public Basic
 {
 };
 
-class TrigFunction : public Function
+class OneArgFunction : public Function
 {
-
 private:
-    RCP<const Basic> arg_; //! The `arg` in `trigclass(arg)`
+    RCP<const Basic> arg_; //! The `arg` in `OneArgFunction(arg)`
 public:
     //! Constructor
-    TrigFunction(RCP<const Basic> arg) : arg_{arg} {};
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
+    OneArgFunction(const RCP<const Basic> &arg) : arg_{arg} {};
+    //! \return the hash
+    inline std::size_t __hash__() const
+    {
+        std::size_t seed = this->get_type_code();
+        hash_combine<Basic>(seed, *arg_);
+        return seed;
+    }
     //! \return `arg_`
-    inline RCP<const Basic> get_arg() const
+    inline const RCP<const Basic> &get_arg() const
     {
         return arg_;
     }
-    virtual vec_basic get_args() const
+    virtual inline vec_basic get_args() const
     {
         return {arg_};
     }
     //! Method to construct classes with canonicalization
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const = 0;
     //! Substitute with `subs_dict`
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const
+    {
+        auto it = subs_dict.find(rcp_from_this());
+        if (it != subs_dict.end())
+            return it->second;
+        RCP<const Basic> t = get_arg()->subs(subs_dict);
+        if (t == get_arg()) {
+            return rcp_from_this();
+        } else {
+            return create(t);
+        }
+    }
+    /*! Equality comparator
+     * \param o - Object to be compared with
+     * \return whether the 2 objects are equal
+     * */
+    virtual inline bool __eq__(const Basic &o) const
+    {
+        return is_same_type(*this, o)
+               and eq(*get_arg(),
+                      *static_cast<const OneArgFunction &>(o).get_arg());
+    }
+    //! Structural equality comparator
+    virtual inline int compare(const Basic &o) const
+    {
+        SYMENGINE_ASSERT(is_same_type(*this, o))
+        return get_arg()->__cmp__(
+            *(static_cast<const OneArgFunction &>(o).get_arg()));
+    }
+};
+
+class TwoArgFunction : public Function
+{
+private:
+    RCP<const Basic> a_; //! `a` in `TwoArgFunction(a, b)`
+    RCP<const Basic> b_; //! `b` in `TwoArgFunction(a, b)`
+public:
+    //! Constructor
+    TwoArgFunction(const RCP<const Basic> &a, const RCP<const Basic> &b)
+        : a_{a}, b_{b} {};
+    //! \return the hash
+    inline std::size_t __hash__() const
+    {
+        std::size_t seed = this->get_type_code();
+        hash_combine<Basic>(seed, *a_);
+        hash_combine<Basic>(seed, *b_);
+        return seed;
+    }
+    //! \return `arg_`
+    inline const RCP<const Basic> &get_arg1() const
+    {
+        return a_;
+    }
+    //! \return `arg_`
+    inline const RCP<const Basic> &get_arg2() const
+    {
+        return b_;
+    }
+    virtual inline vec_basic get_args() const
+    {
+        return {a_, b_};
+    }
+    //! Method to construct classes with canonicalization
+    virtual RCP<const Basic> create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const = 0;
+    //! Substitute with `subs_dict`
+    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const
+    {
+        auto it = subs_dict.find(rcp_from_this());
+        if (it != subs_dict.end())
+            return it->second;
+        RCP<const Basic> t = a_->subs(subs_dict);
+        RCP<const Basic> s = b_->subs(subs_dict);
+        if (t == a_ and s == b_) {
+            return rcp_from_this();
+        } else {
+            return create(t, s);
+        }
+    }
+    /*! Equality comparator
+     * \param o - Object to be compared with
+     * \return whether the 2 objects are equal
+     * */
+    virtual inline bool __eq__(const Basic &o) const
+    {
+        return is_same_type(*this, o)
+               and eq(*get_arg1(),
+                      *static_cast<const TwoArgFunction &>(o).get_arg1())
+               and eq(*get_arg2(),
+                      *static_cast<const TwoArgFunction &>(o).get_arg2());
+    }
+    //! Structural equality comparator
+    virtual inline int compare(const Basic &o) const
+    {
+        SYMENGINE_ASSERT(is_same_type(*this, o))
+        const TwoArgFunction &t = static_cast<const TwoArgFunction &>(o);
+        if (neq(*get_arg1(), *(t.get_arg1()))) {
+            return get_arg1()->__cmp__(
+                *(static_cast<const TwoArgFunction &>(o).get_arg1()));
+        } else {
+            return get_arg2()->__cmp__(
+                *(static_cast<const TwoArgFunction &>(o).get_arg2()));
+        }
+    }
+};
+
+class MultiArgFunction : public Function
+{
+private:
+    vec_basic arg_;
+
+public:
+    //! Constructor
+    MultiArgFunction(const vec_basic &arg) : arg_{arg} {};
+    //! \return the hash
+    inline std::size_t __hash__() const
+    {
+        std::size_t seed = this->get_type_code();
+        for (const auto &a : arg_)
+            hash_combine<Basic>(seed, *a);
+        return seed;
+    }
+    virtual inline vec_basic get_args() const
+    {
+        return arg_;
+    }
+    inline const vec_basic &get_vec() const
+    {
+        return arg_;
+    }
+    //! Method to construct classes with canonicalization
+    virtual RCP<const Basic> create(const vec_basic &v) const = 0;
+    //! Substitute with `subs_dict`
+    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const
+    {
+        auto it = subs_dict.find(rcp_from_this());
+        if (it != subs_dict.end())
+            return it->second;
+        vec_basic v = arg_;
+        for (auto &elem : v) {
+            elem = elem->subs(subs_dict);
+        }
+        return create(v);
+    }
+    /*! Equality comparator
+     * \param o - Object to be compared with
+     * \return whether the 2 objects are equal
+     * */
+    virtual inline bool __eq__(const Basic &o) const
+    {
+        return is_same_type(*this, o)
+               and vec_basic_eq(
+                       get_vec(),
+                       static_cast<const MultiArgFunction &>(o).get_vec());
+    }
+    //! Structural equality comparator
+    virtual inline int compare(const Basic &o) const
+    {
+        SYMENGINE_ASSERT(is_same_type(*this, o))
+        return vec_basic_compare(
+            get_vec(), static_cast<const MultiArgFunction &>(o).get_vec());
+    }
+};
+
+class TrigFunction : public OneArgFunction
+{
+public:
+    //! Constructor
+    TrigFunction(RCP<const Basic> arg) : OneArgFunction(arg){};
 };
 
 /*! \return `true` if `arg` is of form `theta + n*pi/12`
@@ -75,13 +247,6 @@ public:
     IMPLEMENT_TYPEID(SIN)
     //! Sin Constructor
     Sin(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sin
@@ -98,12 +263,6 @@ public:
     IMPLEMENT_TYPEID(COS)
     //! Cos Constructor
     Cos(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o  Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized cos
@@ -120,13 +279,6 @@ public:
     IMPLEMENT_TYPEID(TAN)
     //! Tan Constructor
     Tan(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized tan
@@ -142,13 +294,6 @@ public:
     IMPLEMENT_TYPEID(COT)
     //! Cot Constructor
     Cot(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized cot
@@ -164,13 +309,6 @@ public:
     IMPLEMENT_TYPEID(CSC)
     //! Csc Constructor
     Csc(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized csc
@@ -186,13 +324,6 @@ public:
     IMPLEMENT_TYPEID(SEC)
     //! Sec Constructor
     Sec(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sec
@@ -208,12 +339,6 @@ public:
     IMPLEMENT_TYPEID(ASIN)
     //! ASin Constructor
     ASin(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized asin
@@ -230,12 +355,6 @@ public:
     IMPLEMENT_TYPEID(ACOS)
     //! ACos Constructor
     ACos(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acos
@@ -252,12 +371,6 @@ public:
     IMPLEMENT_TYPEID(ASEC)
     //! ASec Constructor
     ASec(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized asec
@@ -274,12 +387,6 @@ public:
     IMPLEMENT_TYPEID(ACSC)
     //! ACsc Constructor
     ACsc(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acsc
@@ -296,12 +403,6 @@ public:
     IMPLEMENT_TYPEID(ATAN)
     //! ATan Constructor
     ATan(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized atan
@@ -318,12 +419,6 @@ public:
     IMPLEMENT_TYPEID(ACOT)
     //! ACot Constructor
     ACot(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acot
@@ -333,86 +428,55 @@ public:
 //! Canonicalize ACot:
 RCP<const Basic> acot(const RCP<const Basic> &arg);
 
-class ATan2 : public Function
+class ATan2 : public TwoArgFunction
 {
-private:
-    RCP<const Basic> num_; //! The `y` in `atan2(y, x)`
-    RCP<const Basic> den_; //! The `x` in `atan2(y, x)`
 public:
     IMPLEMENT_TYPEID(ATAN2)
     //! ATan2 Constructor
     ATan2(const RCP<const Basic> &num, const RCP<const Basic> &den);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &num,
                       const RCP<const Basic> &den) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `y` in `atan2(y, x)`
     inline RCP<const Basic> get_num() const
     {
-        return num_;
+        return get_arg1();
     }
     //! \return `x` in `atan2(y, x)`
     inline RCP<const Basic> get_den() const
     {
-        return den_;
+        return get_arg2();
     }
-
-    virtual vec_basic get_args() const
-    {
-        return {num_, den_};
-    }
+    //! \return canonicalized `atan2`
+    virtual RCP<const Basic> create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const;
 };
 
 //! Canonicalize ATan2:
 RCP<const Basic> atan2(const RCP<const Basic> &num,
                        const RCP<const Basic> &den);
 
-class LambertW : public Function
+class LambertW : public OneArgFunction
 {
     // Lambert W function, defined as the inverse function of
     // x*exp(x). This function represents the principal branch
     // of this inverse function, which is multivalued.
     // For more information, see:
     // http://en.wikipedia.org/wiki/Lambert_W_function
-private:
-    RCP<const Basic> arg_;
-
 public:
     IMPLEMENT_TYPEID(LAMBERTW)
     //! LambertW Constructor
     LambertW(const RCP<const Basic> &arg);
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
-    /*! Equality comparator
-     * \param o  Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return `arg_`
-    inline RCP<const Basic> get_arg() const
-    {
-        return arg_;
-    }
-    virtual vec_basic get_args() const
-    {
-        return {arg_};
-    }
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
+    //! \return canonicalized lambertw
+    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
 
 //! Create a new LambertW instance:
 RCP<const Basic> lambertw(const RCP<const Basic> &arg);
 
-class Zeta : public Function
+class Zeta : public TwoArgFunction
 {
     // Hurwitz zeta function (or Riemann zeta function).
     //
@@ -425,80 +489,52 @@ class Zeta : public Function
     // If no value is passed for :math:`a`, by this function assumes a default
     // value
     // of :math:`a = 1`, yielding the Riemann zeta function.
-
-private:
-    RCP<const Basic> s_;
-    RCP<const Basic> a_;
-
 public:
     IMPLEMENT_TYPEID(ZETA)
     //! Zeta Constructor
     Zeta(const RCP<const Basic> &s, const RCP<const Basic> &a);
     //! Zeta Constructor
     Zeta(const RCP<const Basic> &s);
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
-    /*! Equality comparator
-     * \param o  Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `s_`
     inline RCP<const Basic> get_s() const
     {
-        return s_;
+        return get_arg1();
     }
     //! \return `a_`
     inline RCP<const Basic> get_a() const
     {
-        return a_;
-    }
-    virtual vec_basic get_args() const
-    {
-        return {s_, a_};
+        return get_arg2();
     }
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &s,
                       const RCP<const Basic> &a) const;
+    //! \return canonicalized `zeta`
+    virtual RCP<const Basic> create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const;
 };
 
 //! Create a new Zeta instance:
 RCP<const Basic> zeta(const RCP<const Basic> &s, const RCP<const Basic> &a);
 RCP<const Basic> zeta(const RCP<const Basic> &s);
 
-class Dirichlet_eta : public Function
+class Dirichlet_eta : public OneArgFunction
 {
     // See http://en.wikipedia.org/wiki/Dirichlet_eta_function
-
-private:
-    RCP<const Basic> s_;
-
 public:
     IMPLEMENT_TYPEID(DIRICHLET_ETA)
     //! Dirichlet_eta Constructor
     Dirichlet_eta(const RCP<const Basic> &s);
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
-    /*! Equality comparator
-     * \param o  Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return `s_`
+    //! \return `s`
     inline RCP<const Basic> get_s() const
     {
-        return s_;
-    }
-    virtual vec_basic get_args() const
-    {
-        return {s_};
+        return get_arg();
     }
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &s) const;
     //! Rewrites in the form of zeta
     RCP<const Basic> rewrite_as_zeta() const;
+    //! \return Canonicalized zeta
+    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
 
 //! Create a new Dirichlet_eta instance:
@@ -651,29 +687,11 @@ public:
     virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 };
 
-class HyperbolicFunction : public Function
+class HyperbolicFunction : public OneArgFunction
 {
-
-private:
-    RCP<const Basic> arg_; //! The `arg` in `hyperbolicclass(arg)`
 public:
     //! Constructor
-    HyperbolicFunction(RCP<const Basic> arg) : arg_{arg} {};
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
-    //! \return `arg_`
-    inline RCP<const Basic> get_arg() const
-    {
-        return arg_;
-    }
-    virtual vec_basic get_args() const
-    {
-        return {arg_};
-    }
-    //! Method to construct classes with canonicalization
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
-    //! Substitute with `subs_dict`
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    HyperbolicFunction(RCP<const Basic> arg) : OneArgFunction{arg} {};
 };
 
 class Sinh : public HyperbolicFunction
@@ -683,12 +701,6 @@ public:
     IMPLEMENT_TYPEID(SINH)
     //! Sinh Constructor
     Sinh(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sinh
@@ -707,13 +719,6 @@ public:
     IMPLEMENT_TYPEID(CSCH)
     //! Csch Constructor
     Csch(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    //! Compares `arg` with `o` returns greater than, equal or less than
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized csch
@@ -732,12 +737,6 @@ public:
     IMPLEMENT_TYPEID(COSH)
     //! Cosh Constructor
     Cosh(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized cosh
@@ -756,13 +755,6 @@ public:
     IMPLEMENT_TYPEID(SECH)
     //! Sech Constructor
     Sech(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    //! Compares `arg` with `o` returns greater than, equal or less than
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sech
@@ -781,12 +773,6 @@ public:
     IMPLEMENT_TYPEID(TANH)
     //! Tanh Constructor
     Tanh(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized tanh
@@ -805,12 +791,6 @@ public:
     IMPLEMENT_TYPEID(COTH)
     //! Coth Constructor
     Coth(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized coth
@@ -829,12 +809,6 @@ public:
     IMPLEMENT_TYPEID(ASINH)
     //! ASinh Constructor
     ASinh(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized asinh
@@ -851,12 +825,6 @@ public:
     IMPLEMENT_TYPEID(ACSCH)
     //! ACsch Constructor
     ACsch(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acsch
@@ -873,12 +841,6 @@ public:
     IMPLEMENT_TYPEID(ACOSH)
     //! ACosh Constructor
     ACosh(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acosh
@@ -895,12 +857,6 @@ public:
     IMPLEMENT_TYPEID(ATANH)
     //! ATanh Constructor
     ATanh(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized atanh
@@ -917,12 +873,6 @@ public:
     IMPLEMENT_TYPEID(ACOTH)
     //! ACoth Constructor
     ACoth(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acoth
@@ -939,12 +889,6 @@ public:
     IMPLEMENT_TYPEID(ASECH)
     //! ASech Constructor
     ASech(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized asech
@@ -954,7 +898,7 @@ public:
 //! Canonicalize ASech:
 RCP<const Basic> asech(const RCP<const Basic> &arg);
 
-class KroneckerDelta : public Function
+class KroneckerDelta : public TwoArgFunction
 {
     /*! The discrete, or Kronecker, delta function.
      * A function that takes in two integers `i` and `j`. It returns `0` if `i`
@@ -962,37 +906,23 @@ class KroneckerDelta : public Function
      * not equal or it returns `1` if `i` and `j` are equal.
      * http://en.wikipedia.org/wiki/Kronecker_delta
      **/
-private:
-    RCP<const Basic> i_;
-    RCP<const Basic> j_;
-
 public:
     IMPLEMENT_TYPEID(KRONECKERDELTA)
     //! KroneckerDelta Constructor
     KroneckerDelta(const RCP<const Basic> &i, const RCP<const Basic> &j);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &i,
                       const RCP<const Basic> &j) const;
-    virtual vec_basic get_args() const
-    {
-        return {i_, j_};
-    }
-    RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    //! \return canonicalized `KroneckerDelta`
+    virtual RCP<const Basic> create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const;
 };
 
 //! Canonicalize KroneckerDelta:
 RCP<const Basic> kronecker_delta(const RCP<const Basic> &i,
                                  const RCP<const Basic> &j);
 
-class LeviCivita : public Function
+class LeviCivita : public MultiArgFunction
 {
     /*! Represent the Levi-Civita symbol.
      *  For even permutations of indices it returns 1, for odd permutations -1,
@@ -1001,33 +931,20 @@ class LeviCivita : public Function
      *
      *  Thus it represents an alternating pseudotensor.
      **/
-private:
-    vec_basic arg_;
-
 public:
     IMPLEMENT_TYPEID(LEVICIVITA)
     //! LeviCivita Constructor
     LeviCivita(const vec_basic &&arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
-    virtual vec_basic get_args() const
-    {
-        return arg_;
-    }
+    //! \return canonicalized Max
+    virtual RCP<const Basic> create(const vec_basic &arg) const;
 };
 
 //! Canonicalize LeviCivita:
 RCP<const Basic> levi_civita(const vec_basic &arg);
 
-class Erf : public Function
+class Erf : public OneArgFunction
 {
     /*   The Gauss error function. This function is defined as:
      *
@@ -1035,37 +952,23 @@ class Erf : public Function
      *      \mathrm{erf}(x) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2}
      *\mathrm{d}t.
      **/
-private:
-    RCP<const Basic> arg_;
-
 public:
     IMPLEMENT_TYPEID(ERF)
     //! Erf Constructor
-    Erf(const RCP<const Basic> &arg) : arg_{arg}
+    Erf(const RCP<const Basic> &arg) : OneArgFunction(arg)
     {
-        SYMENGINE_ASSERT(is_canonical(arg_))
+        SYMENGINE_ASSERT(is_canonical(arg))
     }
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    virtual vec_basic get_args() const
-    {
-        return {arg_};
-    }
-    RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    //! \return Canonicalized erf
+    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
 
 //! Canonicalize Erf:
 RCP<const Basic> erf(const RCP<const Basic> &arg);
 
-class Gamma : public Function
+class Gamma : public OneArgFunction
 {
     /*!    The gamma function
      *
@@ -1077,138 +980,81 @@ class Gamma : public Function
      *  an integer. More general, `\Gamma(z)` is defined in the whole complex
      *  plane except at the negative integers where there are simple poles.
      **/
-private:
-    RCP<const Basic> arg_;
-
 public:
     IMPLEMENT_TYPEID(GAMMA)
     //! Gamma Constructor
     Gamma(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    virtual vec_basic get_args() const
-    {
-        return {arg_};
-    }
-    //! Substitute with `subs_dict`
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    //! \return Canonicalized gamma
+    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
 
 //! Canonicalize Gamma:
 RCP<const Basic> gamma(const RCP<const Basic> &arg);
 
-class LowerGamma : public Function
+class LowerGamma : public TwoArgFunction
 {
     //! The lower incomplete gamma function.
-private:
-    RCP<const Basic> s_;
-    RCP<const Basic> x_;
-
 public:
     IMPLEMENT_TYPEID(LOWERGAMMA)
     //! LowerGamma Constructor
     LowerGamma(const RCP<const Basic> &s, const RCP<const Basic> &x);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &s,
                       const RCP<const Basic> &x) const;
-    virtual vec_basic get_args() const
-    {
-        return {s_, x_};
-    }
-    RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    //! \return canonicalized `LowerGamma`
+    virtual RCP<const Basic> create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const;
 };
 
 //! Canonicalize LowerGamma:
 RCP<const Basic> lowergamma(const RCP<const Basic> &s,
                             const RCP<const Basic> &x);
 
-class UpperGamma : public Function
+class UpperGamma : public TwoArgFunction
 {
     //! The upper incomplete gamma function.
-private:
-    RCP<const Basic> s_;
-    RCP<const Basic> x_;
-
 public:
     IMPLEMENT_TYPEID(UPPERGAMMA)
     //! UpperGamma Constructor
     UpperGamma(const RCP<const Basic> &s, const RCP<const Basic> &x);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &s,
                       const RCP<const Basic> &x) const;
-    virtual vec_basic get_args() const
-    {
-        return {s_, x_};
-    }
-    RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    //! \return canonicalized `UpperGamma`
+    virtual RCP<const Basic> create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const;
 };
 
 //! Canonicalize UpperGamma:
 RCP<const Basic> uppergamma(const RCP<const Basic> &s,
                             const RCP<const Basic> &x);
 
-class LogGamma : public Function
+class LogGamma : public OneArgFunction
 {
     /*!    The loggamma function
         The `loggamma` function implements the logarithm of the
         gamma function i.e, `\log\Gamma(x)`.
      **/
-private:
-    RCP<const Basic> arg_;
-
 public:
     IMPLEMENT_TYPEID(LOGGAMMA)
     //! LogGamma Constructor
-    LogGamma(const RCP<const Basic> &arg) : arg_{arg}
+    LogGamma(const RCP<const Basic> &arg) : OneArgFunction(arg)
     {
-        SYMENGINE_ASSERT(is_canonical(arg_))
+        SYMENGINE_ASSERT(is_canonical(arg))
     }
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    virtual vec_basic get_args() const
-    {
-        return {arg_};
-    }
-    RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
     RCP<const Basic> rewrite_as_gamma() const;
+    //! \return canonicalized loggamma
+    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
 
 //! Canonicalize LogGamma:
 RCP<const Basic> loggamma(const RCP<const Basic> &arg);
 
-class Beta : public Function
+class Beta : public TwoArgFunction
 {
     /*!    The beta function, also called the Euler integral
      *     of the first kind, is a special function defined by
@@ -1216,42 +1062,29 @@ class Beta : public Function
      *   .. math::
      *      \Beta(x, y) := \int^{1}_{0} t^{x-1} (1-t)^{y-1} \mathrm{d}t.
      **/
-private:
-    RCP<const Basic> x_;
-    RCP<const Basic> y_;
-
 public:
     IMPLEMENT_TYPEID(BETA)
     //! Beta Constructor
-    Beta(const RCP<const Basic> &x, const RCP<const Basic> &y) : x_{x}, y_{y}
+    Beta(const RCP<const Basic> &x, const RCP<const Basic> &y)
+        : TwoArgFunction(x, y)
     {
-        SYMENGINE_ASSERT(is_canonical(x_, y_))
+        SYMENGINE_ASSERT(is_canonical(x, y))
     }
     //! return `Beta` with ordered arguments
     static RCP<const Beta> from_two_basic(const RCP<const Basic> &x,
                                           const RCP<const Basic> &y);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &s, const RCP<const Basic> &x);
-    virtual vec_basic get_args() const
-    {
-        return {x_, y_};
-    }
     RCP<const Basic> rewrite_as_gamma() const;
-    RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    //! \return canonicalized `Beta`
+    virtual RCP<const Basic> create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const;
 };
 
 //! Canonicalize Beta:
 RCP<const Basic> beta(const RCP<const Basic> &x, const RCP<const Basic> &y);
 
-class PolyGamma : public Function
+class PolyGamma : public TwoArgFunction
 {
     /*!    The polygamma function
      *
@@ -1263,122 +1096,68 @@ class PolyGamma : public Function
      *  \psi^{(n)} (z) := \frac{\mathrm{d}^{n+1}}{\mathrm{d} z^{n+1}}
      *\log\Gamma(z).
      **/
-private:
-    RCP<const Basic> n_;
-    RCP<const Basic> x_;
-
 public:
     IMPLEMENT_TYPEID(POLYGAMMA)
     //! PolyGamma Constructor
     PolyGamma(const RCP<const Basic> &n, const RCP<const Basic> &x)
-        : n_{n}, x_{x}
+        : TwoArgFunction(n, x)
     {
-        SYMENGINE_ASSERT(is_canonical(n_, x_))
+        SYMENGINE_ASSERT(is_canonical(n, x))
     }
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     bool is_canonical(const RCP<const Basic> &n, const RCP<const Basic> &x);
-    virtual vec_basic get_args() const
-    {
-        return {n_, x_};
-    }
     RCP<const Basic> rewrite_as_zeta() const;
-    //! Substitute with `subs_dict`
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    //! \return canonicalized `PolyGamma`
+    virtual RCP<const Basic> create(const RCP<const Basic> &a,
+                                    const RCP<const Basic> &b) const;
 };
 
 //! Canonicalize PolyGamma
 RCP<const Basic> polygamma(const RCP<const Basic> &n,
                            const RCP<const Basic> &x);
 
-class Abs : public Function
+class Abs : public OneArgFunction
 {
     /*!    The absolute value function
      **/
-private:
-    RCP<const Basic> arg_;
-
 public:
     IMPLEMENT_TYPEID(ABS)
     //! Abs Constructor
     Abs(const RCP<const Basic> &arg);
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
-    inline RCP<const Basic> get_arg() const
-    {
-        return arg_;
-    }
-    virtual vec_basic get_args() const
-    {
-        return {arg_};
-    }
+    //! \return canonicalized abs
+    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
 
 //! Canonicalize Abs:
 RCP<const Basic> abs(const RCP<const Basic> &arg);
 
-class Max : public Function
+class Max : public MultiArgFunction
 {
-
-private:
-    vec_basic arg_;
-
 public:
     IMPLEMENT_TYPEID(MAX)
     //! Max Constructor
     Max(const vec_basic &&arg);
-
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
-    inline vec_basic get_args() const
-    {
-        return arg_;
-    }
+    //! \return canonicalized Max
+    virtual RCP<const Basic> create(const vec_basic &arg) const;
 };
 
 //! Canonicalize Max:
 RCP<const Basic> max(const vec_basic &arg);
 
-class Min : public Function
+class Min : public MultiArgFunction
 {
-
-private:
-    vec_basic arg_;
-
 public:
     IMPLEMENT_TYPEID(MIN)
     //! Min Constructor
     Min(const vec_basic &&arg);
     Min(const RCP<const Basic> &arg, ...);
-
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
-    inline vec_basic get_args() const
-    {
-        return arg_;
-    }
+    //! \return canonicalized Max
+    virtual RCP<const Basic> create(const vec_basic &arg) const;
 };
 
 //! Canonicalize Min:

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -495,46 +495,6 @@ void Mul::power_num(const Ptr<RCP<const Number>> &coef, map_basic_basic &d,
     }
 }
 
-RCP<const Basic> Mul::subs(const map_basic_basic &subs_dict) const
-{
-    RCP<const Mul> self = rcp_from_this_cast<const Mul>();
-    auto it = subs_dict.find(self);
-    if (it != subs_dict.end())
-        return it->second;
-
-    RCP<const Number> coef = coef_;
-    map_basic_basic d;
-    for (const auto &p : dict_) {
-        RCP<const Basic> factor_old;
-        if (eq(*p.second, *one)) {
-            factor_old = p.first;
-        } else {
-            factor_old = make_rcp<Pow>(p.first, p.second);
-        }
-        RCP<const Basic> factor = factor_old->subs(subs_dict);
-        if (factor == factor_old) {
-            // TODO: Check if Mul::dict_add_term is enough
-            Mul::dict_add_term_new(outArg(coef), d, p.second, p.first);
-        } else if (is_a_Number(*factor)) {
-            if (rcp_static_cast<const Number>(factor)->is_zero()) {
-                return factor;
-            }
-            imulnum(outArg(coef), rcp_static_cast<const Number>(factor));
-        } else if (is_a<Mul>(*factor)) {
-            RCP<const Mul> tmp = rcp_static_cast<const Mul>(factor);
-            imulnum(outArg(coef), tmp->coef_);
-            for (const auto &q : tmp->dict_) {
-                Mul::dict_add_term_new(outArg(coef), d, q.second, q.first);
-            }
-        } else {
-            RCP<const Basic> exp, t;
-            Mul::as_base_exp(factor, outArg(exp), outArg(t));
-            Mul::dict_add_term_new(outArg(coef), d, exp, t);
-        }
-    }
-    return Mul::from_dict(coef, std::move(d));
-}
-
 vec_basic Mul::get_args() const
 {
     vec_basic args;

--- a/symengine/mul.h
+++ b/symengine/mul.h
@@ -61,7 +61,6 @@ public:
     //! \return true if both `coef` and `dict` are in canonical form
     bool is_canonical(const RCP<const Number> &coef,
                       const map_basic_basic &dict) const;
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     virtual vec_basic get_args() const;
 };

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -255,20 +255,6 @@ void multinomial_coefficients_mpz(int m, int n, map_vec_mpz &r)
     }
 }
 
-RCP<const Basic> Pow::subs(const map_basic_basic &subs_dict) const
-{
-    RCP<const Pow> self = rcp_from_this_cast<const Pow>();
-    auto it = subs_dict.find(self);
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> base_new = base_->subs(subs_dict);
-    RCP<const Basic> exp_new = exp_->subs(subs_dict);
-    if (base_new == base_ and exp_new == exp_)
-        return self;
-    else
-        return pow(base_new, exp_new);
-}
-
 vec_basic Pow::get_args() const
 {
     return {base_, exp_};

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -279,7 +279,7 @@ RCP<const Basic> exp(const RCP<const Basic> &x)
     return pow(E, x);
 }
 
-Log::Log(const RCP<const Basic> &arg) : arg_{arg}
+Log::Log(const RCP<const Basic> &arg) : OneArgFunction(arg)
 {
     SYMENGINE_ASSERT(is_canonical(*arg))
 }
@@ -307,40 +307,9 @@ bool Log::is_canonical(const Basic &arg) const
     return true;
 }
 
-std::size_t Log::__hash__() const
+RCP<const Basic> Log::create(const RCP<const Basic> &a) const
 {
-    std::size_t seed = LOG;
-    hash_combine<Basic>(seed, *arg_);
-    return seed;
-}
-
-bool Log::__eq__(const Basic &o) const
-{
-    if (is_a<Log>(o) and eq(*arg_, *(static_cast<const Log &>(o).get_arg())))
-        return true;
-
-    return false;
-}
-
-int Log::compare(const Basic &o) const
-{
-    SYMENGINE_ASSERT(is_a<Log>(o))
-    const Log &s = static_cast<const Log &>(o);
-    return arg_->__cmp__(*s.get_arg());
-}
-
-RCP<const Basic> Log::subs(const map_basic_basic &subs_dict) const
-{
-    RCP<const Log> self = rcp_from_this_cast<const Log>();
-    auto it = subs_dict.find(self);
-    if (it != subs_dict.end())
-        return it->second;
-    RCP<const Basic> arg_new = arg_->subs(subs_dict);
-    if (arg_new == arg_) {
-        return self;
-    } else {
-        return log(arg_new);
-    }
+    return log(a);
 }
 
 RCP<const Basic> log(const RCP<const Basic> &arg)

--- a/symengine/pow.h
+++ b/symengine/pow.h
@@ -46,7 +46,6 @@ public:
     {
         return exp_;
     }
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
 
     virtual vec_basic get_args() const;
 };

--- a/symengine/pow.h
+++ b/symengine/pow.h
@@ -67,38 +67,19 @@ inline RCP<const Basic> sqrt(const RCP<const Basic> &x)
     return pow(x, div(one, integer(2)));
 }
 
-class Log : public Function
+class Log : public OneArgFunction
 {
     // Logarithms are taken with the natural base, `e`. To get
     // a logarithm of a different base `b`, use `log(x, b)`,
     // which is essentially short-hand for `log(x)/log(b)`.
-private:
-    RCP<const Basic> arg_; //! The `arg` in `log(arg)`
-
 public:
     IMPLEMENT_TYPEID(LOG)
     //! Log Constructor
     Log(const RCP<const Basic> &arg);
-    //! \return Size of the hash
-    virtual std::size_t __hash__() const;
-    /*! Equality comparator
-     * \param o - Object to be compared with
-     * \return whether the 2 objects are equal
-     * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
     //! \return `true` if canonical
     bool is_canonical(const Basic &arg) const;
-    //! \return `arg` of `log(arg)`
-    inline RCP<const Basic> get_arg() const
-    {
-        return arg_;
-    }
-    virtual vec_basic get_args() const
-    {
-        return {arg_};
-    }
-    virtual RCP<const Basic> subs(const map_basic_basic &subs_dict) const;
+    //! \return canonicalized `log`
+    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };
 
 //! Returns the Natural Logarithm from argument `arg`

--- a/symengine/subs.h
+++ b/symengine/subs.h
@@ -140,7 +140,6 @@ public:
 
     void bvisit(const Derivative &x)
     {
-
         RCP<const Symbol> s;
         map_basic_basic m, n;
         bool subs;
@@ -255,6 +254,22 @@ public:
         result_ = x.rcp_from_this();
     }
 };
+
+//! Mappings in the `subs_dict` are applied to the expression tree of `x`
+inline RCP<const Basic> subs(const RCP<const Basic> &x,
+                             const map_basic_basic &subs_dict)
+{
+    SubsVisitor s(subs_dict);
+    return s.apply(x);
+}
+
+//! Subs which treat f(t) and Derivative(f(t), t) as separate variables
+inline RCP<const Basic> msubs(const RCP<const Basic> &x,
+                              const map_basic_basic &subs_dict)
+{
+    MSubsVisitor s(subs_dict);
+    return s.apply(x);
+}
 
 } // namespace SymEngine
 

--- a/symengine/subs.h
+++ b/symengine/subs.h
@@ -1,0 +1,229 @@
+#ifndef SYMENGINE_SUBS_H
+#define SYMENGINE_SUBS_H
+
+#include <symengine/visitor.h>
+
+namespace SymEngine
+{
+
+class SubsVisitor : public BaseVisitor<SubsVisitor>
+{
+protected:
+    RCP<const Basic> result_;
+    const map_basic_basic& subs_dict_;
+
+public:
+    SubsVisitor(const map_basic_basic &subs_dict) : subs_dict_(subs_dict) {
+    }
+    // TODO : Polynomials, Series, Sets
+    void bvisit(const Basic &x)
+    {
+        result_ = x.rcp_from_this();
+    }
+    void bvisit(const Add &x)
+    {
+        SymEngine::umap_basic_num d;
+        RCP<const Number> coef;
+
+        auto it = subs_dict_.find(x.coef_);
+        if (it != subs_dict_.end()) {
+            coef = zero;
+            Add::coef_dict_add_term(outArg(coef), d, one, it->second);
+        } else {
+            coef = x.coef_;
+        }
+
+        for (const auto &p : x.dict_) {
+            auto it
+                = subs_dict_.find(Add::from_dict(zero, {{p.first, p.second}}));
+            if (it != subs_dict_.end()) {
+                Add::coef_dict_add_term(outArg(coef), d, one, it->second);
+            } else {
+                it = subs_dict_.find(p.second);
+                if (it != subs_dict_.end()) {
+                    Add::coef_dict_add_term(outArg(coef), d, one,
+                                       mul(it->second, apply(p.first)));
+                } else {
+                    Add::coef_dict_add_term(outArg(coef), d, p.second,
+                                       apply(p.first));
+                }
+            }
+        }
+        result_ = Add::from_dict(coef, std::move(d));
+    }
+    void bvisit(const Mul &x)
+    {
+        RCP<const Number> coef = x.coef_;
+        map_basic_basic d;
+        for (const auto &p : x.dict_) {
+            RCP<const Basic> factor_old;
+            if (eq(*p.second, *one)) {
+                factor_old = p.first;
+            } else {
+                factor_old = make_rcp<Pow>(p.first, p.second);
+            }
+            RCP<const Basic> factor = apply(factor_old);
+            if (factor == factor_old) {
+                // TODO: Check if Mul::dict_add_term is enough
+                Mul::dict_add_term_new(outArg(coef), d, p.second, p.first);
+            } else if (is_a_Number(*factor)) {
+                if (rcp_static_cast<const Number>(factor)->is_zero()) {
+                    result_ = factor;
+                    return;
+                }
+                imulnum(outArg(coef), rcp_static_cast<const Number>(factor));
+            } else if (is_a<Mul>(*factor)) {
+                RCP<const Mul> tmp = rcp_static_cast<const Mul>(factor);
+                imulnum(outArg(coef), tmp->coef_);
+                for (const auto &q : tmp->dict_) {
+                    Mul::dict_add_term_new(outArg(coef), d, q.second, q.first);
+                }
+            } else {
+                RCP<const Basic> exp, t;
+                Mul::as_base_exp(factor, outArg(exp), outArg(t));
+                Mul::dict_add_term_new(outArg(coef), d, exp, t);
+            }
+        }
+        result_ = Mul::from_dict(coef, std::move(d));
+    }
+    void bvisit(const Pow &x)
+    {
+        RCP<const Basic> base_new = apply(x.get_base());
+        RCP<const Basic> exp_new = apply(x.get_exp());
+        if (base_new == x.get_base() and exp_new == x.get_exp())
+            result_ = x.rcp_from_this();
+        else
+            result_ = pow(base_new, exp_new);
+    }
+    void bvisit(const OneArgFunction &x)
+    {
+        apply(x.get_arg());
+        if (result_ == x.get_arg()) {
+            result_ = x.rcp_from_this();
+        } else {
+            result_ = x.create(result_);
+        }
+    }
+    void bvisit(const TwoArgFunction &x)
+    {
+        RCP<const Basic> a = apply(x.get_arg1());
+        RCP<const Basic> b = apply(x.get_arg2());
+        if (a == x.get_arg1() and b == x.get_arg2())
+            result_ = x.rcp_from_this();
+        else
+            result_ = x.create(a, b);
+    }
+    void bvisit(const MultiArgFunction &x) {
+        vec_basic v = x.get_args();
+        for (auto &elem : v) {
+            elem = apply(elem);
+        }
+        result_ = x.create(v);
+    }
+    void bvisit(const FunctionSymbol &x) {
+        vec_basic v = x.get_args();
+        for (auto &elem : v) {
+            elem = apply(elem);
+        }
+        result_ = x.create(v);
+    }
+    void bvisit(const Derivative &x) {
+
+        RCP<const Symbol> s;
+        map_basic_basic m, n;
+        bool subs;
+        for (const auto &p : subs_dict_) {
+            subs = true;
+            if (eq(*x.get_arg()->subs({{p.first, p.second}}), *x.get_arg()))
+                continue;
+            // If p.first and p.second are symbols and arg_ is
+            // independent of p.second, p.first can be replaced
+            if (is_a<Symbol>(*p.first) and is_a<Symbol>(*p.second)
+                and eq(*x.get_arg()->diff(rcp_static_cast<const Symbol>(p.second)),
+                       *zero)) {
+                insert(n, p.first, p.second);
+                continue;
+            }
+            for (const auto &d : x.get_symbols()) {
+                if (is_a<Symbol>(*d)) {
+                    s = rcp_static_cast<const Symbol>(d);
+                    // If p.first or p.second has non zero derivates wrt to s
+                    // p.first cannot be replaced
+                    if (neq(*zero, *(p.first->diff(s)))
+                        || neq(*zero, *(p.second->diff(s)))) {
+                        subs = false;
+                        break;
+                    }
+                } else {
+                    result_ = make_rcp<const Subs>(x.rcp_from_this(), subs_dict_);
+                    return;
+                }
+            }
+            if (subs) {
+                insert(n, p.first, p.second);
+            } else {
+                insert(m, p.first, p.second);
+            }
+        }
+        multiset_basic sym;
+        for (auto &p : x.get_symbols()) {
+            sym.insert(p->subs(n));
+        }
+        if (m.empty()) {
+            result_ = Derivative::create(x.get_arg()->subs(n), sym);
+        } else {
+            result_ = make_rcp<const Subs>(Derivative::create(x.get_arg()->subs(n), sym), m);
+        }
+
+    }
+
+    void bvisit(const Subs &x) {
+        map_basic_basic m, n;
+        for (const auto &p : subs_dict_) {
+            bool found = false;
+            for (const auto &s : x.get_dict()) {
+                if (neq(*(s.first->subs({{p.first, p.second}})), *(s.first))) {
+                    found = true;
+                    break;
+                }
+            }
+            // If p.first is not replaced in arg_ by dict_,
+            // store p.first in n to replace in arg_
+            if (not found) {
+                insert(n, p.first, p.second);
+            }
+        }
+        for (const auto &s : x.get_dict()) {
+            insert(m, s.first, apply(s.second));
+        }
+        RCP<const Basic> presub = x.get_arg()->subs(n);
+        if (is_a<Subs>(*presub)) {
+            for (auto &q : static_cast<const Subs &>(*presub).get_dict()) {
+                insert(m, q.first, q.second);
+            }
+            result_ = make_rcp<const Subs>(static_cast<const Subs &>(*presub).get_arg(), m);
+        } else {
+            result_ = make_rcp<const Subs>(presub, m);
+        }
+    }
+
+    RCP<const Basic> apply(const Basic &x)
+    {
+        return apply(x.rcp_from_this());
+    }
+
+    RCP<const Basic> apply(const RCP<const Basic> &x)
+    {
+        auto it = subs_dict_.find(x);
+        if (it != subs_dict_.end()) {
+            result_ = it->second;
+        } else {
+            x->accept(*this);
+        }
+        return result_;
+    }
+};
+
+} // namespace SymEngine
+
+#endif // SYMENGINE_SUBS_H

--- a/symengine/tests/basic/test_subs.cpp
+++ b/symengine/tests/basic/test_subs.cpp
@@ -12,6 +12,7 @@
 #include <symengine/functions.h>
 #include <symengine/constants.h>
 #include <symengine/real_double.h>
+#include <symengine/subs.h>
 
 using SymEngine::Basic;
 using SymEngine::Add;
@@ -35,6 +36,8 @@ using SymEngine::print_stack_on_segfault;
 using SymEngine::real_double;
 using SymEngine::kronecker_delta;
 using SymEngine::levi_civita;
+using SymEngine::msubs;
+using SymEngine::function_symbol;
 
 TEST_CASE("Symbol: subs", "[subs]")
 {
@@ -436,4 +439,17 @@ TEST_CASE("Beta: subs", "[subs]")
     d[z] = i2;
     d[y] = i2;
     REQUIRE(eq(*r1->subs(d), *beta(i2, add(i2, x))));
+}
+
+TEST_CASE("MSubs: subs", "[subs]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Basic> y = symbol("y");
+    RCP<const Basic> f = function_symbol("f", x);
+
+    auto t = msubs(f->diff(x), {{f, y}});
+    REQUIRE(eq(*t, *f->diff(x)));
+
+    t = msubs(f->diff(x), {{f->diff(x), y}});
+    REQUIRE(eq(*t, *y));
 }

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -41,12 +41,29 @@ public:
 void preorder_traversal(const Basic &b, Visitor &v);
 void postorder_traversal(const Basic &b, Visitor &v);
 
+template <bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
 template <class Derived, class Base = Visitor>
 class BaseVisitor : public Base
 {
 
 public:
-    using Base::Base;
+    // Following two ctors can be replaced by `using Base::Base` if inheriting
+    // constructors are allowed by the compiler. GCC 4.8 is the latest version
+    // supporting this.
+    template <typename... Args,
+              typename
+              = enable_if_t<std::is_constructible<Base, Args...>::value>>
+    BaseVisitor(Args &&... args)
+        : Base(std::forward<Args>(args)...)
+    {
+    }
+
+    BaseVisitor() : Base()
+    {
+    }
+
 #define SYMENGINE_ENUM(TypeID, Class)                                          \
     virtual void visit(const Class &x)                                         \
     {                                                                          \

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -46,6 +46,7 @@ class BaseVisitor : public Base
 {
 
 public:
+    using Base::Base;
 #define SYMENGINE_ENUM(TypeID, Class)                                          \
     virtual void visit(const Class &x)                                         \
     {                                                                          \


### PR DESCRIPTION
msubs is to be used as a replacement for `sympy.physics.mechanics.functions.msubs`
Depends on #923 