### PR TITLE
Move clang-format to allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,21 +55,19 @@ matrix:
     - compiler: clang
     - os: osx
   include:
-    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" TEST_CLANG_FORMAT="yes" WITH_COVERAGE="yes" WITH_MPC="yes"
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" WITH_COVERAGE="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
       addons:
         apt:
           sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-precise-3.7
           packages:
           - libgmp-dev
           - libmpfr-dev
           - libmpc-dev
           - binutils-dev
           - g++-5
-          - clang-format-3.7
     - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_PIRANHA="yes" WITH_BENCHMARKS_NONIUS="yes" WITH_COVERAGE="yes" TEST_IN_TREE="yes" WITH_FLINT="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
@@ -136,6 +134,31 @@ matrix:
     - env: BUILD_TYPE="Release"
       compiler: gcc
       os: osx
+    - env: BUILD_TYPE="Release" TEST_CLANG_FORMAT="yes"
+      compiler: gcc
+      os: linux
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-precise-3.7
+          packages:
+          - g++-4.7
+          - libgmp-dev
+          - clang-format-3.7
+  allow_failures:
+    - env: BUILD_TYPE="Release" TEST_CLANG_FORMAT="yes"
+      compiler: gcc
+      os: linux
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-precise-3.7
+          packages:
+          - g++-4.7
+          - libgmp-dev
+          - clang-format-3.7
 
 install:
   - source bin/install_travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,12 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.7
     packages:
     - libgmp-dev
     - libmpfr-dev
     - libmpc-dev
     - binutils-dev
     - g++-4.7
-    - gcc-5
-    - g++-5
-    - clang-format-3.7
 env:
   ## All these variables are sent into the bin/test_travis.sh script. See this
   ## script to know how they are used. Most of them are just passed to cmake,
@@ -29,8 +25,6 @@ env:
   ## executed.
 
   ## Out of tree builds (default):
-  # Debug build (with BFD) with LATEST_GCC
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" TEST_CLANG_FORMAT="yes" WITH_COVERAGE="yes"
   # Debug build (with BFD)
   - BUILD_TYPE="Debug" WITH_BFD="yes"
   # Debug build (with BFD and SYMENGINE_THREAD_SAFE)
@@ -61,6 +55,21 @@ matrix:
     - compiler: clang
     - os: osx
   include:
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" TEST_CLANG_FORMAT="yes" WITH_COVERAGE="yes" WITH_MPC="yes"
+      compiler: gcc
+      os: linux
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-precise-3.7
+          packages:
+          - libgmp-dev
+          - libmpfr-dev
+          - libmpc-dev
+          - binutils-dev
+          - g++-5
+          - clang-format-3.7
     - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_PIRANHA="yes" WITH_BENCHMARKS_NONIUS="yes" WITH_COVERAGE="yes" TEST_IN_TREE="yes" WITH_FLINT="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
 
   ## Out of tree builds (default):
   # Debug build (with BFD) with LATEST_GCC
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" TEST_CLANG_FORMAT="yes"
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" TEST_CLANG_FORMAT="yes" WITH_COVERAGE="yes"
   # Debug build (with BFD)
   - BUILD_TYPE="Debug" WITH_BFD="yes"
   # Debug build (with BFD and SYMENGINE_THREAD_SAFE)


### PR DESCRIPTION
LLVM apt repository temporary down.
Only last commit needs to be reverted when LLVM apt repository comes back up.
