### PR TITLE
Structure change of UnivariateExprPolynomial and UnivariatePolynomial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ symengine/tests/eval/test_lambda_double
 symengine/tests/expression/test_expression
 symengine/tests/basic/test_series_expansion_UP
 symengine/tests/basic/test_series_expansion_URatP
+symengine/tests/basic/test_series_expansion_URatF
 
 # Benchmarks executables
 benchmarks/add1
@@ -104,6 +105,7 @@ benchmarks/expand7
 benchmarks/expand7_ginac
 benchmarks/series_expansion_sincos_piranha
 benchmarks/series_expansion_sinp
+benchmarks/series_expansion_sincos_flint
 
 #rubygem
 symengine/ruby/Gemfile.lock

--- a/benchmarks/series.cpp
+++ b/benchmarks/series.cpp
@@ -15,29 +15,145 @@ using SymEngine::rcp_dynamic_cast;
 using SymEngine::Expression;
 using SymEngine::UnivariatePolynomial;
 using SymEngine::UnivariateExprPolynomial;
+using SymEngine::map_int_Expr;
+using SymEngine::pow;
 
 int main(int argc, char *argv[])
 {
     SymEngine::print_stack_on_segfault();
 
     RCP<const Symbol> x = symbol("x");
-    std::vector<Expression> v;
-    int N;
-
-    N = 1000;
+    // std::vector<Expression> v, v2;
+    map_int_Expr p, q;
+    int N = 100000;
+    int N2 = 1000;
     for (int i = 0; i < N; ++i) {
-        Expression coef(i);
-        v.push_back(coef);
+        // Expression coef(i);
+        Expression coef(pow(x, integer(i)));
+        // v.push_back(coef);
+        p[i] = coef;
+    }
+    for (int j = 0; j < N2; ++j) {
+        // Expression coef(j);
+        Expression coef(pow(x, integer(j)));
+        // v2.push_back(coef);
+        q[j] = coef;
     }
 
-    UnivariateExprPolynomial c, p(UnivariatePolynomial::create(x, v));
+    // UnivariateExprPolynomial c, p(UnivariatePolynomial::create(x, v));
+    UnivariateExprPolynomial c, d, a, b, f, g, s, r, t, u, n, ep(p), epq(q);
+    UnivariateExprPolynomial e({{0, Expression(7)}});
+    Expression coeff(7);
+
+    // ep += ep
+    c = ep;
     auto t1 = std::chrono::high_resolution_clock::now();
-    c = UnivariateSeries::mul(p, p, 1000);
+    c += ep;
+    // d = UnivariateSeries::mul(ep, ep, 1000);
     auto t2 = std::chrono::high_resolution_clock::now();
-    // std::cout << *a << std::endl;
-    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+    std::cout << "ep += ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
                      .count()
               << "ms" << std::endl;
+
+    // ep + ep
+    t1 = std::chrono::high_resolution_clock::now();
+    d = ep + ep;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep + ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep -= ep
+    t = ep;
+    t1 = std::chrono::high_resolution_clock::now();
+    t -= ep;
+    // d = UnivariateSeries::mul(ep, ep, 1000);
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep -= ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep - ep
+    t1 = std::chrono::high_resolution_clock::now();
+    u = ep - ep;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep - ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // -ep
+    t1 = std::chrono::high_resolution_clock::now();
+    n = -ep;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "-ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // epq * epq
+    t1 = std::chrono::high_resolution_clock::now();
+    b = epq * epq;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "epq * epq "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // epq *= epq
+    r = epq;
+    t1 = std::chrono::high_resolution_clock::now();
+    r *= epq;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "epq *= epq "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep * e single constant
+    t1 = std::chrono::high_resolution_clock::now();
+    s = ep * e;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep * e single constant "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep *= e single constant
+    a = ep;
+    t1 = std::chrono::high_resolution_clock::now();
+    a *= e;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep *= e single constant "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep / coeff
+    t1 = std::chrono::high_resolution_clock::now();
+    f = a / coeff;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep / coeff "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+    // std::cout << f.get_dict().at(0) << " + " << f.get_dict().at(1) << " + "
+    // << f.get_dict().at(2) << std::endl;
+
+    // ep /= coeff
+    g = a;
+    t1 = std::chrono::high_resolution_clock::now();
+    g /= coeff;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep /= coeff "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+    // std::cout << g.get_dict().at(0) << " + " << g.get_dict().at(1) << " + "
+    // << g.get_dict().at(2) << std::endl;
 
     return 0;
 }

--- a/benchmarks/series.cpp
+++ b/benchmarks/series.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
     SymEngine::print_stack_on_segfault();
 
     RCP<const Symbol> x = symbol("x");
-    // std::vector<Expression> v, v2;
+    std::vector<Expression> v, v2;
     map_int_Expr p, q;
     int N = 100000;
     int N2 = 1000;
@@ -39,6 +39,19 @@ int main(int argc, char *argv[])
         // v2.push_back(coef);
         q[j] = coef;
     }
+
+    // int N = 200;
+    // auto arg = add(x, pow(x, integer(2)));
+    // auto ex = mul(sin(arg), cos(arg));
+
+    // auto t1 = std::chrono::high_resolution_clock::now();
+    // auto res = SymEngine::UnivariateSeries::series(ex, "x", N);
+    // auto t2 = std::chrono::high_resolution_clock::now();
+    // // std::cout << *res[N-1] << std::endl;
+    // std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t2 -
+    // t1)
+    //                  .count()
+    //           << "ms" << std::endl;
 
     // UnivariateExprPolynomial c, p(UnivariatePolynomial::create(x, v));
     UnivariateExprPolynomial c, d, a, b, f, g, s, r, t, u, n, ep(p), epq(q);

--- a/benchmarks/series.cpp
+++ b/benchmarks/series.cpp
@@ -40,6 +40,6 @@ int main(int argc, char *argv[])
     std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
                      .count()
               << "ms" << std::endl;
-    
+
     return 0;
 }

--- a/benchmarks/series.cpp
+++ b/benchmarks/series.cpp
@@ -23,150 +23,23 @@ int main(int argc, char *argv[])
     SymEngine::print_stack_on_segfault();
 
     RCP<const Symbol> x = symbol("x");
-    std::vector<Expression> v, v2;
-    map_int_Expr p, q;
-    int N = 100000;
-    int N2 = 1000;
+    std::vector<Expression> v;
+    int N;
+
+    N = 1000;
     for (int i = 0; i < N; ++i) {
-        // Expression coef(i);
-        Expression coef(pow(x, integer(i)));
-        // v.push_back(coef);
-        p[i] = coef;
-    }
-    for (int j = 0; j < N2; ++j) {
-        // Expression coef(j);
-        Expression coef(pow(x, integer(j)));
-        // v2.push_back(coef);
-        q[j] = coef;
+        Expression coef(i);
+        v.push_back(coef);
     }
 
-    // int N = 200;
-    // auto arg = add(x, pow(x, integer(2)));
-    // auto ex = mul(sin(arg), cos(arg));
-
-    // auto t1 = std::chrono::high_resolution_clock::now();
-    // auto res = SymEngine::UnivariateSeries::series(ex, "x", N);
-    // auto t2 = std::chrono::high_resolution_clock::now();
-    // // std::cout << *res[N-1] << std::endl;
-    // std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t2 -
-    // t1)
-    //                  .count()
-    //           << "ms" << std::endl;
-
-    // UnivariateExprPolynomial c, p(UnivariatePolynomial::create(x, v));
-    UnivariateExprPolynomial c, d, a, b, f, g, s, r, t, u, n, ep(p), epq(q);
-    UnivariateExprPolynomial e({{0, Expression(7)}});
-    Expression coeff(7);
-
-    // ep += ep
-    c = ep;
+    UnivariateExprPolynomial c, p(UnivariatePolynomial::from_vec(x, v));
     auto t1 = std::chrono::high_resolution_clock::now();
-    c += ep;
-    // d = UnivariateSeries::mul(ep, ep, 1000);
+    c = UnivariateSeries::mul(p, p, 1000);
     auto t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "ep += ep "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+    // std::cout << *a << std::endl;
+    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
                      .count()
               << "ms" << std::endl;
