### PR TITLE
Misc poly changes

### DIFF
--- a/symengine/polys/uexprpoly.cpp
+++ b/symengine/polys/uexprpoly.cpp
@@ -13,18 +13,6 @@ UExprPoly::UExprPoly(const RCP<const Symbol> &var, UExprDict &&dict)
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 
-UExprPoly::UExprPoly(const RCP<const Symbol> &var,
-                     const std::vector<Expression> &v)
-    : UPolyBase(var, std::move(v))
-{
-    poly_.dict_ = {};
-    for (unsigned int i = 0; i < v.size(); i++) {
-        if (v[i] != Expression(0)) {
-            poly_.dict_[i] = v[i];
-        }
-    }
-}
-
 bool UExprPoly::is_canonical(const UExprDict &dict) const
 {
     // Check if dictionary contains terms with coeffienct 0
@@ -77,6 +65,12 @@ RCP<const UExprPoly> UExprPoly::from_dict(const RCP<const Symbol> &var,
         }
     }
     return make_rcp<const UExprPoly>(var, std::move(d));
+}
+
+RCP<const UExprPoly> UExprPoly::from_vec(const RCP<const Symbol> &var,
+                                         const std::vector<Expression> &v)
+{
+    return make_rcp<const UExprPoly>(var, UExprDict::from_vec(v));
 }
 
 vec_basic UExprPoly::get_args() const

--- a/symengine/polys/uexprpoly.cpp
+++ b/symengine/polys/uexprpoly.cpp
@@ -19,7 +19,7 @@ UExprPoly::UExprPoly(const RCP<const Symbol> &var,
 {
     poly_.dict_ = {};
     for (unsigned int i = 0; i < v.size(); i++) {
-        if (v[i] != 0) {
+        if (v[i] != Expression(0)) {
             poly_.dict_[i] = v[i];
         }
     }
@@ -61,12 +61,6 @@ int UExprPoly::compare(const Basic &o) const
         return cmp;
 
     return map_int_Expr_compare(poly_.get_dict(), s.poly_.get_dict());
-}
-
-RCP<const UExprPoly> UExprPoly::from_vec(const RCP<const Symbol> &var,
-                                         const std::vector<Expression> &v)
-{
-    return make_rcp<const UExprPoly>(var, std::move(v));
 }
 
 RCP<const UExprPoly> UExprPoly::from_dict(const RCP<const Symbol> &var,

--- a/symengine/polys/uexprpoly.cpp
+++ b/symengine/polys/uexprpoly.cpp
@@ -54,16 +54,6 @@ int UExprPoly::compare(const Basic &o) const
 RCP<const UExprPoly> UExprPoly::from_dict(const RCP<const Symbol> &var,
                                           UExprDict &&d)
 {
-    auto iter = d.dict_.begin();
-    while (iter != d.dict_.end()) {
-        if (iter->second == Expression(0)) {
-            auto toErase = iter;
-            iter++;
-            d.dict_.erase(toErase);
-        } else {
-            iter++;
-        }
-    }
     return make_rcp<const UExprPoly>(var, std::move(d));
 }
 

--- a/symengine/polys/uexprpoly.cpp
+++ b/symengine/polys/uexprpoly.cpp
@@ -66,6 +66,16 @@ int UExprPoly::compare(const Basic &o) const
 RCP<const UExprPoly> UExprPoly::from_dict(const RCP<const Symbol> &var,
                                           UExprDict &&d)
 {
+    auto iter = d.dict_.begin();
+    while (iter != d.dict_.end()) {
+        if (iter->second == Expression(0)) {
+            auto toErase = iter;
+            iter++;
+            d.dict_.erase(toErase);
+        } else {
+            iter++;
+        }
+    }
     return make_rcp<const UExprPoly>(var, std::move(d));
 }
 

--- a/symengine/polys/uexprpoly.h
+++ b/symengine/polys/uexprpoly.h
@@ -181,7 +181,7 @@ public:
     }
 }; // UExprDict
 
-class UExprPoly : public UPolyBase<UExprDict, UExprPoly, Expression>
+class UExprPoly : public UPolyBase<UExprDict, UExprPoly>
 {
 public:
     IMPLEMENT_TYPEID(UEXPRPOLY)

--- a/symengine/polys/uexprpoly.h
+++ b/symengine/polys/uexprpoly.h
@@ -181,7 +181,7 @@ public:
     }
 }; // UExprDict
 
