### PR TITLE
Bugfixes for series.h

### DIFF
--- a/symengine/integer.cpp
+++ b/symengine/integer.cpp
@@ -78,9 +78,13 @@ RCP<const Number> Integer::pow_negint(const Integer &other) const
 {
     RCP<const Number> tmp = powint(*other.neg());
     if (is_a<Integer>(*tmp)) {
-        rational_class q(mp_sign(static_cast<const Integer &>(*tmp).i),
-                         mp_abs(static_cast<const Integer &>(*tmp).i));
-        return make_rcp<const Rational>(std::move(q));
+        if (mp_abs(static_cast<const Integer &>(*tmp).i) != 1) {
+            rational_class q(mp_sign(static_cast<const Integer &>(*tmp).i),
+                             mp_abs(static_cast<const Integer &>(*tmp).i));
+            return make_rcp<const Rational>(std::move(q));
+        }
+        return make_rcp<const Integer>(static_cast<const Integer &>(*tmp).i);
+
     } else {
         throw std::runtime_error("powint returned non-integer");
     }

--- a/symengine/integer.cpp
+++ b/symengine/integer.cpp
@@ -78,13 +78,9 @@ RCP<const Number> Integer::pow_negint(const Integer &other) const
 {
     RCP<const Number> tmp = powint(*other.neg());
     if (is_a<Integer>(*tmp)) {
-        if (mp_abs(static_cast<const Integer &>(*tmp).i) != 1) {
-            rational_class q(mp_sign(static_cast<const Integer &>(*tmp).i),
-                             mp_abs(static_cast<const Integer &>(*tmp).i));
-            return make_rcp<const Rational>(std::move(q));
-        }
-        return make_rcp<const Integer>(static_cast<const Integer &>(*tmp).i);
-
+        rational_class q(mp_sign(static_cast<const Integer &>(*tmp).i),
+                         mp_abs(static_cast<const Integer &>(*tmp).i));
+        return Rational::from_mpq(std::move(q));
     } else {
         throw std::runtime_error("powint returned non-integer");
     }

--- a/symengine/series.h
+++ b/symengine/series.h
@@ -346,7 +346,7 @@ public:
                                      prec);
     }
 
-    static inline Poly res_sin(const Poly &s, unsigned int prec)
+    static inline Poly _series_sin(const Poly &s, unsigned int prec)
     {
         Poly res_p(0), monom(s);
         Poly ssquare = Series::mul(s, s, prec);
@@ -368,10 +368,10 @@ public:
         const Coeff c(Series::find_cf(s, var, 0));
         if (c != 0) {
             const Poly t = s - c;
-            return Series::cos(c) * res_sin(t, prec)
-                   + Series::sin(c) * res_cos(t, prec);
+            return Series::cos(c) * _series_sin(t, prec)
+                   + Series::sin(c) * _series_cos(t, prec);
         } else {
-            return res_sin(s, prec);
+            return _series_sin(s, prec);
         }
 
         //        if (c == 0) {
@@ -424,7 +424,7 @@ public:
         return Series::acos(c) - series_asin(s - c, var, prec);
     }
 
-    static inline Poly res_cos(const Poly &s, unsigned int prec)
+    static inline Poly _series_cos(const Poly &s, unsigned int prec)
     {
         Poly res_p(1);
         Poly ssquare = Series::mul(s, s, prec);
@@ -447,10 +447,10 @@ public:
         const Coeff c(Series::find_cf(s, var, 0));
         if (c != 0) {
             const Poly t = s - c;
-            return Series::cos(c) * res_cos(t, prec)
-                   - Series::sin(c) * res_sin(t, prec);
+            return Series::cos(c) * _series_cos(t, prec)
+                   - Series::sin(c) * _series_sin(t, prec);
         } else {
-            return res_cos(s, prec);
+            return _series_cos(s, prec);
         }
         //
         //        if (c == 0) {

--- a/symengine/series.h
+++ b/symengine/series.h
@@ -265,7 +265,7 @@ public:
             res_p *= Series::pow(var, ldeg / n, prec);
         }
         if (do_inv)
-            return res_p * ctroot;
+            return res_p / ctroot;
         else
             return Series::series_invert(res_p, var, prec) * ctroot;
     }
