### PR TITLE
Misc changes polynomials

### DIFF
--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -59,22 +59,6 @@ int UnivariateIntPolynomial::compare(const Basic &o) const
     return map_uint_mpz_compare(poly_.dict_, s.poly_.dict_);
 }
 
-RCP<const UnivariateIntPolynomial>
-UnivariateIntPolynomial::from_dict(const RCP<const Symbol> &var, UIntDict &&d)
-{
-    auto iter = d.dict_.begin();
-    while (iter != d.dict_.end()) {
-        if (iter->second == 0) {
-            auto toErase = iter;
-            iter++;
-            d.dict_.erase(toErase);
-        } else {
-            iter++;
-        }
-    }
-    return make_rcp<const UnivariateIntPolynomial>(var, std::move(d));
-}
-
 vec_basic UnivariateIntPolynomial::get_args() const
 {
     vec_basic args;
@@ -226,13 +210,6 @@ int UnivariatePolynomial::compare(const Basic &o) const
         return cmp;
 
     return map_int_Expr_compare(poly_.get_dict(), s.poly_.get_dict());
-}
-
-RCP<const UnivariatePolynomial>
-UnivariatePolynomial::from_dict(const RCP<const Symbol> &var,
-                                UnivariateExprPolynomial &&d)
-{
-    return make_rcp<const UnivariatePolynomial>(var, std::move(d));
 }
 
 vec_basic UnivariatePolynomial::get_args() const

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -11,22 +11,28 @@ UnivariateIntPolynomial::UnivariateIntPolynomial(const RCP<const Symbol> &var,
                                                  UIntDict &&dict)
     : UIntPolyBase(var, std::move(dict))
 {
-    SYMENGINE_ASSERT(is_canonical(poly_))
+    auto iter = dict.dict_.begin();
+    while (iter != dict.dict_.end()) {
+        if (iter->second == integer_class(0)) {
+            auto toErase = iter;
+            iter++;
+            dict.dict_.erase(toErase);
+        } else {
+            iter++;
+        }
+    }
 }
 
 UnivariateIntPolynomial::UnivariateIntPolynomial(
     const RCP<const Symbol> &var, const std::vector<integer_class> &v)
     : UIntPolyBase(var, std::move(v))
 {
-}
-
-bool UnivariateIntPolynomial::is_canonical(const UIntDict &dict) const
-{
-    // Check if dictionary contains terms with coeffienct 0
-    for (auto iter : dict.dict_)
-        if (iter.second == 0)
-            return false;
-    return true;
+    poly_.dict_ = {};
+    for (unsigned int i = 0; i < v.size(); i++) {
+        if (v[i] != integer_class(0)) {
+            poly_.dict_[i] = v[i];
+        }
+    }
 }
 
 std::size_t UnivariateIntPolynomial::__hash__() const