-class UExprPoly : public UPolyBase<UExprDict, UExprPoly>
+class UExprPoly : public UPolyBase<UExprDict, UExprPoly, Expression>
 {
 public:
     IMPLEMENT_TYPEID(UEXPRPOLY)
@@ -194,13 +194,8 @@ public:
     std::size_t __hash__() const;
     int compare(const Basic &o) const;
 
-    /*! Creates appropriate instance (i.e Symbol, Integer,
-    * Mul, Pow, UExprPoly) depending on the size of dictionary `d`.
-    */
     static RCP<const UExprPoly> from_dict(const RCP<const Symbol> &var,
                                           UExprDict &&d);
-    static RCP<const UExprPoly> from_vec(const RCP<const Symbol> &var,
-                                         const std::vector<Expression> &v);
 
     Expression max_coef() const;
     //! Evaluates the UExprPoly at value x

--- a/symengine/polys/uexprpoly.h
+++ b/symengine/polys/uexprpoly.h
@@ -187,8 +187,6 @@ public:
     IMPLEMENT_TYPEID(UEXPRPOLY)
     //! Constructor of UExprPoly class
     UExprPoly(const RCP<const Symbol> &var, UExprDict &&dict);
-    //! Constructor using a dense vector of Expression
-    UExprPoly(const RCP<const Symbol> &var, const std::vector<Expression> &v);
 
     bool is_canonical(const UExprDict &dict) const;
     std::size_t __hash__() const;
@@ -196,6 +194,8 @@ public:
 
     static RCP<const UExprPoly> from_dict(const RCP<const Symbol> &var,
                                           UExprDict &&d);
+    static RCP<const UExprPoly> from_vec(const RCP<const Symbol> &var,
+                                         const std::vector<Expression> &v);
 
     Expression max_coef() const;
     //! Evaluates the UExprPoly at value x

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -106,11 +106,6 @@ vec_basic UIntPoly::get_args() const
     return args;
 }
 
-integer_class UIntPoly::max_abs_coef() const
-{
-    return poly_.max_abs_coef();
-}
-
 integer_class UIntPoly::eval(const integer_class &x) const
 {
     unsigned int last_deg = poly_.dict_.rbegin()->first;

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -10,7 +10,6 @@ namespace SymEngine
 UIntPoly::UIntPoly(const RCP<const Symbol> &var, UIntDict &&dict)
     : UPolyBase(var, std::move(dict))
 {
-
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 
@@ -78,12 +77,6 @@ RCP<const UIntPoly> UIntPoly::from_dict(const RCP<const Symbol> &var,
         }
     }
     return make_rcp<const UIntPoly>(var, std::move(d));
-}
-
-RCP<const UIntPoly> UIntPoly::from_vec(const RCP<const Symbol> &var,
-                                       const std::vector<integer_class> &v)
-{
-    return make_rcp<const UIntPoly>(var, std::move(v));
 }
 
 vec_basic UIntPoly::get_args() const

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -13,18 +13,6 @@ UIntPoly::UIntPoly(const RCP<const Symbol> &var, UIntDict &&dict)
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 
-UIntPoly::UIntPoly(const RCP<const Symbol> &var,
-                   const std::vector<integer_class> &v)
-    : UPolyBase(var, std::move(v))
-{
-    poly_.dict_ = {};
-    for (unsigned int i = 0; i < v.size(); i++) {
-        if (v[i] != 0) {
-            poly_.dict_[i] = v[i];
-        }
-    }
-}
-
 bool UIntPoly::is_canonical(const UIntDict &dict) const
 {
     // Check if dictionary contains terms with coeffienct 0
@@ -77,6 +65,12 @@ RCP<const UIntPoly> UIntPoly::from_dict(const RCP<const Symbol> &var,
         }
     }
     return make_rcp<const UIntPoly>(var, std::move(d));
+}
+
+RCP<const UIntPoly> UIntPoly::from_vec(const RCP<const Symbol> &var,
+                                       const std::vector<integer_class> &v)
+{
+    return make_rcp<const UIntPoly>(var, UIntDict::from_vec(v));
 }
 
 vec_basic UIntPoly::get_args() const

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -54,16 +54,6 @@ int UIntPoly::compare(const Basic &o) const
 RCP<const UIntPoly> UIntPoly::from_dict(const RCP<const Symbol> &var,
                                         UIntDict &&d)
 {
-    auto iter = d.dict_.begin();
-    while (iter != d.dict_.end()) {
-        if (iter->second == 0) {
-            auto toErase = iter;
-            iter++;
-            d.dict_.erase(toErase);
-        } else {
-            iter++;
-        }
-    }
     return make_rcp<const UIntPoly>(var, std::move(d));
 }
 

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -132,9 +132,6 @@ public:
     IMPLEMENT_TYPEID(UINTPOLY)
     //! Constructor of UIntPoly class
     UIntPoly(const RCP<const Symbol> &var, UIntDict &&dict);