@@ -346,17 +346,8 @@ public:
                                      prec);
     }
 
-    static inline Poly series_sin(const Poly &s, const Poly &var,
-                                  unsigned int prec)
+    static inline Poly res_sin(const Poly &s, unsigned int prec)
     {
-        const Coeff c(Series::find_cf(s, var, 0));
-
-        if (c != 0) {
-            const Poly t = s - c;
-            return Series::sin(c) * Series::series_cos(t, var, prec)
-                   + Series::cos(c) * Series::series_sin(t, var, prec);
-        }
-        //! fast sin(x)
         Poly res_p(0), monom(s);
         Poly ssquare = Series::mul(s, s, prec);
         Coeff prod(1);
@@ -369,6 +360,19 @@ public:
             monom = Series::mul(monom, ssquare, prec);
         }
         return res_p;
+    }
+
+    static inline Poly series_sin(const Poly &s, const Poly &var,
+                                  unsigned int prec)
+    {
+        const Coeff c(Series::find_cf(s, var, 0));
+        if (c != 0) {
+            const Poly t = s - c;
+            return Series::cos(c) * res_sin(t, prec)
+                   + Series::sin(c) * res_cos(t, prec);
+        } else {
+            return res_sin(s, prec);
+        }
 
         //        if (c == 0) {
         //            // return 2*t/(1+t**2)
@@ -420,15 +424,8 @@ public:
         return Series::acos(c) - series_asin(s - c, var, prec);
     }
 
-    static inline Poly series_cos(const Poly &s, const Poly &var,
-                                  unsigned int prec)
+    static inline Poly res_cos(const Poly &s, unsigned int prec)
     {
-        const Coeff c(Series::find_cf(s, var, 0));
-        if (c != 0) {
-            const Poly t = s - c;
-            return Series::cos(c) * Series::series_cos(t, var, prec)
-                   - Series::sin(c) * Series::series_sin(t, var, prec);
-        }
         Poly res_p(1);
         Poly ssquare = Series::mul(s, s, prec);
         Poly monom(ssquare);
@@ -442,6 +439,19 @@ public:
             monom = Series::mul(monom, ssquare, prec);
         }
         return res_p;
+    }
+
+    static inline Poly series_cos(const Poly &s, const Poly &var,
+                                  unsigned int prec)
+    {
+        const Coeff c(Series::find_cf(s, var, 0));
+        if (c != 0) {
+            const Poly t = s - c;
+            return Series::cos(c) * res_cos(t, prec)
+                   - Series::sin(c) * res_sin(t, prec);
+        } else {
+            return res_cos(s, prec);
+        }
         //
         //        if (c == 0) {
         //            // return (1-t**2)/(1+t**2)
@@ -623,9 +633,10 @@ public:
         if (c != 0) {
             res_p -= c;
         }
+        Poly s_(res_p);
         auto steps = step_list(prec);
         for (const auto step : steps) {
-            const Poly p(s - Series::series_atanh(res_p, var, step));
+            const Poly p(s_ - Series::series_atanh(res_p, var, step));
             res_p += Series::mul(-p, Series::pow(res_p, 2, step) - 1, step);
         }
         if (c != 0) {

--- a/symengine/series_visitor.h
+++ b/symengine/series_visitor.h
@@ -66,7 +66,10 @@ public:
             } else if (sh == -1) {
                 p = Series::series_invert(p, var, prec);
             } else {
-                p = Series::series_invert(Series::pow(p, -sh, prec), var, prec);
+                // Invert and then exponentiate to give the correct behavior
+                // when expanding 1/x**(prec), which should return x**(-prec),
+                // not 0.
+                p = Series::pow(Series::series_invert(p, var, prec), -sh, prec);
             }
 
         } else if (is_a<Rational>(*exp)) {

--- a/symengine/tests/basic/test_series_generic.cpp
+++ b/symengine/tests/basic/test_series_generic.cpp
@@ -28,6 +28,8 @@ using SymEngine::umap_short_basic;
 using SymEngine::EulerGamma;
 using SymEngine::Number;
 using SymEngine::umap_int_basic;
+using SymEngine::pi;
+using SymEngine::I;
 
 using namespace SymEngine::literals;
 
@@ -242,7 +244,9 @@ TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]")
     auto z3 = add(sin(x), cos(x));
     auto z4 = mul(sin(x), cos(x));
     auto z5 = sin(atan(x));