-
-    // ep + ep
-    t1 = std::chrono::high_resolution_clock::now();
-    d = ep + ep;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "ep + ep "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-
-    // ep -= ep
-    t = ep;
-    t1 = std::chrono::high_resolution_clock::now();
-    t -= ep;
-    // d = UnivariateSeries::mul(ep, ep, 1000);
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "ep -= ep "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-
-    // ep - ep
-    t1 = std::chrono::high_resolution_clock::now();
-    u = ep - ep;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "ep - ep "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-
-    // -ep
-    t1 = std::chrono::high_resolution_clock::now();
-    n = -ep;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "-ep "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-
-    // epq * epq
-    t1 = std::chrono::high_resolution_clock::now();
-    b = epq * epq;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "epq * epq "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-
-    // epq *= epq
-    r = epq;
-    t1 = std::chrono::high_resolution_clock::now();
-    r *= epq;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "epq *= epq "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-
-    // ep * e single constant
-    t1 = std::chrono::high_resolution_clock::now();
-    s = ep * e;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "ep * e single constant "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-
-    // ep *= e single constant
-    a = ep;
-    t1 = std::chrono::high_resolution_clock::now();
-    a *= e;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "ep *= e single constant "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-
-    // ep / coeff
-    t1 = std::chrono::high_resolution_clock::now();
-    f = a / coeff;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "ep / coeff "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-    // std::cout << f.get_dict().at(0) << " + " << f.get_dict().at(1) << " + "
-    // << f.get_dict().at(2) << std::endl;
-
-    // ep /= coeff
-    g = a;
-    t1 = std::chrono::high_resolution_clock::now();
-    g /= coeff;
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "ep /= coeff "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
-                     .count()
-              << "ms" << std::endl;
-    // std::cout << g.get_dict().at(0) << " + " << g.get_dict().at(1) << " + "
-    // << g.get_dict().at(2) << std::endl;
-
+    
     return 0;
 }

--- a/symengine/dict.cpp
+++ b/symengine/dict.cpp
@@ -92,7 +92,11 @@ std::ostream &operator<<(std::ostream &out, const SymEngine::set_basic &d)
     return SymEngine::print_vec_rcp(out, d);
 }
 
-//! derivatives of base functions
+std::ostream &operator<<(std::ostream &out, const SymEngine::map_int_Expr &d)
+{
+    return SymEngine::print_map(out, d);
+}
+
 bool vec_basic_eq(const vec_basic &a, const vec_basic &b)
 {
     return vec_set_eq<vec_basic>(a, b);

--- a/symengine/dict.h
+++ b/symengine/dict.h
@@ -183,6 +183,7 @@ std::ostream &operator<<(std::ostream &out,
                          const SymEngine::umap_basic_basic &d);
 std::ostream &operator<<(std::ostream &out, const SymEngine::vec_basic &d);
 std::ostream &operator<<(std::ostream &out, const SymEngine::set_basic &d);
+std::ostream &operator<<(std::ostream &out, const SymEngine::map_int_Expr &d);
 
 } // SymEngine
 

--- a/symengine/expand.cpp
+++ b/symengine/expand.cpp
@@ -286,10 +286,10 @@ public:
             = univariate_polynomial(x->get_var(), {{0, 1}});
         while (i != 0) {
             if (i % 2 == 1) {
-                r = mul_uni_poly(r, x);
+                r = mul_uni_poly(*r, *x);
                 i--;
             }
-            x = mul_uni_poly(x, x);
+            x = mul_uni_poly(*x, *x);
             i /= 2;
         }
         _coef_dict_add_term(multiply, r);

--- a/symengine/expand.cpp
+++ b/symengine/expand.cpp
@@ -282,8 +282,9 @@ public:
 
     void pow_expand(RCP<const UnivariatePolynomial> &x, unsigned long &i)
     {
+        UnivariateExprPolynomial e({{0, Expression(1)}});
         RCP<const UnivariatePolynomial> r
-            = univariate_polynomial(x->get_var(), {{0, 1}});
+            = univariate_polynomial(x->get_var(), std::move(e));
         while (i != 0) {
             if (i % 2 == 1) {
                 r = mul_uni_poly(*r, *x);

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -358,9 +358,9 @@ RCP<const UnivariateIntPolynomial> mul_poly(const UnivariateIntPolynomial &a,
         return UnivariateIntPolynomial::from_dict(var, std::move(dict));
 }
 
-UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
-                                           const int &degree,
-                                           const map_int_Expr &&dict)
+UnivariatePolynomial::UnivariatePolynomial(
+    const RCP<const Symbol> &var, const int &degree,
+    const UnivariateExprPolynomial &&dict)
     : degree_{degree}, var_{var}, dict_{std::move(dict)}
 {
     SYMENGINE_ASSERT(is_canonical(degree_, dict_))
@@ -417,9 +417,9 @@ std::size_t UnivariatePolynomial::__hash__() const
 bool UnivariatePolynomial::__eq__(const Basic &o) const
 {
     return eq(*var_, *(static_cast<const UnivariatePolynomial &>(o).var_))
-           and (dict_.get_dict() ==
-                               static_cast<const UnivariatePolynomial &>(o)
-                                   .dict_.get_dict());
+           and (dict_.get_dict()
+                == static_cast<const UnivariatePolynomial &>(o)
+                       .dict_.get_dict());
 }
 
 int UnivariatePolynomial::compare(const Basic &o) const
@@ -445,11 +445,12 @@ UnivariatePolynomial::from_vec(const RCP<const Symbol> &var,
 }
 
 RCP<const UnivariatePolynomial>
-UnivariatePolynomial::from_dict(const RCP<const Symbol> &var, map_int_Expr &&d)
+UnivariatePolynomial::from_dict(const RCP<const Symbol> &var,
+                                UnivariateExprPolynomial &&d)
 {
     int degree = 0;
-    if (!d.empty())
-        degree = (--(d.end()))->first;
+    if (!d.get_dict().empty())
+        degree = (--(d.get_dict().end()))->first;
     return make_rcp<const UnivariatePolynomial>(var, degree, std::move(d));
 }
 
@@ -555,15 +556,14 @@ RCP<const UnivariatePolynomial> add_uni_poly(const UnivariatePolynomial &a,
     } else {
         var = a.get_var();
     }
-    map_int_Expr dict;
-    dict = (a.get_dict2() + b.get_dict2()).get_dict();
+    UnivariateExprPolynomial dict = a.get_dict2();
+    dict += b.get_dict2();
     return univariate_polynomial(var, std::move(dict));
 }
 
 RCP<const UnivariatePolynomial> neg_uni_poly(const UnivariatePolynomial &a)
 {
-    map_int_Expr dict;
-    dict = (-a.get_dict2()).get_dict();
+    UnivariateExprPolynomial dict = -(a.get_dict2());
     return univariate_polynomial(a.get_var(), std::move(dict));
 }
 
@@ -580,8 +580,8 @@ RCP<const UnivariatePolynomial> sub_uni_poly(const UnivariatePolynomial &a,
     } else {
         var = a.get_var();
     }
-    map_int_Expr dict;
-    dict = (a.get_dict2() - b.get_dict2()).get_dict();
+    UnivariateExprPolynomial dict = a.get_dict2();
+    dict -= b.get_dict2();
     return univariate_polynomial(var, std::move(dict));
 }
 
@@ -598,8 +598,8 @@ RCP<const UnivariatePolynomial> mul_uni_poly(const UnivariatePolynomial &a,
     } else {
         var = a.get_var();
     }
-    map_int_Expr dict;
-    dict = (a.get_dict2() * b.get_dict2()).get_dict();
+    UnivariateExprPolynomial dict = a.get_dict2();
+    dict *= b.get_dict2();
     return univariate_polynomial(var, std::move(dict));
 }
 

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -379,7 +379,9 @@ UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
         }
     }
     if (var->get_name() == "")
-        if (!(expr_dict_.dict_.empty() or (expr_dict_.dict_.size() == 1 and expr_dict_.dict_.begin()->first == 0)))
+        if (!(expr_dict_.dict_.empty()
+              or (expr_dict_.dict_.size() == 1
+                  and expr_dict_.dict_.begin()->first == 0)))
             throw std::runtime_error("Should only have a constant term");
     degree_ = deg;
 }
