### PR TITLE
Minor changes in Univariate polynomials

### DIFF
--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -94,14 +94,10 @@ RCP<const UnivariateIntPolynomial>
 UnivariateIntPolynomial::from_dict(const RCP<const Symbol> &var,
                                    map_uint_mpz &&d)
 {
-    auto itter = d.begin();
-    while (itter != d.end()) {
-        if (integer_class(0) == itter->second) {
-            auto toErase = itter;
-            itter++;
+    for (auto iter = d.begin(); iter != d.end(); iter++) {
+        if (iter->second == 0) {
+            auto toErase = iter;
             d.erase(toErase);
-        } else {
-            itter++;
         }
     }
     unsigned int degree = 0;
@@ -443,14 +439,11 @@ UnivariatePolynomial::from_vec(const RCP<const Symbol> &var,
 RCP<const UnivariatePolynomial>
 UnivariatePolynomial::from_dict(const RCP<const Symbol> &var, map_int_Expr &&d)
 {
-    auto iter = d.begin();
-    while (iter != d.end()) {
-        if (Expression(0) == iter->second) {
+    for (auto iter = d.begin(); iter != d.end(); iter++) {
+        if (iter->second == 0) {
             auto toErase = iter;
-            iter++;
             d.erase(toErase);
-        } else
-            iter++;
+        }
     }
     int degree = 0;
     if (!d.empty())

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -39,8 +39,8 @@ bool UnivariateIntPolynomial::is_canonical(const unsigned int &degree_,
             return false;
 
     if (dict.size() != 0) {
-        unsigned int prev_degree = (--dict.end())->first;
-        if (prev_degree != degree_) {
+        unsigned int actual_degree = (--dict.end())->first;
+        if (actual_degree != degree_) {
             return false;
         }
     } else if (degree_ != 0)
@@ -48,7 +48,7 @@ bool UnivariateIntPolynomial::is_canonical(const unsigned int &degree_,
 
     // Check if dictionary contains terms with coeffienct 0
     for (auto iter : dict)
-        if (iter.second == 0)
+        if (iter.first != 0 and iter.second == 0)
             return false;
     return true;
 }
@@ -382,8 +382,8 @@ bool UnivariatePolynomial::is_canonical(const int &degree_,
             return false;
 
     if (dict.size() != 0) {
-        int prev_degree = (--dict.end())->first;
-        if (prev_degree != degree_) {
+        int actual_degree = (--dict.end())->first;
+        if (actual_degree != degree_) {
             return false;
         }
     } else if (degree_ != 0)

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -20,11 +20,15 @@ UnivariateIntPolynomial::UnivariateIntPolynomial(
     const RCP<const Symbol> &var, const std::vector<integer_class> &v)
     : var_{var}
 {
-    for (unsigned int i = 0; i < v.size(); i++)
-        if (v[i] != 0)
-            dict_add_term(dict_, v[i], i);
-    degree_ = v.size() - 1;
-    SYMENGINE_ASSERT(is_canonical(degree_, dict_))
+    dict_ = {};
+    unsigned int deg = 0;
+    for (unsigned int i = 0; i < v.size(); i++) {
+        if (v[i] != 0) {
+            dict_[i] = v[i];
+            deg = i;
+        }
+    }
+    degree_ = deg;
 }
 
 bool UnivariateIntPolynomial::is_canonical(const unsigned int &degree_,
@@ -111,15 +115,6 @@ UnivariateIntPolynomial::from_vec(const RCP<const Symbol> &var,
                                   const std::vector<integer_class> &v)
 {
     return make_rcp<const UnivariateIntPolynomial>(var, std::move(v));
-}
-
-void UnivariateIntPolynomial::dict_add_term(map_uint_mpz &d,
-                                            const integer_class &coef,
-                                            const unsigned int &n)
-{
-    auto it = d.find(n);
-    if (it == d.end())
-        d[n] = coef;
 }
 
 vec_basic UnivariateIntPolynomial::get_args() const
@@ -328,7 +323,7 @@ RCP<const UnivariateIntPolynomial> mul_poly(const UnivariateIntPolynomial &a,
         = bit_length(std::min(a.get_degree() + 1, b.get_degree() + 1))
           + bit_length(a.max_abs_coef()) + bit_length(b.max_abs_coef());
 
-    integer_class a1(1), b1;
+    integer_class a1(1), b1, res;
     a1 <<= N;
     integer_class a2 = a1 / 2;
     integer_class mask = a1 - 1;
@@ -368,11 +363,15 @@ UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
                                            const std::vector<Expression> &v)
     : var_{var}
 {
-    for (unsigned int i = 0; i < v.size(); i++)
-        if (v[i] != 0)
-            dict_add_term(dict_, v[i], i);
-    degree_ = v.size() - 1;
-    SYMENGINE_ASSERT(is_canonical(degree_, dict_))
+    dict_ = {};
+    unsigned int deg = 0;
+    for (unsigned int i = 0; i < v.size(); i++) {
+        if (v[i] != 0) {
+            dict_[i] = v[i];
+            deg = i;
+        }
+    }
+    degree_ = deg;
 }
 
 bool UnivariatePolynomial::is_canonical(const int &degree_,
@@ -457,14 +456,6 @@ UnivariatePolynomial::from_dict(const RCP<const Symbol> &var, map_int_Expr &&d)
     if (!d.empty())
         degree = (--(d.end()))->first;
     return make_rcp<const UnivariatePolynomial>(var, degree, std::move(d));
-}
-
-void UnivariatePolynomial::dict_add_term(map_int_Expr &d,
-                                         const Expression &coef, const int &n)
-{
-    auto it = d.find(n);
-    if (it == d.end())
-        d[n] = coef;
 }
 
 vec_basic UnivariatePolynomial::get_args() const

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -329,22 +329,30 @@ RCP<const UnivariateIntPolynomial> mul_poly(const UnivariateIntPolynomial &a,
 
     std::vector<integer_class> v;
     integer_class carry(0);
+    unsigned int deg = 0;
+    map_uint_mpz dict;
 
     while (r != 0 or carry != 0) {
         mp_and(b1, r, mask);
         if (b1 < a2) {
-            v.push_back(b1 + carry);
+            res = b1 + carry;
+            if (res != 0)
+                dict[deg] = res;
             carry = 0;
         } else {
-            v.push_back(b1 - a1 + carry);
+            res = b1 - a1 + carry;
+            if (res != 0)
+                dict[deg] = res;
             carry = 1;
         }
         r >>= N;
+        deg++;
     }
     if (neg)
-        return neg_poly(*UnivariateIntPolynomial::from_vec(var, v));
+        return neg_poly(
+            *UnivariateIntPolynomial::from_dict(var, std::move(dict)));
     else
-        return UnivariateIntPolynomial::from_vec(var, v);
+        return UnivariateIntPolynomial::from_dict(var, std::move(dict));
 }
 
 UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -21,14 +21,15 @@ UnivariateIntPolynomial::UnivariateIntPolynomial(
     : var_{var}
 {
     dict_ = {};
-    unsigned int deg = 0;
     for (unsigned int i = 0; i < v.size(); i++) {
         if (v[i] != 0) {
             dict_[i] = v[i];
-            deg = i;
         }
     }
-    degree_ = deg;
+    if (dict_.empty())
+        degree_ = 0;
+    else
+        degree_ = (--dict_.end())->first;
 }
 
 bool UnivariateIntPolynomial::is_canonical(const unsigned int &degree_,
@@ -48,7 +49,7 @@ bool UnivariateIntPolynomial::is_canonical(const unsigned int &degree_,
 
     // Check if dictionary contains terms with coeffienct 0
     for (auto iter : dict)
-        if (iter.first != 0 and iter.second == 0)
+        if (iter.second == 0)
             return false;
     return true;
 }
@@ -94,10 +95,14 @@ RCP<const UnivariateIntPolynomial>
 UnivariateIntPolynomial::from_dict(const RCP<const Symbol> &var,
                                    map_uint_mpz &&d)
 {
-    for (auto iter = d.begin(); iter != d.end(); iter++) {
+    auto iter = d.begin();
+    while (iter != d.end()) {
         if (iter->second == 0) {
             auto toErase = iter;
+            iter++;
             d.erase(toErase);
+        } else {
+            iter++;
         }
     }
     unsigned int degree = 0;
@@ -395,7 +400,7 @@ bool UnivariatePolynomial::is_canonical(const int &degree_,
 
     // Check if dictionary contains terms with coeffienct 0
     for (auto iter : dict)
-        if (iter.first != 0 and iter.second == 0)
+        if (iter.second == 0)
             return false;
     return true;
 }
@@ -447,10 +452,14 @@ UnivariatePolynomial::from_vec(const RCP<const Symbol> &var,
 RCP<const UnivariatePolynomial>
 UnivariatePolynomial::from_dict(const RCP<const Symbol> &var, map_int_Expr &&d)
 {
-    for (auto iter = d.begin(); iter != d.end(); iter++) {
-        if (iter->second == 0) {
+    auto iter = d.begin();
+    while (iter != d.end()) {
+        if (iter->second == Expression(0)) {
             auto toErase = iter;
+            iter++;
             d.erase(toErase);
+        } else {
+            iter++;
         }
     }
     int degree = 0;

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -63,8 +63,6 @@ public:
     /*!
     * Adds coef*var_**n to the dict_
     */
-    static void dict_add_term(map_uint_mpz &d, const integer_class &coef,
-                              const unsigned int &n);
     integer_class max_abs_coef() const;
     //! Evaluates the UnivariateIntPolynomial at value x
     integer_class eval(const integer_class &x) const;
@@ -156,8 +154,6 @@ public:
     /*!
     * Adds coef*var_**n to the dict_
     */
-    static void dict_add_term(map_int_Expr &d, const Expression &coef,
-                              const int &n);
     Expression max_coef() const;
     //! Evaluates the UnivariatePolynomial at value x
     Expression eval(const Expression &x) const;


### PR DESCRIPTION
- removed the unecessary `dict_add_term` function
- Also removed `SYMENGINE_ASSERT` from vector constructor, because the polynomial formed is guaranteed to be canonical
- UnivariateInt had an incorrect `is_canonical`, for the 0 polynomial
- minor formatting/style changes in `from_dict`
- `mul_poly` was initially constructing a redundant vector (which could be too inefficient for sparse polys) Now uses `from_dict`. Constructs the dictionary on the go

More minor changes to follow.
@isuruf @Sumith1896 