+    auto z5prime = sin(add(x, integer(5)));
     auto z6 = cos(div(x, sub(one, x)));
+    auto z6prime = cos(add(x, integer(5)));
     auto z7 = sin(mul(symbol("a"), x));
 
     REQUIRE(series_coeff(z1, x, 10, 9)->__eq__(*rational(1, 362880)));
@@ -251,7 +255,11 @@ TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]")
     REQUIRE(series_coeff(z3, x, 9, 8)->__eq__(*rational(1, 40320)));
     REQUIRE(series_coeff(z4, x, 12, 11)->__eq__(*rational(-4, 155925)));
     REQUIRE(series_coeff(z5, x, 30, 27)->__eq__(*rational(-1300075, 8388608)));
+    REQUIRE(series_coeff(z5prime, x, 11, 10)
+                ->__eq__(*mul(rational(-1, 3628800), sin(integer(5)))));
     REQUIRE(series_coeff(z6, x, 15, 11)->__eq__(*rational(-125929, 362880)));
+    REQUIRE(series_coeff(z6prime, x, 15, 11)
+                ->__eq__(*mul(rational(1, 39916800), sin(integer(5)))));
     REQUIRE(series_coeff(z7, x, 10, 9)
                 ->__eq__(
                     *mul((pow(symbol("a"), integer(9))), rational(1, 362880))));
@@ -318,6 +326,7 @@ TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]")
     auto ex3 = log(div(one, sub(one, x)));
     auto ex4 = exp(x);
     auto ex5 = exp(log(add(x, one)));
+    auto ex5prime = exp(add(x, integer(5)));
     auto ex6 = log(exp(x));
     auto ex7 = exp(sin(x));
     auto ex8 = pow(cos(x), sin(x));
@@ -329,6 +338,8 @@ TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]")
     auto res1 = umap_short_basic{{0, integer(1)}, {1, integer(1)}};
     auto res2 = umap_short_basic{{1, integer(1)}};
     REQUIRE(expand_check_pairs(ex5, x, 20, res1));
+    REQUIRE(series_coeff(ex5prime, x, 20, 11)
+                ->__eq__(*mul(exp(integer(5)), rational(1, 39916800))));
     REQUIRE(expand_check_pairs(ex6, x, 20, res2));
     REQUIRE(series_coeff(ex7, x, 20, 10)->__eq__(*rational(-2951, 3628800)));
     REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*rational(1381, 2661120)));