@@ -158,23 +164,28 @@ UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
                                            UnivariateExprPolynomial &&dict)
     : UIntPolyBase(var, std::move(dict))
 {
-    SYMENGINE_ASSERT(is_canonical(poly_))
+    auto iter = dict.dict_.begin();
+    while (iter != dict.dict_.end()) {
+        if (iter->second == Expression(0)) {
+            auto toErase = iter;
+            iter++;
+            dict.dict_.erase(toErase);
+        } else {
+            iter++;
+        }
+    }
 }
 
 UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
                                            const std::vector<Expression> &v)
     : UIntPolyBase(var, std::move(v))
 {
-}
-
-bool UnivariatePolynomial::is_canonical(
-    const UnivariateExprPolynomial &dict) const
-{
-    // Check if dictionary contains terms with coeffienct 0
-    for (auto iter : dict.get_dict())
-        if (iter.second == 0)
-            return false;
-    return true;
+    poly_.dict_ = {};
+    for (unsigned int i = 0; i < v.size(); i++) {
+        if (v[i] != Expression(0)) {
+            poly_.dict_[i] = v[i];
+        }
+    }
 }
 
 std::size_t UnivariatePolynomial::__hash__() const

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -11,7 +11,6 @@ UnivariateIntPolynomial::UnivariateIntPolynomial(const RCP<const Symbol> &var,
                                                  UIntDict &&dict)
     : UIntPolyBase(var, std::move(dict))
 {
-
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 
@@ -19,12 +18,6 @@ UnivariateIntPolynomial::UnivariateIntPolynomial(
     const RCP<const Symbol> &var, const std::vector<integer_class> &v)
     : UIntPolyBase(var, std::move(v))
 {
-    poly_.dict_ = {};
-    for (unsigned int i = 0; i < v.size(); i++) {
-        if (v[i] != 0) {
-            poly_.dict_[i] = v[i];
-        }
-    }
 }
 
 bool UnivariateIntPolynomial::is_canonical(const UIntDict &dict) const
@@ -80,13 +73,6 @@ UnivariateIntPolynomial::from_dict(const RCP<const Symbol> &var, UIntDict &&d)
         }
     }
     return make_rcp<const UnivariateIntPolynomial>(var, std::move(d));
-}
-
-RCP<const UnivariateIntPolynomial>
-UnivariateIntPolynomial::from_vec(const RCP<const Symbol> &var,
-                                  const std::vector<integer_class> &v)
-{
-    return make_rcp<const UnivariateIntPolynomial>(var, std::move(v));
 }
 
 vec_basic UnivariateIntPolynomial::get_args() const
@@ -200,12 +186,6 @@ UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
                                            const std::vector<Expression> &v)
     : UIntPolyBase(var, std::move(v))
 {
-    poly_.dict_ = {};
-    for (unsigned int i = 0; i < v.size(); i++) {
-        if (v[i] != 0) {
-            poly_.dict_[i] = v[i];
-        }
-    }
 }
 
 bool UnivariatePolynomial::is_canonical(
@@ -246,13 +226,6 @@ int UnivariatePolynomial::compare(const Basic &o) const
         return cmp;
 
     return map_int_Expr_compare(poly_.get_dict(), s.poly_.get_dict());
-}
-
-RCP<const UnivariatePolynomial>
-UnivariatePolynomial::from_vec(const RCP<const Symbol> &var,
-                               const std::vector<Expression> &v)
-{
-    return make_rcp<const UnivariatePolynomial>(var, std::move(v));
 }
 
 RCP<const UnivariatePolynomial>

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -86,11 +86,6 @@ vec_basic UnivariateIntPolynomial::get_args() const
     return args;
 }
 
-integer_class UnivariateIntPolynomial::max_abs_coef() const
-{
-    return poly_.max_abs_coef();
-}
-
 integer_class UnivariateIntPolynomial::eval(const integer_class &x) const
 {
     unsigned int last_deg = poly_.dict_.rbegin()->first;

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -300,7 +300,6 @@ public:
     std::size_t __hash__() const;
     int compare(const Basic &o) const;
 
-    integer_class max_abs_coef() const;
     //! Evaluates the UnivariateIntPolynomial at value x
     integer_class eval(const integer_class &x) const;
 

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -300,14 +300,6 @@ public:
     std::size_t __hash__() const;
     int compare(const Basic &o) const;
 
-    // creates a UnivariateIntPolynomial in cannonical form based on the
-    // dictionary.
-    static RCP<const UnivariateIntPolynomial>
-    from_dict(const RCP<const Symbol> &var, UIntDict &&d);
-
-    /*!
-    * Adds coef*var_**n to the dict_
-    */
     integer_class max_abs_coef() const;
     //! Evaluates the UnivariateIntPolynomial at value x
     integer_class eval(const integer_class &x) const;
@@ -542,12 +534,6 @@ public:
     bool is_canonical(const UnivariateExprPolynomial &dict) const;
     std::size_t __hash__() const;
     int compare(const Basic &o) const;
-
-    /*! Creates appropriate instance (i.e Symbol, Integer,
-    * Mul, Pow, UnivariatePolynomial) depending on the size of dictionary `d`.
-    */
-    static RCP<const UnivariatePolynomial>
-    from_dict(const RCP<const Symbol> &var, UnivariateExprPolynomial &&d);
 
     Expression max_coef() const;
     //! Evaluates the UnivariatePolynomial at value x

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -283,7 +283,7 @@ public:
 }; // UIntDict
 
 class UnivariateIntPolynomial