@@ -515,7 +517,8 @@ bool UnivariatePolynomial::is_one() const
 
 bool UnivariatePolynomial::is_minus_one() const
 {
-    return expr_dict_.size() == 1 and expr_dict_.get_dict().begin()->second == -1
+    return expr_dict_.size() == 1
+           and expr_dict_.get_dict().begin()->second == -1
            and expr_dict_.get_dict().begin()->first == 0;
 }
 

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -182,12 +182,9 @@ public:
     friend UnivariateExprPolynomial operator+(const UnivariateExprPolynomial &a,
                                               const UnivariateExprPolynomial &b)
     {
-        map_int_Expr dict;
-        for (const auto &it : a.dict_)
-            dict[it.first] = it.second;
-        for (const auto &it : b.dict_)
-            dict[it.first] += it.second;
-        return UnivariateExprPolynomial(dict);
+        UnivariateExprPolynomial c = a;
+        c += b;
+        return UnivariateExprPolynomial(std::move(c));
     }
 
     UnivariateExprPolynomial &operator+=(const UnivariateExprPolynomial &other)
@@ -200,12 +197,9 @@ public:
     friend UnivariateExprPolynomial operator-(const UnivariateExprPolynomial &a,
                                               const UnivariateExprPolynomial &b)
     {
-        map_int_Expr dict;
-        for (const auto &it : a.dict_)
-            dict[it.first] = it.second;
-        for (const auto &it : b.dict_)
-            dict[it.first] -= it.second;
-        return UnivariateExprPolynomial(dict);
+        UnivariateExprPolynomial c = a;
+        c -= b;
+        return UnivariateExprPolynomial(std::move(c));
     }
 
     UnivariateExprPolynomial operator-() const
@@ -226,15 +220,9 @@ public:
     friend UnivariateExprPolynomial operator*(const UnivariateExprPolynomial &a,
                                               const UnivariateExprPolynomial &b)
     {
-        if (a.dict_.empty() or b.dict_.empty())
-            return UnivariateExprPolynomial({{0, Expression(0)}});
-
-        map_int_Expr dict;
-        for (const auto &i1 : a.dict_)
-            for (const auto &i2 : b.dict_)
-                dict[i1.first + i2.first] += i1.second * i2.second;
-
-        return UnivariateExprPolynomial(dict);
+        UnivariateExprPolynomial c = a;
+        c *= b;
+        return UnivariateExprPolynomial(std::move(c));
     }
 
     friend UnivariateExprPolynomial operator/(const UnivariateExprPolynomial &a,
@@ -362,7 +350,7 @@ public:
     IMPLEMENT_TYPEID(UNIVARIATEPOLYNOMIAL)
     //! Constructor of UnivariatePolynomial class
     UnivariatePolynomial(const RCP<const Symbol> &var, const int &degree,
-                         const map_int_Expr &&dict);
+                         const UnivariateExprPolynomial &&dict);
     //! Constructor using a dense vector of Expression
     UnivariatePolynomial(const RCP<const Symbol> &var,
                          const std::vector<Expression> &v);
@@ -383,7 +371,7 @@ public:
     * Mul, Pow, UnivariatePolynomial) depending on the size of dictionary `d`.
     */
     static RCP<const UnivariatePolynomial>
-    from_dict(const RCP<const Symbol> &var, map_int_Expr &&d);
+    from_dict(const RCP<const Symbol> &var, UnivariateExprPolynomial &&d);
     static RCP<const UnivariatePolynomial>
     from_vec(const RCP<const Symbol> &var, const std::vector<Expression> &v);
 
@@ -440,7 +428,7 @@ RCP<const UnivariatePolynomial> mul_uni_poly(const UnivariatePolynomial &a,
                                              const UnivariatePolynomial &b);
 
 inline RCP<const UnivariatePolynomial>
-univariate_polynomial(RCP<const Symbol> i, map_int_Expr &&dict)
+univariate_polynomial(RCP<const Symbol> i, UnivariateExprPolynomial &&dict)
 {
     return UnivariatePolynomial::from_dict(i, std::move(dict));
 }

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -184,7 +184,7 @@ public:
     UnivariateExprPolynomial &operator+=(const UnivariateExprPolynomial &other)
     {
         for (auto &it : other.dict_) {
-            if(dict_[it.first] + it.second != 0) {
+            if (dict_[it.first] + it.second != 0) {
                 dict_[it.first] += it.second;
             } else {
                 auto toErase = dict_.find(it.first);
@@ -213,7 +213,7 @@ public:
     UnivariateExprPolynomial &operator-=(const UnivariateExprPolynomial &other)
     {
         for (auto &it : other.dict_) {
-            if(dict_[it.first] - it.second != 0) {
+            if (dict_[it.first] - it.second != 0) {
                 dict_[it.first] -= it.second;
             } else {
                 auto toErase = dict_.find(it.first);
@@ -242,7 +242,7 @@ public:
         if (dict_.empty())
             return *this;
 
-        if(other.dict_.empty()) {
+        if (other.dict_.empty()) {
             *this = other;
             return *this;
         }
@@ -316,7 +316,8 @@ public:
         return seed;
     }
 
-    std::string __str__(const std::string name) const {
+    std::string __str__(const std::string name) const
+    {
         std::ostringstream o;
         bool first = true;
         for (auto it = dict_.rbegin(); it != dict_.rend(); ++it) {
@@ -344,10 +345,16 @@ public:
                     if (it->second == -1)
                         o << "-";
                 } else {
-                    if (static_cast<const Integer &>(*it->second.get_basic()).as_mpz() < 0) {
-                        o << " " << "-" << " ";
+                    if (static_cast<const Integer &>(*it->second.get_basic())
+                            .as_mpz()
+                        < 0) {
+                        o << " "
+                          << "-"
+                          << " ";
                     } else {
-                        o << " " << "+" << " ";
+                        o << " "
+                          << "+"
+                          << " ";
                     }
                 }
             }
@@ -377,7 +384,8 @@ public:
             } else if (it->first < 0) {
                 o << "**(" << it->first << ")";
             }
-            // corner cases of only first term handled successfully, switch the bool
+            // corner cases of only first term handled successfully, switch the
+            // bool
             first = false;
         }
         return o.str();
@@ -413,8 +421,9 @@ public:
             if (p->first != o->first)
                 return (p->first < o->first) ? -1 : 1;
             if (p->second != o->second)
-                return (p->second.get_basic()->__cmp__(*o->second.get_basic())) ? -1
-                                                                                : 1;
+                return (p->second.get_basic()->__cmp__(*o->second.get_basic()))
+                           ? -1
+                           : 1;
         }
         return 0;
     }

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -365,7 +365,8 @@ void StrPrinter::bvisit(const UnivariatePolynomial &x)
 void StrPrinter::bvisit(const UnivariateSeries &x)
 {
     std::ostringstream o;
-    o << x.get_poly().__str__(x.get_var()) << " + O(" << x.get_var() << "**" << x.get_degree() << ")";
+    o << x.get_poly().__str__(x.get_var()) << " + O(" << x.get_var() << "**"
+      << x.get_degree() << ")";
     str_ = o.str();
 }
 

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -355,140 +355,17 @@ void StrPrinter::bvisit(const UnivariateIntPolynomial &x)
 void StrPrinter::bvisit(const UnivariatePolynomial &x)
 {
     std::ostringstream s;
-    // bool variable needed to take care of cases like -5, -x, -3*x etc.
-    bool first = true;
-    // we iterate over the map in reverse order so that highest degree gets
-    // printed first
-    for (auto it = x.get_dict().rbegin(); it != x.get_dict().rend(); ++it) {
-        std::string t;
-        // if exponent is 0, then print only coefficient
-        if (it->first == 0) {
-            if (first) {
-                s << it->second;
-            } else {
-                t = parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul);
-                if (t[0] == '-') {
-                    s << " - " << t.substr(1);
-                } else {
-                    s << " + " << t;
-                }
-            }
-            first = false;
-            continue;
-        }
-        // if the coefficient of a term is +1 or -1
-        if (it->second == 1 or it->second == -1) {
-            // in cases of -x, print -x
-            // in cases of x**2 - x, print - x
-            if (first) {
-                if (it->second == -1)
-                    s << "-";
-            } else {
-                s << " " << _print_sign(static_cast<const Integer &>(
-                                            *it->second.get_basic())
-                                            .as_mpz())
-                  << " ";
-            }
-        }
-        // same logic is followed as above
-        else {
-            // in cases of -2*x, print -2*x
-            // in cases of x**2 - 2*x, print - 2*x
-            if (first) {
-                s << parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul)
-                  << "*";
-            } else {
-                t = parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul);
-                if (t[0] == '-') {
-                    s << " - " << t.substr(1);
-                } else {
-                    s << " + " << t;
-                }
-                s << "*";
-            }
-        }
-        s << x.get_var()->get_name();
-        // if exponent is not 1, print the exponent;
-        if (it->first > 1) {
-            s << "**" << it->first;
-        } else if (it->first < 0) {
-            s << "**(" << it->first << ")";
-        }
-        // corner cases of only first term handled successfully, switch the bool
-        first = false;
-    }
     if (x.get_dict().size() == 0)
         s << "0";
+    else
+        s << x.get_expr_dict().__str__(x.get_var()->get_name());
     str_ = s.str();
 }
 
 void StrPrinter::bvisit(const UnivariateSeries &x)
 {
     std::ostringstream o;
-    bool first = true;
-    for (auto it = x.get_poly().get_dict().rbegin();
-         it != x.get_poly().get_dict().rend(); ++it) {
-        std::string t;
-        // if exponent is 0, then print only coefficient
-        if (it->first == 0) {
-            if (first) {
-                o << it->second;
-            } else {
-                t = parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul);
-                if (t[0] == '-') {
-                    o << " - " << t.substr(1);
-                } else {
-                    o << " + " << t;
-                }
-            }
-            first = false;
-            continue;
-        }
-        // if the coefficient of a term is +1 or -1
-        if (it->second == 1 or it->second == -1) {
-            // in cases of -x, print -x
-            // in cases of x**2 - x, print - x
-            if (first) {
-                if (it->second == -1)
-                    o << "-";
-            } else {
-                o << " " << _print_sign(static_cast<const Integer &>(
-                                            *it->second.get_basic())
-                                            .as_mpz())
-                  << " ";
-            }
-        }
-        // if the coefficient of a term is 0, skip
-        else if (it->second == 0)
-            continue;
-        // same logic is followed as above
-        else {
-            // in cases of -2*x, print -2*x
-            // in cases of x**2 - 2*x, print - 2*x
-            if (first) {
-                o << parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul)
-                  << "*";
-            } else {
-                t = parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul);
-                if (t[0] == '-') {
-                    o << " - " << t.substr(1);
-                } else {
-                    o << " + " << t;
-                }
-                o << "*";
-            }
-        }
-        o << x.get_var();
-        // if exponent is not 1, print the exponent;
-        if (it->first > 1) {
-            o << "**" << it->first;
-        } else if (it->first < 0) {
-            o << "**(" << it->first << ")";
-        }
-        // corner cases of only first term handled successfully, switch the bool
-        first = false;
-    }
-    o << " + O(" << x.get_var() << "**" << x.get_degree() << ")";
+    o << x.get_poly().__str__(x.get_var()) << " + O(" << x.get_var() << "**" << x.get_degree() << ")";
     str_ = o.str();
 }
 