@@ -359,8 +370,28 @@ TEST_CASE("Expression series expansion: atan, tan, asin, cot, sec, csc",
     auto ex2 = atan(div(x, sub(one, x)));
     auto ex3 = tan(x);
     auto ex4 = tan(div(x, sub(one, x)));
+    auto ex4prime = tan(add(x, integer(5)));
+    auto ans4 = add(
+        pow(tan(integer(5)), integer(13)), // tan(5)**13 +
+        add(mul(rational(13, 3),
+                pow(tan(integer(5)), integer(11))), // (13/3)*tan(5)**11 +
+            add(mul(rational(338, 45),
+                    pow(tan(integer(5)), integer(9))), // (338/45)*tan(5)**9 +
+                add(mul(rational(6214, 945),
+                        pow(tan(integer(5)),
+                            integer(7))), // (6214/945)*tan(5)**7
+                    add(mul(rational(6071, 2025),
+                            pow(tan(integer(5)),
+                                integer(5))), // + (6071/2025)*tan(5)**5
+                        add(mul(rational(1729, 2673),
+                                pow(tan(integer(5)),
+                                    integer(3))), // + (1729/2673)*tan(5)**3
+                            mul(rational(21844, 467775),
+                                tan(integer(
+                                    5))))))))); // + (21844/467775)*tan(5)
     auto ex5 = asin(x);
     auto ex6 = asin(div(x, sub(one, x)));
+    auto ex6prime = asin(add(x, integer(5)));
     auto ex7 = cot(x);
     auto ex8 = cot(sin(x));
     auto res1 = umap_short_basic{{-1, integer(1)}, {1, rational(-1, 3)}};
@@ -375,8 +406,12 @@ TEST_CASE("Expression series expansion: atan, tan, asin, cot, sec, csc",
     REQUIRE(series_coeff(ex2, x, 40, 33)->__eq__(*rational(65536, 33)));
     REQUIRE(series_coeff(ex3, x, 20, 13)->__eq__(*rational(21844, 6081075)));
     REQUIRE(series_coeff(ex4, x, 20, 12)->__eq__(*rational(1303712, 14175)));
+    REQUIRE(expand(series_coeff(ex4prime, x, 20, 12))->__eq__(*ans4));
     REQUIRE(series_coeff(ex5, x, 20, 15)->__eq__(*rational(143, 10240)));
     REQUIRE(series_coeff(ex6, x, 20, 16)->__eq__(*rational(1259743, 2048)));
+    REQUIRE(series_coeff(ex6prime, x, 10, 5)
+                ->__eq__(*mul(rational(-5603, 318504960),
+                              mul(I, sqrt(integer(24))))));
     REQUIRE(expand_check_pairs(ex7, x, 5, res1));
     REQUIRE(expand_check_pairs(ex8, x, 10, res2));
     REQUIRE(series_coeff(ex9, x, 20, 8)->__eq__(*rational(277, 8064)));
@@ -394,6 +429,29 @@ TEST_CASE("Expression series expansion: sinh, cosh, tanh, asinh, atanh",
     auto ex4 = cosh(div(x, sub(one, x)));
     auto ex5 = tanh(x);
     auto ex6 = tanh(div(x, sub(one, x)));
+    auto ex6prime = tanh(add(x, integer(5)));
+    auto ans6 = add(
+        mul(rational(-2141, 189),
+            pow(tanh(integer(5)), integer(9))), //-2141*tanh(5)**9/189
+        add(mul(integer(-5),
+                pow(tanh(integer(5)), integer(13))), //- 5*tanh(5)**13
+            add(mul(rational(-24779, 10395),
+                    pow(tanh(integer(5)),
+                        integer(5))), //- 24779*tanh(5)**5/10395
+                add(mul(rational(-929569, 42567525),
+                        tanh(integer(5))), //- 929569*tanh(5)/42567525
+                    add(mul(rational(16769029, 42567525),
+                            pow(tanh(integer(5)),
+                                integer(3))), //+ 16769029*tanh(5)**3/42567525
+                        add(pow(tanh(integer(5)), integer(15)), //+ tanh(5)**15
+                            add(mul(rational(2207, 315),
+                                    pow(tanh(integer(5)),
+                                        integer(7))), //+ 2207*tanh(5)**7/315
+                                mul(rational(31, 3),
+                                    pow(tanh(integer(5)),
+                                        integer(
+                                            11)))))))))); //+ 31*tanh(5)**11/3
+
     auto ex7 = atanh(x);
     auto ex8 = atanh(div(x, sub(one, x)));
     auto ex9 = asinh(x);
@@ -405,6 +463,7 @@ TEST_CASE("Expression series expansion: sinh, cosh, tanh, asinh, atanh",
     REQUIRE(series_coeff(ex4, x, 20, 11)->__eq__(*rational(3756889, 362880)));
     REQUIRE(series_coeff(ex5, x, 20, 13)->__eq__(*rational(21844, 6081075)));
     REQUIRE(series_coeff(ex6, x, 20, 14)->__eq__(*rational(225979, 66825)));
+    REQUIRE(expand(series_coeff(ex6prime, x, 20, 14))->__eq__(*ans6));
     REQUIRE(series_coeff(ex7, x, 100, 99)->__eq__(*rational(1, 99)));
     REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*integer(2048)));
     REQUIRE(series_coeff(ex9, x, 20, 15)->__eq__(*rational(-143, 10240)));


### PR DESCRIPTION
While testing multivariable series expansion, I found a few bugs in `series.h`.  Since multivariable expansion is not quite ready yet and these bugs are in code that's already out there, I'm submitting these fixes in a separate PR.  

It seems that the functions in `series.h` were not tested on inputs with nonzero constant terms, so I've also added some tests to that effect.  