-    //! Constructor using a dense vector of integer_class coefficients
-
-    UIntPoly(const RCP<const Symbol> &var, const std::vector<integer_class> &v);
 
     //! \return true if canonical
     bool is_canonical(const UIntDict &dict) const;
@@ -146,6 +143,8 @@ public:
     // dictionary.
     static RCP<const UIntPoly> from_dict(const RCP<const Symbol> &var,
                                          UIntDict &&d);
+    static RCP<const UIntPoly> from_vec(const RCP<const Symbol> &var,
+                                        const std::vector<integer_class> &v);
     //! Evaluates the UIntPoly at value x
     integer_class eval(const integer_class &x) const;
 

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -146,11 +146,6 @@ public:
     // dictionary.
     static RCP<const UIntPoly> from_dict(const RCP<const Symbol> &var,
                                          UIntDict &&d);
-
-    /*!
-    * Adds coef*var_**n to the dict_
-    */
-    integer_class max_abs_coef() const;
     //! Evaluates the UIntPoly at value x
     integer_class eval(const integer_class &x) const;
 

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -126,7 +126,7 @@ public:
 
 }; // UIntDict
 
-class UIntPoly : public UPolyBase<UIntDict, UIntPoly>
+class UIntPoly : public UPolyBase<UIntDict, UIntPoly, integer_class>
 {
 public:
     IMPLEMENT_TYPEID(UINTPOLY)
@@ -146,10 +146,6 @@ public:
     // dictionary.
     static RCP<const UIntPoly> from_dict(const RCP<const Symbol> &var,
                                          UIntDict &&d);
-    // create a UIntPoly from a dense vector of integer_class
-    // coefficients
-    static RCP<const UIntPoly> from_vec(const RCP<const Symbol> &var,
-                                        const std::vector<integer_class> &v);
 
     /*!
     * Adds coef*var_**n to the dict_

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -126,7 +126,7 @@ public:
 
 }; // UIntDict
 
-class UIntPoly : public UPolyBase<UIntDict, UIntPoly, integer_class>
+class UIntPoly : public UPolyBase<UIntDict, UIntPoly>
 {
 public:
     IMPLEMENT_TYPEID(UINTPOLY)

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -205,7 +205,7 @@ public:
 
     // create a Poly from a vector of Coeff coefficients
     static RCP<const Poly> from_vec(const RCP<const Symbol> &var,
-                                        const std::vector<Coeff> &v)
+                                    const std::vector<Coeff> &v)
     {
         return make_rcp<const Poly>(var, std::move(v));
     }

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -166,7 +166,7 @@ public:
     }
 };
 
-template <typename Container, typename Poly>
+template <typename Container, typename Poly, typename Coeff>
 class UPolyBase : public Basic
 {
 protected:
@@ -181,14 +181,16 @@ public:
 
     // unify these two constructor? another template would be required
     // may solve some more problems, like `get_degree` virtualization
-    UPolyBase(const RCP<const Symbol> &var, const std::vector<integer_class> &v)
+    UPolyBase(const RCP<const Symbol> &var, const std::vector<Coeff> &v)
         : var_{var}
     {
     }
 
-    UPolyBase(const RCP<const Symbol> &var, const std::vector<Expression> &v)
-        : var_{var}
+    // create a Poly from a vector of Coeff coefficients
+    static RCP<const Poly> from_vec(const RCP<const Symbol> &var,
+                                        const std::vector<Coeff> &v)
     {
+        return make_rcp<const Poly>(var, std::move(v));
     }
 
     // TODO think of something to make this purely virtual

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -120,6 +120,23 @@ public:
 
     Wrapper &operator*=(const Wrapper &other)
     {
+        if (dict_.empty())
+            return static_cast<Wrapper &>(*this);
+
+        if (other.dict_.empty()) {
+            *this = other;
+            return static_cast<Wrapper &>(*this);
+        }
+
+        // ! other is a just constant term
+        if (other.dict_.size() == 1
+            and other.dict_.find(0) != other.dict_.end()) {
+            for (const auto &i1 : dict_)
+                for (const auto &i2 : other.dict_)
+                    dict_[i1.first] = i1.second * i2.second;
+            return static_cast<Wrapper &>(*this);
+        }
+
         std::map<Key, Value> p;
         for (const auto &i1 : dict_)
             for (const auto &i2 : other.dict_)

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -195,7 +195,7 @@ public:
     }
 };
 
-template <typename Container, typename Poly, typename Coeff>
+template <typename Container, typename Poly>
 class UPolyBase : public Basic
 {
 protected:

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -59,7 +59,7 @@ public:
                 x.dict_[i] = v[i];
             }
         }
-        return static_cast<Wrapper &>(x);
+        return x;
     }
 
     Wrapper &operator=(Wrapper &&other) SYMENGINE_NOEXCEPT

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -50,6 +50,18 @@ public:
         dict_[1] = Value(1);
     }
 
+    static Wrapper from_vec(const std::vector<Value> &v)
+    {
+        Wrapper x;
+        x.dict_ = {};
+        for (unsigned int i = 0; i < v.size(); i++) {
+            if (v[i] != Value(0)) {
+                x.dict_[i] = v[i];
+            }
+        }
+        return static_cast<Wrapper &>(x);
+    }
+
     Wrapper &operator=(Wrapper &&other) SYMENGINE_NOEXCEPT
     {
         if (this != &other)
@@ -195,21 +207,6 @@ public:
         : var_{var}, poly_{container}
     {
     }
-
-    // unify these two constructor? another template would be required
-    // may solve some more problems, like `get_degree` virtualization
-    UPolyBase(const RCP<const Symbol> &var, const std::vector<Coeff> &v)
-        : var_{var}
-    {
-    }
-
-    // create a Poly from a vector of Coeff coefficients
-    static RCP<const Poly> from_vec(const RCP<const Symbol> &var,
-                                    const std::vector<Coeff> &v)
-    {
-        return make_rcp<const Poly>(var, std::move(v));
-    }
-
     // TODO think of something to make this purely virtual
     //! \returns the degree of the polynomial
     // virtual unsigned int get_degree() const = 0;

--- a/symengine/tests/polynomial/test_uexprpoly.cpp
+++ b/symengine/tests/polynomial/test_uexprpoly.cpp
@@ -58,6 +58,9 @@ TEST_CASE("Constructor of UExprPoly", "[UExprPoly]")
 
     RCP<const UExprPoly> T = uexpr_poly(none, map_int_Expr{});
     REQUIRE(T->__str__() == "0");
+
+    RCP<const UExprPoly> U = uexpr_poly(x, {{0, c}, {1, 0_z}, {2, d}});
+    REQUIRE(U->__str__() == "d*x**2 + c");
 }
 
 TEST_CASE("Adding two UExprPoly", "[UExprPoly]")

--- a/symengine/tests/polynomial/test_uexprpoly.cpp
+++ b/symengine/tests/polynomial/test_uexprpoly.cpp
@@ -46,8 +46,8 @@ TEST_CASE("Constructor of UExprPoly", "[UExprPoly]")
     RCP<const UExprPoly> R = uexpr_poly(x, {{0, d}, {1, c}, {2, b}, {3, a}});
     REQUIRE(R->__str__() == "a*x**3 + b*x**2 + c*x + d");
 
-    UExprPoly S(x, {1, 0, 2, 1});
-    REQUIRE(S.__str__() == "x**3 + 2*x**2 + 1");
+    RCP<const UExprPoly> S = UExprPoly::from_vec(x, {1, 0, 2, 1});
+    REQUIRE(S->__str__() == "x**3 + 2*x**2 + 1");
 
     R = uexpr_poly(x, {{-1, d}});
     REQUIRE(R->__str__() == "d*x**(-1)");

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -35,8 +35,8 @@ TEST_CASE("Constructor of UIntPoly", "[UIntPoly]")
     RCP<const UIntPoly> Q = UIntPoly::from_vec(x, {1_z, 0_z, 2_z, 1_z});
     REQUIRE(Q->__str__() == "x**3 + 2*x**2 + 1");
 
-    UIntPoly R(x, {1_z, 0_z, 2_z, 1_z});
-    REQUIRE(R.__str__() == "x**3 + 2*x**2 + 1");
+    RCP<const UIntPoly> R = UIntPoly::from_vec(x, {1_z, 0_z, 2_z, 1_z});
+    REQUIRE(R->__str__() == "x**3 + 2*x**2 + 1");
 
     RCP<const UIntPoly> S = uint_poly(x, {{0, 2_z}});
     REQUIRE(S->__str__() == "2");

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -43,6 +43,9 @@ TEST_CASE("Constructor of UIntPoly", "[UIntPoly]")
 
     RCP<const UIntPoly> T = uint_poly(x, map_uint_mpz{});
     REQUIRE(T->__str__() == "0");
+
+    RCP<const UIntPoly> U = uint_poly(x, {{0, 2_z}, {1, 0_z}, {2, 0_z}});
+    REQUIRE(U->__str__() == "2");
 }
 
 TEST_CASE("Adding two UIntPoly", "[UIntPoly]")


### PR DESCRIPTION
In the last commit, I removed `is_canonical`. What I basically do is always force only canonical polynomials to be formed (in the constructors itself).

The (new) constructors should remain specific to the derived class, as they will be different for Flint and Piranha polynomials. The methods `from_dict` and `from_vec` now call the constructors of the derived class, have been moved to the base class. 
@isuruf  @Sumith1896 

Edit : removed the last commit