--- a/symengine/series_generic.cpp
+++ b/symengine/series_generic.cpp
@@ -29,37 +29,12 @@ int UnivariateSeries::compare(const Basic &other) const
 {
     SYMENGINE_ASSERT(is_a<UnivariateSeries>(other))
     const UnivariateSeries &o_ = static_cast<const UnivariateSeries &>(other);
-    if (p_.size() != o_.p_.size())
-        return (p_.size() < o_.p_.size()) ? -1 : 1;
-    auto p = p_.get_dict().begin();
-    auto o = o_.p_.get_dict().begin();
-    for (; p != p_.get_dict().end(); ++p, ++o) {
-        if (p->first != o->first)
-            return (p->first < o->first) ? -1 : 1;
-        if (p->second != o->second)
-            return (p->second.get_basic()->__cmp__(*o->second.get_basic())) ? -1
-                                                                            : 1;
-    }
-    return 0;
+    return p_.compare(o_.get_poly());
 }
 
 RCP<const Basic> UnivariateSeries::as_basic() const
 {
-    RCP<const Symbol> x = symbol(var_);
-    umap_basic_num dict_;
-    RCP<const Number> coeff;
-    for (const auto &it : p_.get_dict()) {
-        if (it.first != 0) {
-            auto term = SymEngine::mul(
-                it.second.get_basic(),
-                pow_ex(Expression(x), Expression(it.first)).get_basic());
-            RCP<const Number> coef;
-            coef = zero;
-            Add::coef_dict_add_term(outArg((coef)), dict_, one, term);
-        } else
-            coeff = rcp_static_cast<const Number>(it.second.get_basic());
-    }
-    return Add::from_dict(coeff, std::move(dict_));
+    return p_.get_basic(var_);
 }
 
 umap_int_basic UnivariateSeries::as_dict() const

--- a/symengine/tests/basic/test_polynomial.cpp
+++ b/symengine/tests/basic/test_polynomial.cpp
@@ -404,8 +404,8 @@ TEST_CASE("Multiplication of two UnivariatePolynomial",
     RCP<const UnivariatePolynomial> b = univariate_polynomial(
         x, {{0, -1}, {1, -2}, {2, mul(integer(-1), symbol("a"))}});
 
-    RCP<const UnivariatePolynomial> c = mul_uni_poly(a, a);
-    RCP<const UnivariatePolynomial> d = mul_uni_poly(a, b);
+    RCP<const UnivariatePolynomial> c = mul_uni_poly(*a, *a);
+    RCP<const UnivariatePolynomial> d = mul_uni_poly(*a, *b);
 
     REQUIRE(c->__str__()
             == "a**2*x**4 + 2*a*b*x**3 + (2*a + b**2)*x**2 + 2*b*x + 1");
@@ -413,18 +413,18 @@ TEST_CASE("Multiplication of two UnivariatePolynomial",
                             "2*b)*x**2 + (-2 - b)*x - 1");
 
     RCP<const UnivariatePolynomial> f = univariate_polynomial(x, {{0, 2}});
-    REQUIRE(mul_uni_poly(a, f)->__str__() == "2*a*x**2 + 2*b*x + 2");
-    REQUIRE(mul_uni_poly(f, a)->__str__() == "2*a*x**2 + 2*b*x + 2");
+    REQUIRE(mul_uni_poly(*a, *f)->__str__() == "2*a*x**2 + 2*b*x + 2");
+    REQUIRE(mul_uni_poly(*f, *a)->__str__() == "2*a*x**2 + 2*b*x + 2");
 
     f = univariate_polynomial(y, {{0, 2}, {1, 4}});
-    CHECK_THROWS_AS(mul_uni_poly(a, f), std::runtime_error);
+    CHECK_THROWS_AS(mul_uni_poly(*a, *f), std::runtime_error);
 
     f = univariate_polynomial(x, std::map<int, Expression>{});
-    REQUIRE(mul_uni_poly(a, f)->__str__() == "0");
+    REQUIRE(mul_uni_poly(*a, *f)->__str__() == "0");
 
     a = univariate_polynomial(x, {{-2, 5}, {-1, 3}, {0, 1}, {1, 2}});
 
-    c = mul_uni_poly(a, b);
+    c = mul_uni_poly(*a, *b);
     REQUIRE(c->__str__() == "-2*a*x**3 + (-4 - a)*x**2 + (-4 - 3*a)*x + (-7 - "
                             "5*a) - 13*x**(-1) - 5*x**(-2)");
 }

--- a/symengine/tests/basic/test_polynomial.cpp
+++ b/symengine/tests/basic/test_polynomial.cpp
@@ -12,6 +12,7 @@ using SymEngine::UnivariateIntPolynomial;
 using SymEngine::UnivariatePolynomial;
 using SymEngine::univariate_int_polynomial;
 using SymEngine::univariate_polynomial;
+using SymEngine::UnivariateExprPolynomial;
 using SymEngine::Symbol;
 using SymEngine::symbol;
 using SymEngine::Pow;
@@ -306,30 +307,31 @@ TEST_CASE("Constructor of UnivariatePolynomial", "[UnivariatePolynomial]")
     Expression num2(integer(2));
     Expression num1(integer(1));
 