-    : public UIntPolyBase<UIntDict, UnivariateIntPolynomial>
+    : public UIntPolyBase<UIntDict, UnivariateIntPolynomial, integer_class>
 {
 public:
     IMPLEMENT_TYPEID(UNIVARIATEINTPOLYNOMIAL)
@@ -304,10 +304,6 @@ public:
     // dictionary.
     static RCP<const UnivariateIntPolynomial>
     from_dict(const RCP<const Symbol> &var, UIntDict &&d);
-    // create a UnivariateIntPolynomial from a dense vector of integer_class
-    // coefficients
-    static RCP<const UnivariateIntPolynomial>
-    from_vec(const RCP<const Symbol> &var, const std::vector<integer_class> &v);
 
     /*!
     * Adds coef*var_**n to the dict_
@@ -531,7 +527,8 @@ public:
 }; // UnivariateExprPolynomial
 
 class UnivariatePolynomial
-    : public UIntPolyBase<UnivariateExprPolynomial, UnivariatePolynomial>
+    : public UIntPolyBase<UnivariateExprPolynomial, UnivariatePolynomial,
+                          Expression>
 {
 public:
     IMPLEMENT_TYPEID(UNIVARIATEPOLYNOMIAL)
@@ -551,8 +548,6 @@ public:
     */
     static RCP<const UnivariatePolynomial>
     from_dict(const RCP<const Symbol> &var, UnivariateExprPolynomial &&d);
-    static RCP<const UnivariatePolynomial>
-    from_vec(const RCP<const Symbol> &var, const std::vector<Expression> &v);
 
     Expression max_coef() const;
     //! Evaluates the UnivariatePolynomial at value x

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -133,6 +133,23 @@ public:
 
     Wrapper &operator*=(const Wrapper &other)
     {
+        if (dict_.empty())
+            return static_cast<Wrapper &>(*this);
+
+        if (other.dict_.empty()) {
+            *this = other;
+            return static_cast<Wrapper &>(*this);
+        }
+
+        // ! other is a just constant term
+        if (other.dict_.size() == 1
+            and other.dict_.find(0) != other.dict_.end()) {
+            for (const auto &i1 : dict_)
+                for (const auto &i2 : other.dict_)
+                    dict_[i1.first] = i1.second * i2.second;
+            return static_cast<Wrapper &>(*this);
+        }
+
         std::map<Key, Value> p;
         for (const auto &i1 : dict_)
             for (const auto &i2 : other.dict_)
@@ -471,7 +488,6 @@ public:
         return o.str();
     }
 
-    // const umap_int_basic get_basic() const
     const RCP<const Basic> get_basic(std::string var) const
     {
         RCP<const Symbol> x = symbol(var);

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -311,8 +311,6 @@ public:
     UnivariateIntPolynomial(const RCP<const Symbol> &var,
                             const std::vector<integer_class> &v);
 
-    //! \return true if canonical
-    bool is_canonical(const UIntDict &dict) const;
     //! \return size of the hash
     std::size_t __hash__() const;
     int compare(const Basic &o) const;
@@ -546,7 +544,6 @@ public:
     UnivariatePolynomial(const RCP<const Symbol> &var,
                          const std::vector<Expression> &v);
 
-    bool is_canonical(const UnivariateExprPolynomial &dict) const;
     std::size_t __hash__() const;
     int compare(const Basic &o) const;
 

--- a/symengine/uint_base.h
+++ b/symengine/uint_base.h
@@ -18,36 +18,20 @@ protected:
     Container poly_;
 
 public:
-    UIntPolyBase(const RCP<const Symbol> &var, Container &&container)
-        : var_{var}, poly_{container}
+    UIntPolyBase(const RCP<const Symbol> &var, Container &&d)
+        : var_{var}, poly_{d}
     {
     }
 
     UIntPolyBase(const RCP<const Symbol> &var, const std::vector<Coeff> &v)
         : var_{var}
     {
-        poly_.dict_ = {};
-        for (unsigned int i = 0; i < v.size(); i++) {
-            if (v[i] != Coeff(0)) {
-                poly_.dict_[i] = v[i];
-            }
-        }
     }
 
     // creates a Poly in cannonical form based on the dictionary.
     static RCP<const Poly> from_dict(const RCP<const Symbol> &var,
                                      Container &&d)
     {
-        auto iter = d.dict_.begin();
-        while (iter != d.dict_.end()) {
-            if (iter->second == Coeff(0)) {
-                auto toErase = iter;
-                iter++;
-                d.dict_.erase(toErase);
-            } else {
-                iter++;
-            }
-        }
         return make_rcp<const Poly>(var, std::move(d));
     }
     // create a Poly from a dense vector of Coeff coefficients

--- a/symengine/uint_base.h
+++ b/symengine/uint_base.h
@@ -34,6 +34,23 @@ public:
         }
     }
 
