### PR TITLE
removed redundant function `create`

### DIFF
--- a/benchmarks/series.cpp
+++ b/benchmarks/series.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
         v.push_back(coef);
     }
 
-    UnivariateExprPolynomial c, p(UnivariatePolynomial::create(x, v));
+    UnivariateExprPolynomial c, p(UnivariatePolynomial::from_vec(x, v));
     auto t1 = std::chrono::high_resolution_clock::now();
     c = UnivariateSeries::mul(p, p, 1000);
     auto t2 = std::chrono::high_resolution_clock::now();

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -33,12 +33,6 @@ public:
     UnivariateIntPolynomial(const RCP<const Symbol> &var,
                             const std::vector<integer_class> &v);
 
-    static RCP<const UnivariateIntPolynomial>
-    create(const RCP<const Symbol> &var, const std::vector<integer_class> &v)
-    {
-        return UnivariateIntPolynomial::from_vec(var, v);
-    }
-
     //! \return true if canonical
     bool is_canonical(const unsigned int &degree,
                       const map_uint_mpz &dict) const;
@@ -132,12 +126,6 @@ public:
     //! Constructor using a dense vector of Expression
     UnivariatePolynomial(const RCP<const Symbol> &var,
                          const std::vector<Expression> &v);
-
-    static RCP<const UnivariatePolynomial>
-    create(const RCP<const Symbol> &var, const std::vector<Expression> &v)
-    {
-        return UnivariatePolynomial::from_vec(var, v);
-    }
 
     bool is_canonical(const int &degree, const map_int_Expr &dict) const;
     std::size_t __hash__() const;
@@ -239,11 +227,11 @@ public:
     {
     }
     UnivariateExprPolynomial(int i)
-        : poly_(UnivariatePolynomial::create(symbol(""), {Expression(i)}))
+        : poly_(UnivariatePolynomial::from_vec(symbol(""), {Expression(i)}))
     {
     }
     UnivariateExprPolynomial(std::string varname)
-        : poly_(UnivariatePolynomial::create(symbol(varname), {0, 1}))
+        : poly_(UnivariatePolynomial::from_vec(symbol(varname), {0, 1}))
     {
     }
     UnivariateExprPolynomial(RCP<const UnivariatePolynomial> p)
@@ -251,7 +239,7 @@ public:
     {
     }
     UnivariateExprPolynomial(Expression expr)
-        : poly_(UnivariatePolynomial::create(symbol(""), {expr}))
+        : poly_(UnivariatePolynomial::from_vec(symbol(""), {expr}))
     {
     }
     UnivariateExprPolynomial &operator=(const UnivariateExprPolynomial &)

--- a/symengine/series_generic.cpp
+++ b/symengine/series_generic.cpp
@@ -14,7 +14,8 @@ RCP<const UnivariateSeries> UnivariateSeries::series(const RCP<const Basic> &t,
                                                      const std::string &x,
                                                      unsigned int prec)
 {
-    UnivariateExprPolynomial p(UnivariatePolynomial::create(symbol(x), {0, 1}));
+    UnivariateExprPolynomial p(
+        UnivariatePolynomial::from_vec(symbol(x), {0, 1}));
     SeriesVisitor<UnivariateExprPolynomial, Expression, UnivariateSeries>
         visitor(std::move(p), x, prec);
     return visitor.series(t);
@@ -58,7 +59,7 @@ RCP<const Basic> UnivariateSeries::get_coeff(int deg) const
 UnivariateExprPolynomial UnivariateSeries::var(const std::string &s)
 {
     return UnivariateExprPolynomial(
-        UnivariatePolynomial::create(symbol(s), {0, 1}));
+        UnivariatePolynomial::from_vec(symbol(s), {0, 1}));
 }
 
 Expression UnivariateSeries::convert(const Basic &x)

--- a/symengine/tests/basic/test_polynomial.cpp
+++ b/symengine/tests/basic/test_polynomial.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Constructor of UnivariateIntPolynomial", "[UnivariateIntPolynomial]")
     REQUIRE(P->__str__() == "x**2 + 2*x + 1");
 
     RCP<const UnivariateIntPolynomial> Q
-        = UnivariateIntPolynomial::create(x, {1_z, 0_z, 2_z, 1_z});
+        = UnivariateIntPolynomial::from_vec(x, {1_z, 0_z, 2_z, 1_z});
     REQUIRE(Q->__str__() == "x**3 + 2*x**2 + 1");
 
     UnivariateIntPolynomial R(x, {1_z, 0_z, 2_z, 1_z});
@@ -311,7 +311,7 @@ TEST_CASE("Constructor of UnivariatePolynomial", "[UnivariatePolynomial]")
     REQUIRE(P->__str__() == "x**2 + 2*x + 1");
 
     RCP<const UnivariatePolynomial> Q
-        = UnivariatePolynomial::create(x, {1, 0, 2, 1});
+        = UnivariatePolynomial::from_vec(x, {1, 0, 2, 1});
     REQUIRE(Q->__str__() == "x**3 + 2*x**2 + 1");
 
     RCP<const UnivariatePolynomial> R


### PR DESCRIPTION
The functions `from_dict`, `from_vec` and `create` have been removed from the `UnivariateIntPolynomial` class, essentially because they were not needed. Also, the method `univariate_int_polynomial` function has been overloaded to take in both dictionaries and vectors, to construct the polynomial. 

In the `univariate_int_polynomial`, for singletons in dictionaries, we explicitly have to tell the type (vector or dic) (otherwise it is an ambiguous function call).  ie
```
T = univariate_int_polynomial(x, map_uint_mpz{{0, 2_z}});
REQUIRE(T->__str__() == "2");

U = univariate_int_polynomial(x, std::vector<integer_class>{{0_z, 2_z}});
REQUIRE(U->__str__() == "2*x");
```
Have made these changes wherever required. Also, some add, sub and neg tests were changed.