-    RCP<const UnivariatePolynomial> P
-        = univariate_polynomial(x, {{0, num1}, {1, num2}, {2, num1}});
+    RCP<const UnivariatePolynomial> P = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, num1}, {1, num2}, {2, num1}}));
     REQUIRE(P->__str__() == "x**2 + 2*x + 1");
 
     RCP<const UnivariatePolynomial> Q
         = UnivariatePolynomial::create(x, {1, 0, 2, 1});
     REQUIRE(Q->__str__() == "x**3 + 2*x**2 + 1");
 
-    RCP<const UnivariatePolynomial> R
-        = univariate_polynomial(x, {{0, d}, {1, c}, {2, b}, {3, a}});
+    RCP<const UnivariatePolynomial> R = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, d}, {1, c}, {2, b}, {3, a}}));
     REQUIRE(R->__str__() == "a*x**3 + b*x**2 + c*x + d");
 
     UnivariatePolynomial S(x, {1, 0, 2, 1});
     REQUIRE(S.__str__() == "x**3 + 2*x**2 + 1");
 
-    R = univariate_polynomial(x, {{-1, d}});
+    R = univariate_polynomial(x, UnivariateExprPolynomial({{-1, d}}));
     REQUIRE(R->__str__() == "d*x**(-1)");
     REQUIRE(not(R->__str__() == "d*x**-1"));
 
-    R = univariate_polynomial(x, {{-2, d}, {-1, c}, {0, b}, {1, a}});
+    R = univariate_polynomial(
+        x, UnivariateExprPolynomial({{-2, d}, {-1, c}, {0, b}, {1, a}}));
     REQUIRE(R->__str__() == "a*x + b + c*x**(-1) + d*x**(-2)");
 
     RCP<const UnivariatePolynomial> T
-        = univariate_polynomial(none, std::map<int, Expression>{});
+        = univariate_polynomial(none, UnivariateExprPolynomial({}));
     REQUIRE(T->__str__() == "0");
 }
 
@@ -338,36 +340,39 @@ TEST_CASE("Adding two UnivariatePolynomial", "[UnivariatePolynomial]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> none = symbol("");
-    map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, symbol("a")}};
-    map_int_Expr bdict_ = {{0, 2}, {1, 3}, {2, symbol("b")}};
+    UnivariateExprPolynomial adict_({{0, 1}, {1, 2}, {2, symbol("a")}});
+    UnivariateExprPolynomial bdict_({{0, 2}, {1, 3}, {2, symbol("b")}});
     const UnivariatePolynomial a(x, 2, std::move(adict_));
     const UnivariatePolynomial b(x, 2, std::move(bdict_));
 
     RCP<const Basic> c = add_uni_poly(a, b);
     REQUIRE(c->__str__() == "(a + b)*x**2 + 5*x + 3");
 
-    RCP<const UnivariatePolynomial> d = univariate_polynomial(none, {{0, 2}});
+    RCP<const UnivariatePolynomial> d = univariate_polynomial(
+        none, UnivariateExprPolynomial({{0, Expression(2)}}));
     REQUIRE(add_uni_poly(a, *d)->__str__() == "a*x**2 + 2*x + 3");
     REQUIRE(add_uni_poly(*d, a)->__str__() == "a*x**2 + 2*x + 3");
 
-    d = univariate_polynomial(y, {{0, 2}, {1, 4}});
+    d = univariate_polynomial(y, UnivariateExprPolynomial({{0, 2}, {1, 4}}));
     CHECK_THROWS_AS(add_uni_poly(a, *d), std::runtime_error);
 }
 
 TEST_CASE("Negative of a UnivariatePolynomial", "[UnivariatePolynomial]")
 {
     RCP<const Symbol> x = symbol("x");
-    map_int_Expr adict_ = {{0, 1}, {1, symbol("a")}, {2, symbol("c")}};
-    const UnivariatePolynomial a(x, 2, std::move(adict_));
+    const UnivariatePolynomial a(
+        x, 2,
+        UnivariateExprPolynomial({{0, 1}, {1, symbol("a")}, {2, symbol("c")}}));
 
     RCP<const UnivariatePolynomial> b = neg_uni_poly(a);
     REQUIRE(b->__str__() == "-c*x**2 - a*x - 1");
 
     RCP<const UnivariatePolynomial> c
-        = univariate_polynomial(x, std::map<int, Expression>{});
+        = univariate_polynomial(x, UnivariateExprPolynomial({}));
     REQUIRE(neg_uni_poly(*c)->__str__() == "0");
 
-    c = univariate_polynomial(x, {{0, 2}});
+    c = univariate_polynomial(x,
+                              UnivariateExprPolynomial({{0, Expression(2)}}));
     REQUIRE(neg_uni_poly(*c)->__str__() == "-2");
 }
 
@@ -376,19 +381,21 @@ TEST_CASE("Subtracting two UnivariatePolynomial", "[UnivariatePolynomial]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> none = symbol("");
-    map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    map_int_Expr bdict_ = {{0, 2}, {1, symbol("b")}, {2, symbol("a")}};
+    UnivariateExprPolynomial adict_({{0, 1}, {1, 2}, {2, 1}});
+    UnivariateExprPolynomial bdict_(
+        {{0, 2}, {1, symbol("b")}, {2, symbol("a")}});
     const UnivariatePolynomial a(x, 2, std::move(adict_));
     const UnivariatePolynomial b(x, 2, std::move(bdict_));
 
     RCP<const Basic> c = sub_uni_poly(b, a);
     REQUIRE(c->__str__() == "(-1 + a)*x**2 + (-2 + b)*x + 1");
 
-    RCP<const UnivariatePolynomial> d = univariate_polynomial(none, {{0, 2}});
+    RCP<const UnivariatePolynomial> d = univariate_polynomial(
+        none, UnivariateExprPolynomial({{0, Expression(2)}}));
     REQUIRE(sub_uni_poly(a, *d)->__str__() == "x**2 + 2*x - 1");
     REQUIRE(sub_uni_poly(*d, a)->__str__() == "-x**2 - 2*x + 1");
 
-    d = univariate_polynomial(y, {{0, 2}, {1, 4}});
+    d = univariate_polynomial(y, UnivariateExprPolynomial({{0, 2}, {1, 4}}));
     CHECK_THROWS_AS(sub_uni_poly(a, *d), std::runtime_error);
 }
 
@@ -400,9 +407,11 @@ TEST_CASE("Multiplication of two UnivariatePolynomial",
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> none = symbol("");
     RCP<const UnivariatePolynomial> a = univariate_polynomial(
-        x, {{0, 1}, {1, symbol("b")}, {2, symbol("a")}});
+        x,
+        UnivariateExprPolynomial({{0, 1}, {1, symbol("b")}, {2, symbol("a")}}));
     RCP<const UnivariatePolynomial> b = univariate_polynomial(
-        x, {{0, -1}, {1, -2}, {2, mul(integer(-1), symbol("a"))}});
+        x, UnivariateExprPolynomial(
+               {{0, -1}, {1, -2}, {2, mul(integer(-1), symbol("a"))}}));
 
     RCP<const UnivariatePolynomial> c = mul_uni_poly(*a, *a);
     RCP<const UnivariatePolynomial> d = mul_uni_poly(*a, *b);
@@ -412,17 +421,19 @@ TEST_CASE("Multiplication of two UnivariatePolynomial",
     REQUIRE(d->__str__() == "-a**2*x**4 + (-2*a - a*b)*x**3 + (-2*a - "
                             "2*b)*x**2 + (-2 - b)*x - 1");
 
-    RCP<const UnivariatePolynomial> f = univariate_polynomial(x, {{0, 2}});
+    RCP<const UnivariatePolynomial> f = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, Expression(2)}}));
     REQUIRE(mul_uni_poly(*a, *f)->__str__() == "2*a*x**2 + 2*b*x + 2");
     REQUIRE(mul_uni_poly(*f, *a)->__str__() == "2*a*x**2 + 2*b*x + 2");
 
-    f = univariate_polynomial(y, {{0, 2}, {1, 4}});
+    f = univariate_polynomial(y, UnivariateExprPolynomial({{0, 2}, {1, 4}}));
     CHECK_THROWS_AS(mul_uni_poly(*a, *f), std::runtime_error);
 