+    // creates a Poly in cannonical form based on the dictionary.
+    static RCP<const Poly> from_dict(const RCP<const Symbol> &var,
+                                     Container &&d)
+    {
+        auto iter = d.dict_.begin();
+        while (iter != d.dict_.end()) {
+            if (iter->second == Coeff(0)) {
+                auto toErase = iter;
+                iter++;
+                d.dict_.erase(toErase);
+            } else {
+                iter++;
+            }
+        }
+        return make_rcp<const Poly>(var, std::move(d));
+    }
+    // create a Poly from a dense vector of Coeff coefficients
     static RCP<const Poly> from_vec(const RCP<const Symbol> &var,
                                     const std::vector<Coeff> v)
     {

--- a/symengine/uint_base.h
+++ b/symengine/uint_base.h
@@ -10,7 +10,7 @@
 namespace SymEngine
 {
 
-template <typename Container, typename Poly>
+template <typename Container, typename Poly, typename Coeff>
 class UIntPolyBase : public Basic
 {
 protected:
@@ -23,17 +23,21 @@ public:
     {
     }
 
-    // unify these two constructor? another template would be required
-    // may solve some more problems, like `get_degree` virtualization
-    UIntPolyBase(const RCP<const Symbol> &var,
-                 const std::vector<integer_class> &v)
+    UIntPolyBase(const RCP<const Symbol> &var, const std::vector<Coeff> &v)
         : var_{var}
     {
+        poly_.dict_ = {};
+        for (unsigned int i = 0; i < v.size(); i++) {
+            if (v[i] != Coeff(0)) {
+                poly_.dict_[i] = v[i];
+            }
+        }
     }
 
-    UIntPolyBase(const RCP<const Symbol> &var, const std::vector<Expression> &v)
-        : var_{var}
+    static RCP<const Poly> from_vec(const RCP<const Symbol> &var,
+                                    const std::vector<Coeff> v)
     {
+        return make_rcp<const Poly>(var, std::move(v));
     }
 
     // TODO think of something to make this purely virtual


### PR DESCRIPTION
In the last commit, I removed `is_canonical`. What I basically do is always force only canonical polynomials to be formed (in the constructors itself). 

The (new) constructors should remain specific to the derived class, as they will be different for Flint and Piranha polynomials. The methods `from_dict` and `from_vec` now call the constructors of the derived class, have been moved to the base class.