### PR TITLE
make target uninstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ CMakeCache.txt
 CMakeFiles
 Makefile
 cmake_install.cmake
+cmake_uninstall.cmake
 install_manifest.txt
 CTestTestfile.cmake
 cython_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,6 @@ install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/SymEngineConfig.cma
               cmake/FindBFD.cmake
               cmake/FindECM.cmake
               cmake/FindEXECINFO.cmake
-              cmake/FindFLINT.cmake
               cmake/FindGMP.cmake
               cmake/FindLINKH.cmake
               cmake/FindMPC.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,6 +460,15 @@ install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/SymEngineConfig.cma
         DESTINATION ${INSTALL_CMAKE_DIR})
 install(EXPORT SymEngineTargets DESTINATION ${INSTALL_CMAKE_DIR})
 
+# uninstall target
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+
 file(COPY ${symengine_SOURCE_DIR}/cmake/ DESTINATION ${symengine_BINARY_DIR}/cmake)
 
 if (BUILD_BENCHMARKS)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,24 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\nSymEngine doesn't seem to be installed!")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)
+
+# remove install_manifest.txt after uninstalling
+file(REMOVE "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")


### PR DESCRIPTION
Removed an extra `cmake/findFLINT.cmake`  (there's already one on line 446). I found this, after I saw duplicate entries of `/usr/local/lib/cmake/symengine/FindFLINT.cmake` in my `install_manifest.txt`

Also added target `uninstall` as shown [here](https://cmake.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F).