-    f = univariate_polynomial(x, std::map<int, Expression>{});
+    f = univariate_polynomial(x, UnivariateExprPolynomial({}));
     REQUIRE(mul_uni_poly(*a, *f)->__str__() == "0");
 
-    a = univariate_polynomial(x, {{-2, 5}, {-1, 3}, {0, 1}, {1, 2}});
+    a = univariate_polynomial(
+        x, UnivariateExprPolynomial({{-2, 5}, {-1, 3}, {0, 1}, {1, 2}}));
 
     c = mul_uni_poly(*a, *b);
     REQUIRE(c->__str__() == "-2*a*x**3 + (-4 - a)*x**2 + (-4 - 3*a)*x + (-7 - "
@@ -434,26 +445,32 @@ TEST_CASE("Comparing two UnivariatePolynomial", "[UnivariatePolynomial]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const UnivariatePolynomial> P
-        = univariate_polynomial(x, {{0, 1}, {1, 2}});
-    RCP<const UnivariatePolynomial> Q
-        = univariate_polynomial(x, {{0, 1}, {1, symbol("b")}, {2, 1}});
+        = univariate_polynomial(x, UnivariateExprPolynomial({{0, 1}, {1, 2}}));
+    RCP<const UnivariatePolynomial> Q = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, symbol("b")}, {2, 1}}));
 
     REQUIRE(P->compare(*Q) == -1);
 
-    P = univariate_polynomial(x, {{0, 1}, {1, symbol("k")}, {2, 3}, {3, 2}});
+    P = univariate_polynomial(
+        x,
+        UnivariateExprPolynomial({{0, 1}, {1, symbol("k")}, {2, 3}, {3, 2}}));
     REQUIRE(P->compare(*Q) == 1);
 
-    P = univariate_polynomial(x, {{0, 1}, {1, 2}, {3, 3}});
+    P = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 2}, {3, 3}}));
     REQUIRE(P->compare(*Q) == -1);
 
-    P = univariate_polynomial(y, {{0, 1}, {1, 2}, {3, 3}});
+    P = univariate_polynomial(
+        y, UnivariateExprPolynomial({{0, 1}, {1, 2}, {3, 3}}));
     REQUIRE(P->compare(*Q) == 1);
 
-    P = univariate_polynomial(x, {{0, 1}, {1, symbol("b")}, {2, 1}});
+    P = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, symbol("b")}, {2, 1}}));
     REQUIRE(P->compare(*Q) == 0);
     REQUIRE(P->__eq__(*Q) == true);
 
-    P = univariate_polynomial(x, {{0, 1}, {1, symbol("a")}, {2, 1}});
+    P = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, symbol("a")}, {2, 1}}));
     REQUIRE(P->compare(*Q) == -1);
     REQUIRE(P->__eq__(*Q) == false);
 }
@@ -461,29 +478,30 @@ TEST_CASE("Comparing two UnivariatePolynomial", "[UnivariatePolynomial]")
 TEST_CASE("UnivariatePolynomial get_args", "[UnivariatePolynomial]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UnivariatePolynomial> a
-        = univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}});
+    RCP<const UnivariatePolynomial> a = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 2}, {2, 1}}));
 
     REQUIRE(vec_basic_eq_perm(a->get_args(),
                               {one, mul(integer(2), x), pow(x, integer(2))}));
     REQUIRE(not vec_basic_eq_perm(
         a->get_args(), {one, mul(integer(3), x), pow(x, integer(2))}));
 
-    a = univariate_polynomial(x, {{0, 1}, {1, 1}, {2, 2}});
+    a = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 1}, {2, 2}}));
     REQUIRE(vec_basic_eq_perm(a->get_args(),
                               {one, x, mul(integer(2), pow(x, integer(2)))}));
 
-    a = univariate_polynomial(x, std::map<int, Expression>{});
+    a = univariate_polynomial(x, UnivariateExprPolynomial({}));
     REQUIRE(vec_basic_eq_perm(a->get_args(), {zero}));
 }
 
 TEST_CASE("UnivariatePolynomial max_coef", "[UnivariatePolynomial]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UnivariatePolynomial> a
-        = univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 4}});
-    RCP<const UnivariatePolynomial> b
-        = univariate_polynomial(x, {{0, 2}, {1, 2}, {2, symbol("b")}});
+    RCP<const UnivariatePolynomial> a = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 2}, {2, 4}}));
+    RCP<const UnivariatePolynomial> b = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 2}, {1, 2}, {2, symbol("b")}}));
 
     Expression c(symbol("a"));
     Expression d(symbol("b"));
@@ -498,12 +516,13 @@ TEST_CASE("UnivariatePolynomial max_coef", "[UnivariatePolynomial]")
 TEST_CASE("Evaluation of UnivariatePolynomial", "[UnivariatePolynomial]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UnivariatePolynomial> a
-        = univariate_polynomial(x, {{0, 1}, {1, 2}, {2, symbol("a")}});
+    RCP<const UnivariatePolynomial> a = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 2}, {2, symbol("a")}}));
 
     REQUIRE(a->eval(2).get_basic()->__str__() == "5 + 4*a");
 
-    a = univariate_polynomial(x, {{-2, 5}, {-1, 3}, {0, 1}, {1, 2}});
+    a = univariate_polynomial(
+        x, UnivariateExprPolynomial({{-2, 5}, {-1, 3}, {0, 1}, {1, 2}}));
     REQUIRE(a->eval(2).get_basic()->__str__() == "31/4");
 }
 
@@ -512,22 +531,25 @@ TEST_CASE("Derivative of UnivariatePolynomial", "[UnivariatePolynomial]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> none = symbol("");
-    RCP<const UnivariatePolynomial> a
-        = univariate_polynomial(x, {{0, 1}, {1, 2}, {2, symbol("a")}});
-    RCP<const UnivariatePolynomial> b = univariate_polynomial(x, {{0, 1}});
-    RCP<const UnivariatePolynomial> c = univariate_polynomial(none, {{0, 5}});
+    RCP<const UnivariatePolynomial> a = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 2}, {2, symbol("a")}}));
+    RCP<const UnivariatePolynomial> b = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, Expression(1)}}));
+    RCP<const UnivariatePolynomial> c = univariate_polynomial(
+        none, UnivariateExprPolynomial({{0, Expression(5)}}));
 
     REQUIRE(a->diff(x)->__str__() == "2*a*x + 2");
     REQUIRE(a->diff(y)->__str__() == "0");
     REQUIRE(b->diff(y)->__str__() == "0");
 
     a = univariate_polynomial(
-        x, {{-2, 5}, {-1, 3}, {0, 1}, {1, 2}, {2, symbol("a")}});
+        x, UnivariateExprPolynomial(
+               {{-2, 5}, {-1, 3}, {0, 1}, {1, 2}, {2, symbol("a")}}));
     REQUIRE(a->diff(x)->__str__() == "2*a*x + 2 - 3*x**(-2) - 10*x**(-3)");
 
     REQUIRE(c->diff(x)->__str__() == "0");
 
-    c = univariate_polynomial(none, std::map<int, Expression>{});
+    c = univariate_polynomial(none, UnivariateExprPolynomial({}));
     REQUIRE(c->diff(x)->__str__() == "0");
 }
 
@@ -535,18 +557,26 @@ TEST_CASE("Bool checks specific UnivariatePolynomial cases",
           "[UnivariatePolynomial]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UnivariatePolynomial> z = univariate_polynomial(x, {{0, 0}});
-    RCP<const UnivariatePolynomial> o = univariate_polynomial(x, {{0, 1}});
-    RCP<const UnivariatePolynomial> mo = univariate_polynomial(x, {{0, -1}});
-    RCP<const UnivariatePolynomial> i = univariate_polynomial(x, {{0, 6}});
-    RCP<const UnivariatePolynomial> s = univariate_polynomial(x, {{1, 1}});
-    RCP<const UnivariatePolynomial> m1 = univariate_polynomial(x, {{1, 6}});
-    RCP<const UnivariatePolynomial> m2 = univariate_polynomial(x, {{3, 5}});
-    RCP<const UnivariatePolynomial> po = univariate_polynomial(x, {{5, 1}});
-    RCP<const UnivariatePolynomial> poly
-        = univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}});
-    RCP<const UnivariatePolynomial> neg
-        = univariate_polynomial(x, {{-2, 5}, {-1, 3}, {0, 1}, {1, 2}});
+    RCP<const UnivariatePolynomial> z = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, Expression(0)}}));
+    RCP<const UnivariatePolynomial> o = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, Expression(1)}}));
+    RCP<const UnivariatePolynomial> mo = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, Expression(-1)}}));
+    RCP<const UnivariatePolynomial> i = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, Expression(6)}}));
+    RCP<const UnivariatePolynomial> s = univariate_polynomial(
+        x, UnivariateExprPolynomial({{1, Expression(1)}}));
+    RCP<const UnivariatePolynomial> m1 = univariate_polynomial(
+        x, UnivariateExprPolynomial({{1, Expression(6)}}));
+    RCP<const UnivariatePolynomial> m2 = univariate_polynomial(
+        x, UnivariateExprPolynomial({{3, Expression(5)}}));
+    RCP<const UnivariatePolynomial> po = univariate_polynomial(
+        x, UnivariateExprPolynomial({{5, Expression(1)}}));
+    RCP<const UnivariatePolynomial> poly = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 2}, {2, 1}}));
+    RCP<const UnivariatePolynomial> neg = univariate_polynomial(
+        x, UnivariateExprPolynomial({{-2, 5}, {-1, 3}, {0, 1}, {1, 2}}));
 
     REQUIRE((z->is_zero() and not z->is_one() and not z->is_minus_one()
              and z->is_integer() and not z->is_symbol() and not z->is_mul()
@@ -585,8 +615,8 @@ TEST_CASE("Bool checks specific UnivariatePolynomial cases",
 TEST_CASE("UnivariatePolynomial expand", "[UnivariatePolynomial][expand]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UnivariatePolynomial> a
-        = univariate_polynomial(x, {{1, 1}, {2, 1}, {3, symbol("a")}});
+    RCP<const UnivariatePolynomial> a = univariate_polynomial(
+        x, UnivariateExprPolynomial({{1, 1}, {2, 1}, {3, symbol("a")}}));
     RCP<const Basic> b = make_rcp<const Pow>(a, integer(3));
     RCP<const Basic> c = expand(b);
 

--- a/symengine/tests/basic/test_series_generic.cpp
+++ b/symengine/tests/basic/test_series_generic.cpp
@@ -35,21 +35,18 @@ TEST_CASE("Create UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
     map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    UnivariateExprPolynomial apoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial apoly_(adict_);
     RCP<const UnivariateSeries> P = univariate_series(x, 2, apoly_);
     REQUIRE(P->__str__() == "x**2 + 2*x + 1 + O(x**2)");
 
     map_int_Expr bdict_ = {{0, 1}, {1, 0}, {2, 2}, {3, 1}};
-    UnivariateExprPolynomial bpoly_(
-        UnivariatePolynomial::from_dict(x, std::move(bdict_)));
+    UnivariateExprPolynomial bpoly_(bdict_);
     RCP<const UnivariateSeries> Q = UnivariateSeries::create(x, 5, bpoly_);
     REQUIRE(Q->__str__() == "x**3 + 2*x**2 + 1 + O(x**5)");
 
     map_int_Expr cdict_
         = {{0, symbol("c")}, {1, symbol("b")}, {2, symbol("a")}};
-    UnivariateExprPolynomial cpoly_(
-        univariate_polynomial(x, std::move(cdict_)));
+    UnivariateExprPolynomial cpoly_(cdict_);
     RCP<const UnivariateSeries> R = UnivariateSeries::create(x, 3, cpoly_);
     REQUIRE(R->__str__() == "a*x**2 + b*x + c + O(x**3)");
 }
@@ -58,14 +55,11 @@ TEST_CASE("Adding two UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
     map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    UnivariateExprPolynomial apoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial apoly_(adict_);
     map_int_Expr bdict_ = {{0, 2}, {1, 3}, {2, 4}};
-    UnivariateExprPolynomial bpoly_(
-        univariate_polynomial(x, std::move(bdict_)));
+    UnivariateExprPolynomial bpoly_(bdict_);
     map_int_Expr ddict_ = {{0, 3}, {1, 5}, {2, 5}};
-    UnivariateExprPolynomial dpoly_(
-        univariate_polynomial(x, std::move(ddict_)));
+    UnivariateExprPolynomial dpoly_(ddict_);
 
     RCP<const UnivariateSeries> a = UnivariateSeries::create(x, 5, apoly_);
     RCP<const UnivariateSeries> b = UnivariateSeries::create(x, 4, bpoly_);
@@ -83,17 +77,13 @@ TEST_CASE("Negative of a UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
     map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    UnivariateExprPolynomial apoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial apoly_(adict_);
     map_int_Expr bdict_ = {{0, -1}, {1, -2}, {2, -1}};
-    UnivariateExprPolynomial bpoly_(
-        univariate_polynomial(x, std::move(bdict_)));
+    UnivariateExprPolynomial bpoly_(bdict_);
     map_int_Expr cdict_ = {{0, 1}, {1, symbol("a")}};
-    UnivariateExprPolynomial cpoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial cpoly_(cdict_);
     map_int_Expr ddict_ = {{0, -1}, {1, mul(integer(-1), symbol("a"))}};
-    UnivariateExprPolynomial dpoly_(
-        univariate_polynomial(x, std::move(bdict_)));
+    UnivariateExprPolynomial dpoly_(ddict_);
 
     RCP<const UnivariateSeries> a = UnivariateSeries::create(x, 5, apoly_);
     RCP<const Basic> b = neg(a);
@@ -109,17 +99,13 @@ TEST_CASE("Subtracting two UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
     map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    UnivariateExprPolynomial apoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial apoly_(adict_);
     map_int_Expr bdict_ = {{0, 2}, {1, 3}, {2, 4}};
-    UnivariateExprPolynomial bpoly_(
-        univariate_polynomial(x, std::move(bdict_)));
+    UnivariateExprPolynomial bpoly_(bdict_);
     map_int_Expr fdict_ = {{0, -1}, {1, -1}, {2, -3}};
-    UnivariateExprPolynomial fpoly_(
-        univariate_polynomial(x, std::move(fdict_)));
+    UnivariateExprPolynomial fpoly_(fdict_);
     map_int_Expr gdict_ = {{0, -1}, {1, -1}};
-    UnivariateExprPolynomial gpoly_(
-        univariate_polynomial(x, std::move(gdict_)));
+    UnivariateExprPolynomial gpoly_(gdict_);
 
     RCP<const UnivariateSeries> a = UnivariateSeries::create(x, 3, apoly_);
     RCP<const UnivariateSeries> b = UnivariateSeries::create(x, 4, bpoly_);
@@ -137,14 +123,10 @@ TEST_CASE("Multiplication of two UnivariateExprPolynomial with precision",
           "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial a(
-        univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}}));
-    UnivariateExprPolynomial b(
-        univariate_polynomial(x, {{0, -1}, {1, -2}, {2, -1}}));
-    UnivariateExprPolynomial c(
-        univariate_polynomial(x, {{0, 1}, {1, 4}, {2, 6}, {3, 4}}));
-    UnivariateExprPolynomial d(univariate_polynomial(
-        x, {{0, -1}, {1, -4}, {2, -6}, {3, -4}, {4, -1}}));
+    UnivariateExprPolynomial a({{0, 1}, {1, 2}, {2, 1}});
+    UnivariateExprPolynomial b({{0, -1}, {1, -2}, {2, -1}});
+    UnivariateExprPolynomial c({{0, 1}, {1, 4}, {2, 6}, {3, 4}});
+    UnivariateExprPolynomial d({{0, -1}, {1, -4}, {2, -6}, {3, -4}, {4, -1}});
 
     UnivariateExprPolynomial e = UnivariateSeries::mul(a, a, 4);
     UnivariateExprPolynomial f = UnivariateSeries::mul(a, b, 5);
@@ -157,16 +139,13 @@ TEST_CASE("Exponentiation of UnivariateExprPolynomial with precision",
           "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial zero(univariate_polynomial(symbol(""), {{0, 0}}));
-    UnivariateExprPolynomial one(univariate_polynomial(symbol(""), {{0, 1}}));
-    UnivariateExprPolynomial a(
-        univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}}));
-    UnivariateExprPolynomial b(
-        univariate_polynomial(x, {{0, -1}, {1, -2}, {2, -1}}));
-    UnivariateExprPolynomial c(
-        univariate_polynomial(x, {{0, 1}, {1, 4}, {2, 6}, {3, 4}}));
-    UnivariateExprPolynomial d(univariate_polynomial(
-        x, {{0, -1}, {1, -6}, {2, -15}, {3, -20}, {4, -15}}));
+    UnivariateExprPolynomial zero({{0, Expression(0)}});
+    UnivariateExprPolynomial one({{0, Expression(1)}});
+    UnivariateExprPolynomial a({{0, 1}, {1, 2}, {2, 1}});
+    UnivariateExprPolynomial b({{0, -1}, {1, -2}, {2, -1}});
+    UnivariateExprPolynomial c({{0, 1}, {1, 4}, {2, 6}, {3, 4}});
+    UnivariateExprPolynomial d(
+        {{0, -1}, {1, -6}, {2, -15}, {3, -20}, {4, -15}});
 
     UnivariateExprPolynomial e = UnivariateSeries::pow(a, 2, 4);
     UnivariateExprPolynomial f = UnivariateSeries::pow(b, 3, 5);
@@ -181,20 +160,17 @@ TEST_CASE("Exponentiation of UnivariateExprPolynomial with precision",
 TEST_CASE("Differentiation of UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial a(
-        univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}}));
-    UnivariateExprPolynomial b(univariate_polynomial(x, {{0, 2}, {1, 2}}));
+    UnivariateExprPolynomial a({{0, 1}, {1, 2}, {2, 1}});
+    UnivariateExprPolynomial b({{0, 2}, {1, 2}});
     REQUIRE(UnivariateSeries::diff(a, UnivariateSeries::var("x")) == b);
 }
 
 TEST_CASE("Integration of UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial a(univariate_polynomial(x, {{-1, 1}}));
-    UnivariateExprPolynomial b(
-        univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 3}}));
-    UnivariateExprPolynomial c(
-        univariate_polynomial(x, {{1, 1}, {2, 1}, {3, 1}}));
+    UnivariateExprPolynomial a({{-1, Expression(1)}});
+    UnivariateExprPolynomial b({{0, 1}, {1, 2}, {2, 3}});
+    UnivariateExprPolynomial c({{1, 1}, {2, 1}, {3, 1}});
     REQUIRE_THROWS_AS(
         UnivariateSeries::integrate(a, UnivariateSeries::var("x")),
         std::runtime_error);
@@ -204,9 +180,8 @@ TEST_CASE("Integration of UnivariateSeries", "[UnivariateSeries]")
 TEST_CASE("UnivariateSeries: compare, as_basic, as_dict", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial P(univariate_polynomial(x, {{0, 1}, {1, 2}}));
-    UnivariateExprPolynomial Q(
-        univariate_polynomial(x, {{0, 1}, {1, symbol("b")}, {2, 1}}));
+    UnivariateExprPolynomial P({{0, 1}, {1, 2}});
+    UnivariateExprPolynomial Q({{0, 1}, {1, symbol("b")}, {2, 1}});
     RCP<const UnivariateSeries> R = univariate_series(x, 4, P);
     RCP<const UnivariateSeries> S = univariate_series(x, 5, Q);
     umap_int_basic m = {{0, integer(1)}, {1, integer(2)}};

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -24,6 +24,7 @@ using SymEngine::Expression;
 using SymEngine::pow;
 using SymEngine::univariate_int_polynomial;
 using SymEngine::univariate_polynomial;
+using SymEngine::UnivariateExprPolynomial;
 using SymEngine::mul;
 using SymEngine::integer;
 using SymEngine::print_stack_on_segfault;
@@ -304,38 +305,48 @@ TEST_CASE("test_univariate_polynomial(): printing", "[printing]")
     Expression c(symbol("c"));
     Expression d(symbol("d"));
 
-    p = univariate_polynomial(x, {{0, 0}});
+    p = univariate_polynomial(x,
+                              UnivariateExprPolynomial({{0, Expression(0)}}));
     REQUIRE(p->__str__() == "0");
-    p = univariate_polynomial(x, {{0, 1}});
+    p = univariate_polynomial(x,
+                              UnivariateExprPolynomial({{0, Expression(1)}}));
     REQUIRE(p->__str__() == "1");
-    p = univariate_polynomial(x, {{1, 1}});
+    p = univariate_polynomial(x,
+                              UnivariateExprPolynomial({{1, Expression(1)}}));
     REQUIRE(p->__str__() == "x");
-    p = univariate_polynomial(x, {{0, 1}, {1, 2}});
+    p = univariate_polynomial(x, UnivariateExprPolynomial({{0, 1}, {1, 2}}));
     REQUIRE(p->__str__() == "2*x + 1");
-    p = univariate_polynomial(x, {{0, -1}, {1, 2}});
+    p = univariate_polynomial(x, UnivariateExprPolynomial({{0, -1}, {1, 2}}));
     REQUIRE(p->__str__() == "2*x - 1");
-    p = univariate_polynomial(x, {{0, -1}});
+    p = univariate_polynomial(x,
+                              UnivariateExprPolynomial({{0, Expression(-1)}}));
     REQUIRE(p->__str__() == "-1");
-    p = univariate_polynomial(x, {{1, -1}});
+    p = univariate_polynomial(x,
+                              UnivariateExprPolynomial({{1, Expression(-1)}}));
     REQUIRE(p->__str__() == "-x");
-    p = univariate_polynomial(x, {{0, -1}, {1, 1}});
+    p = univariate_polynomial(x, UnivariateExprPolynomial({{0, -1}, {1, 1}}));
     REQUIRE(p->__str__() == "x - 1");
-    p = univariate_polynomial(x, {{0, 1}, {1, 1}, {2, 1}});
+    p = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 1}, {2, 1}}));
     REQUIRE(p->__str__() == "x**2 + x + 1");
-    p = univariate_polynomial(x, {{0, 1}, {1, -1}, {2, 1}});
+    p = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, -1}, {2, 1}}));
     REQUIRE(p->__str__() == "x**2 - x + 1");
-    p = univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}});
+    p = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, 1}, {1, 2}, {2, 1}}));
     REQUIRE(p->__str__() == "x**2 + 2*x + 1");
-    p = univariate_polynomial(x, {{1, 2}, {2, 1}});
+    p = univariate_polynomial(x, UnivariateExprPolynomial({{1, 2}, {2, 1}}));
     REQUIRE(p->__str__() == "x**2 + 2*x");
-    p = univariate_polynomial(x, {{0, -1}, {1, -2}, {2, -1}});
+    p = univariate_polynomial(
+        x, UnivariateExprPolynomial({{0, -1}, {1, -2}, {2, -1}}));
     REQUIRE(p->__str__() == "-x**2 - 2*x - 1");
-    p = univariate_polynomial(x, {{-1, d}});
+    p = univariate_polynomial(x, UnivariateExprPolynomial({{-1, d}}));
 
     REQUIRE(p->__str__() == "d*x**(-1)");
     REQUIRE(not(p->__str__() == "d*x**-1"));
 
-    p = univariate_polynomial(x, {{-2, d}, {-1, c}, {0, b}, {1, a}});
+    p = univariate_polynomial(
+        x, UnivariateExprPolynomial({{-2, d}, {-1, c}, {0, b}, {1, a}}));
     REQUIRE(p->__str__() == "a*x + b + c*x**(-1) + d*x**(-2)");
 }
 


### PR DESCRIPTION
* Ignore flint executables

* Changed mul_uni_poly parameters to const & instead of RCP UnivariatePolynomial

* UnivariatePolynomial wraps UnivariateExprPolynomial, which has map_int_Expr dict; progress on changes to series_generic use of UnivariateExprPolynomial

* Add constant multiplication condition for faster performance, UnivariateExprPolynomial benchmark tests

* Refactor UnivariateSeries and most of its tests to work with new UnivariateExprPolynomial except as_basic(), moved 0 checking in UnivariatePolynomial to UnivariateExprPolynomial

* Check for 0 terms in all UnivariateExprPolynomial constructors, uncomment rest of test_series_generic

* Resolve conflicts