### PR TITLE
more poly functionality

### DIFF
--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -55,17 +55,6 @@ public:
     DIFF0(LeviCivita)
     DIFF0(Max)
     DIFF0(Min)
-
-#ifdef HAVE_SYMENGINE_FLINT
-    // will implement soon
-    DIFF0(UIntPolyFlint)
-#endif
-
-#ifdef HAVE_SYMENGINE_PIRANHA
-    // will implement soon
-    DIFF0(UIntPolyPiranha)
-#endif
-
 #endif
 
     static RCP<const Basic> diff(const Number &self, const RCP<const Symbol> &x)
@@ -496,14 +485,13 @@ public:
     {
         if (self.get_var()->__eq__(*x)) {
             Dict d;
-            for (const auto &p : self.get_dict()) {
-                if (p.first != 0)
-                    d[p.first - 1] = p.second * p.first;
+            for (auto it = self.begin(); it != self.end(); ++it) {
+                if (it->first != 0)
+                    d[it->first - 1] = it->second * it->first;
             }
-            return make_rcp<const Poly>(self.get_var(), std::move(d));
+            return Poly::from_dict(self.get_var(), std::move(d));
         } else {
-            Dict d;
-            return make_rcp<const Poly>(self.get_var(), std::move(d));
+            return Poly::from_dict(self.get_var(), {{}});
         }
     }
 
@@ -512,6 +500,29 @@ public:
     {
         return diff_upoly<UIntPoly, map_uint_mpz>(self, x);
     }
+
+#ifdef HAVE_SYMENGINE_PIRANHA
+    static RCP<const Basic> diff(const UIntPolyPiranha &self,
+                                 const RCP<const Symbol> &x)
+    {
+        return diff_upoly<UIntPolyPiranha, map_uint_mpz>(self, x);
+    }
+#endif
+
+#ifdef HAVE_SYMENGINE_FLINT
+    static RCP<const Basic> diff(const UIntPolyFlint &self,
+                                 const RCP<const Symbol> &x)
+    {
+        if (self.get_var()->__eq__(*x)) {
+            flint::fmpz_polyxx d;
+            d = static_cast<flint::fmpz_polyxx>(
+                flint::derivative(self.get_poly()));
+            return UIntPolyFlint::from_container(self.get_var(), std::move(d));
+        } else {
+            return UIntPolyFlint::from_dict(self.get_var(), {{}});
+        }
+    }
+#endif
 
     static RCP<const Basic> diff(const UExprPoly &self,
                                  const RCP<const Symbol> &x)

--- a/symengine/dict.h
+++ b/symengine/dict.h
@@ -48,6 +48,7 @@ typedef std::map<RCP<const Integer>, unsigned, RCPIntegerKeyLess>
     map_integer_uint;
 typedef std::map<unsigned, integer_class> map_uint_mpz;
 typedef std::map<int, Expression> map_int_Expr;
+typedef std::vector<integer_class> vec_integer_class;
 //! Part of umap_vec_mpz:
 typedef struct {
     inline std::size_t operator()(const vec_int &k) const

--- a/symengine/expand.cpp
+++ b/symengine/expand.cpp
@@ -298,7 +298,7 @@ public:
     void pow_expand(RCP<const UIntPoly> &x, unsigned long &i)
     {
         RCP<const UIntPoly> r
-            = uint_poly(x->get_var(), UIntDict({{0, integer_class(1)}}));
+            = UIntPoly::from_dict(x->get_var(), {{0, integer_class(1)}});
         while (i != 0) {
             if (i % 2 == 1) {
                 r = mul_upoly(*r, *x);

--- a/symengine/ntheory.cpp
+++ b/symengine/ntheory.cpp
@@ -1612,7 +1612,7 @@ void powermod_list(std::vector<RCP<const Integer>> &pows,
     }
 }
 
-std::vector<integer_class> quadratic_residues(const Integer &a)
+vec_integer_class quadratic_residues(const Integer &a)
 {
     /*
         Returns the list of quadratic residues.
@@ -1626,7 +1626,7 @@ std::vector<integer_class> quadratic_residues(const Integer &a)
         throw std::runtime_error("quadratic_residues: Input must be > 0");
     }
 
-    std::vector<integer_class> residue;
+    vec_integer_class residue;
     for (integer_class i = integer_class(0); i <= a.as_int() / 2; i++) {
         residue.push_back((i * i) % a.as_int());
     }

--- a/symengine/ntheory.h
+++ b/symengine/ntheory.h
@@ -196,7 +196,7 @@ void powermod_list(std::vector<RCP<const Integer>> &pows,
                    const RCP<const Integer> &m);
 
 //! Finds all Quadratic Residues of a Positive Integer
-std::vector<integer_class> quadratic_residues(const Integer &a);
+vec_integer_class quadratic_residues(const Integer &a);
 
 //! Returns true if 'a' is a quadratic residue of 'p'
 bool is_quad_residue(const Integer &a, const Integer &p);

--- a/symengine/polys/uexprpoly.h
+++ b/symengine/polys/uexprpoly.h
@@ -219,6 +219,25 @@ public:
     {
         return poly_.get_coeff(x);
     }
+
+    typedef map_int_Expr::const_iterator iterator;
+    typedef map_int_Expr::const_reverse_iterator reverse_iterator;
+    iterator begin() const
+    {
+        return poly_.dict_.begin();
+    }
+    iterator end() const
+    {
+        return poly_.dict_.end();
+    }
+    reverse_iterator obegin() const
+    {
+        return poly_.dict_.rbegin();
+    }
+    reverse_iterator oend() const
+    {
+        return poly_.dict_.rend();
+    }
 }; // UExprPoly
 
 inline RCP<const UExprPoly> uexpr_poly(RCP<const Symbol> i, UExprDict &&dict)

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -158,4 +158,39 @@ RCP<const UIntPoly> pow_upoly(const UIntPoly &a, unsigned int p)
     return make_rcp<const UIntPoly>(a.get_var(), std::move(res * tmp));
 }
 
+std::pair<bool, RCP<const UIntPoly>> divides_upoly(const UIntPoly &a, const UIntPoly &b)
+{   
+    if (!(a.get_var()->__eq__(*b.get_var())))
+        throw std::runtime_error("Error: variables must agree.");
+
+    auto a_poly = a.get_poly();
+    auto b_poly = b.get_poly();
+    if (a_poly.size() == 0)
+        return std::make_pair(false, UIntPoly::from_dict(a.get_var(), {{}}));
+        
+    map_uint_mpz res;
+    UIntDict tmp;
+    integer_class q, r;
+    unsigned int a_deg, b_deg;
+
+    while (b_poly.size() >= a_poly.size())
+    {   
+        a_deg = a_poly.degree();
+        b_deg = b_poly.degree();
+
+        mp_tdiv_qr(q, r, b_poly.get_lc(), a_poly.get_lc());
+        if (r != 0)
+            return std::make_pair(false, UIntPoly::from_dict(a.get_var(), {{}}));
+
+        res[b_deg - a_deg] = q;
+        UIntDict tmp = UIntDict({{b_deg-a_deg, q}});
+        b_poly -= (a_poly * tmp);
+    }
+
+    if (b_poly.empty())
+        return std::make_pair(true, UIntPoly::from_dict(a.get_var(), std::move(res)));
+    else
+        return std::make_pair(false, UIntPoly::from_dict(a.get_var(), {{}}));
+}
+
 } // SymEngine

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -79,6 +79,15 @@ integer_class UIntPoly::eval(const integer_class &x) const
     return result;
 }
 
+std::vector<integer_class> UIntPoly::multieval(const std::vector<integer_class> &v) const
+{
+    // this is not the optimal algorithm
+    std::vector<integer_class> res(v.size());
+    for (unsigned int i = 0; i < v.size(); ++i)
+        res[i] = eval(v[i]);
+    return res;
+}
+
 bool UIntPoly::is_zero() const
 {
     return poly_.empty();
@@ -128,6 +137,25 @@ bool UIntPoly::is_pow() const
         and poly_.dict_.begin()->first != 1 and poly_.dict_.begin()->first != 0)
         return true;
     return false;
+}
+
+RCP<const UIntPoly> pow_upoly(const UIntPoly &a, unsigned int p)
+{
+    auto tmp = a.get_poly();
+    UIntDict res(1);
+
+    while(p > 1) {
+        if (p % 2 == 0) {
+            tmp = tmp * tmp;
+            p = p/2;
+        } else {
+            res = res * tmp;
+            tmp = tmp * tmp;
+            p = (p-1)/2;
+        }
+    }
+
+    return make_rcp<const UIntPoly>(a.get_var(), std::move(res * tmp));
 }
 
 } // SymEngine

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -57,7 +57,7 @@ RCP<const UIntPoly> UIntPoly::from_dict(const RCP<const Symbol> &var,
 }
 
 RCP<const UIntPoly> UIntPoly::from_vec(const RCP<const Symbol> &var,
-                                       const std::vector<integer_class> &v)
+                                       const vec_integer_class &v)
 {
     return make_rcp<const UIntPoly>(var, UIntDict::from_vec(v));
 }
@@ -79,10 +79,10 @@ integer_class UIntPoly::eval(const integer_class &x) const
     return result;
 }
 
-std::vector<integer_class> UIntPoly::multieval(const std::vector<integer_class> &v) const
+vec_integer_class UIntPoly::multieval(const vec_integer_class &v) const
 {
     // this is not the optimal algorithm
-    std::vector<integer_class> res(v.size());
+    vec_integer_class res(v.size());
     for (unsigned int i = 0; i < v.size(); ++i)
         res[i] = eval(v[i]);
     return res;
@@ -144,14 +144,14 @@ RCP<const UIntPoly> pow_upoly(const UIntPoly &a, unsigned int p)
     auto tmp = a.get_poly();
     UIntDict res(1);
 
-    while(p > 1) {
+    while (p > 1) {
         if (p % 2 == 0) {
             tmp = tmp * tmp;
-            p = p/2;
+            p = p / 2;
         } else {
             res = res * tmp;
             tmp = tmp * tmp;
-            p = (p-1)/2;
+            p = (p - 1) / 2;
         }
     }
 

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -158,8 +158,9 @@ RCP<const UIntPoly> pow_upoly(const UIntPoly &a, unsigned int p)
     return make_rcp<const UIntPoly>(a.get_var(), std::move(res * tmp));
 }
 
-std::pair<bool, RCP<const UIntPoly>> divides_upoly(const UIntPoly &a, const UIntPoly &b)
-{   
+std::pair<bool, RCP<const UIntPoly>> divides_upoly(const UIntPoly &a,
+                                                   const UIntPoly &b)
+{
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
 
@@ -167,28 +168,29 @@ std::pair<bool, RCP<const UIntPoly>> divides_upoly(const UIntPoly &a, const UInt
     auto b_poly = b.get_poly();
     if (a_poly.size() == 0)
         return std::make_pair(false, UIntPoly::from_dict(a.get_var(), {{}}));
-        
+
     map_uint_mpz res;
     UIntDict tmp;
     integer_class q, r;
     unsigned int a_deg, b_deg;
 
-    while (b_poly.size() >= a_poly.size())
-    {   
+    while (b_poly.size() >= a_poly.size()) {
         a_deg = a_poly.degree();
         b_deg = b_poly.degree();
 
         mp_tdiv_qr(q, r, b_poly.get_lc(), a_poly.get_lc());
         if (r != 0)
-            return std::make_pair(false, UIntPoly::from_dict(a.get_var(), {{}}));
+            return std::make_pair(false,
+                                  UIntPoly::from_dict(a.get_var(), {{}}));
 
         res[b_deg - a_deg] = q;
-        UIntDict tmp = UIntDict({{b_deg-a_deg, q}});
+        UIntDict tmp = UIntDict({{b_deg - a_deg, q}});
         b_poly -= (a_poly * tmp);
     }
 
     if (b_poly.empty())
-        return std::make_pair(true, UIntPoly::from_dict(a.get_var(), std::move(res)));
+        return std::make_pair(true,
+                              UIntPoly::from_dict(a.get_var(), std::move(res)));
     else
         return std::make_pair(false, UIntPoly::from_dict(a.get_var(), {{}}));
 }

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -140,10 +140,10 @@ public:
     static RCP<const UIntPoly> from_dict(const RCP<const Symbol> &var,
                                          map_uint_mpz &&d);
     static RCP<const UIntPoly> from_vec(const RCP<const Symbol> &var,
-                                        const std::vector<integer_class> &v);
+                                        const vec_integer_class &v);
     //! Evaluates the UIntPoly at value x
     integer_class eval(const integer_class &x) const;
-    std::vector<integer_class> multieval(const std::vector<integer_class> &v) const;
+    vec_integer_class multieval(const vec_integer_class &v) const;
 
     //! \return `true` if `0`
     bool is_zero() const;

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -64,6 +64,13 @@ public:
         return result;
     }
 
+    integer_class get_lc()
+    {   
+        if (dict_.empty())
+            return integer_class(0);
+        return dict_.rbegin()->second;
+    }
+
     static UIntDict mul(const UIntDict &a, const UIntDict &b)
     {
         int mul = 1;
@@ -199,6 +206,8 @@ public:
 }; // UIntPoly
 
 RCP<const UIntPoly> pow_upoly(const UIntPoly &a, unsigned int p);
+// returns (true, b/a) if a exactly divides b otherwise (false, 0)
+std::pair<bool, RCP<const UIntPoly>> divides_upoly(const UIntPoly &a, const UIntPoly &b);
 
 } // SymEngine
 

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -143,6 +143,7 @@ public:
                                         const std::vector<integer_class> &v);
     //! Evaluates the UIntPoly at value x
     integer_class eval(const integer_class &x) const;
+    std::vector<integer_class> multieval(const std::vector<integer_class> &v) const;
 
     //! \return `true` if `0`
     bool is_zero() const;
@@ -196,6 +197,8 @@ public:
     }
 
 }; // UIntPoly
+
+RCP<const UIntPoly> pow_upoly(const UIntPoly &a, unsigned int p);
 
 } // SymEngine
 

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -197,16 +197,6 @@ public:
 
 }; // UIntPoly
 
-inline RCP<const UIntPoly> uint_poly(RCP<const Symbol> i, UIntDict &&dict)
-{
-    return UIntPoly::from_container(i, std::move(dict));
-}
-
-inline RCP<const UIntPoly> uint_poly(RCP<const Symbol> i, map_uint_mpz &&dict)
-{
-    return UIntPoly::from_dict(i, std::move(dict));
-}
-
 } // SymEngine
 
 #endif

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -65,7 +65,7 @@ public:
     }
 
     integer_class get_lc()
-    {   
+    {
         if (dict_.empty())
             return integer_class(0);
         return dict_.rbegin()->second;
@@ -207,7 +207,8 @@ public:
 
 RCP<const UIntPoly> pow_upoly(const UIntPoly &a, unsigned int p);
 // returns (true, b/a) if a exactly divides b otherwise (false, 0)
-std::pair<bool, RCP<const UIntPoly>> divides_upoly(const UIntPoly &a, const UIntPoly &b);
+std::pair<bool, RCP<const UIntPoly>> divides_upoly(const UIntPoly &a,
+                                                   const UIntPoly &b);
 
 } // SymEngine
 

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -206,9 +206,9 @@ public:
 }; // UIntPoly
 
 RCP<const UIntPoly> pow_upoly(const UIntPoly &a, unsigned int p);
-// returns (true, b/a) if a exactly divides b otherwise (false, 0)
-std::pair<bool, RCP<const UIntPoly>> divides_upoly(const UIntPoly &a,
-                                                   const UIntPoly &b);
+// true & sets `out` to b/a if a exactly divides b, otherwise false & undefined
+bool divides_upoly(const UIntPoly &a, const UIntPoly &b,
+                   const Ptr<RCP<const UIntPoly>> &res);
 
 } // SymEngine
 

--- a/symengine/polys/uintpoly_flint.cpp
+++ b/symengine/polys/uintpoly_flint.cpp
@@ -83,6 +83,21 @@ integer_class UIntPolyFlint::eval(const integer_class &x) const
     return to_integer_class(static_cast<flint::fmpzxx>(poly_(r)));
 }
 
+std::vector<integer_class> UIntPolyFlint::multieval(const std::vector<integer_class> &v) const
+{
+    flint::fmpz_vecxx t(v.size());
+    for (unsigned int i = 0; i < v.size(); ++i)
+        fmpz_set_mpz(t[i]._data().inner, get_mpz_t(v[i]));
+
+    flint::fmpz_vecxx nn(flint::evaluate(poly_, t));
+
+    std::vector<integer_class> res(v.size());
+    for (unsigned int i = 0; i < v.size(); ++i)
+        res[i] = to_integer_class(nn[i]);
+
+    return res;
+}
+
 integer_class UIntPolyFlint::get_coeff(unsigned int x) const
 {
     return to_integer_class(poly_.coeff(x));

--- a/symengine/polys/uintpoly_flint.cpp
+++ b/symengine/polys/uintpoly_flint.cpp
@@ -56,9 +56,8 @@ RCP<const UIntPolyFlint> UIntPolyFlint::from_dict(const RCP<const Symbol> &var,
     return make_rcp<const UIntPolyFlint>(var, std::move(f));
 }
 
-RCP<const UIntPolyFlint>
-UIntPolyFlint::from_vec(const RCP<const Symbol> &var,
-                        const std::vector<integer_class> &v)
+RCP<const UIntPolyFlint> UIntPolyFlint::from_vec(const RCP<const Symbol> &var,
+                                                 const vec_integer_class &v)
 {
     // benchmark this against vec->str->fmpz_polyxx
     unsigned int deg = v.size() - 1;
@@ -83,7 +82,7 @@ integer_class UIntPolyFlint::eval(const integer_class &x) const
     return to_integer_class(static_cast<flint::fmpzxx>(poly_(r)));
 }
 
-std::vector<integer_class> UIntPolyFlint::multieval(const std::vector<integer_class> &v) const
+vec_integer_class UIntPolyFlint::multieval(const vec_integer_class &v) const
 {
     flint::fmpz_vecxx t(v.size());
     for (unsigned int i = 0; i < v.size(); ++i)
@@ -91,7 +90,7 @@ std::vector<integer_class> UIntPolyFlint::multieval(const std::vector<integer_cl
 
     flint::fmpz_vecxx nn(flint::evaluate(poly_, t));
 
-    std::vector<integer_class> res(v.size());
+    vec_integer_class res(v.size());
     for (unsigned int i = 0; i < v.size(); ++i)
         res[i] = to_integer_class(nn[i]);
 

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -63,26 +63,26 @@ public:
 
 }; // UIntPolyFLint
 
-RCP<const UIntPolyFlint> gcd_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+inline RCP<const UIntPolyFlint> gcd_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
 {   
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
     return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::gcd(a.get_poly(), b.get_poly()))));
 }
 
-RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+inline RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
 {   
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
     return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::lcm(a.get_poly(), b.get_poly()))));
 }
 
-RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a, unsigned int p)
+inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a, unsigned int p)
 {   
     return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::pow(a.get_poly(), p))));
 }
 
-bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
 {
     return flint::divides(a.get_poly(), b.get_poly()).get<0>();
 }

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -93,9 +93,16 @@ inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a,
                          flint::pow(a.get_poly(), p))));
 }
 
-inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
-{
-    return flint::divides(b.get_poly(), a.get_poly()).get<0>();
+inline std::pair<bool, RCP<const UIntPolyFlint>> divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+{   
+    if (!(a.get_var()->__eq__(*b.get_var())))
+        throw std::runtime_error("Error: variables must agree.");
+
+    auto t = flint::divides(b.get_poly(), a.get_poly());
+    if(t.get<0>())
+        return std::make_pair(true, UIntPolyFlint::from_container(a.get_var(), static_cast<flint::fmpz_polyxx>(t.get<1>())));
+    else
+        return std::make_pair(false, UIntPolyFlint::from_dict(a.get_var(), {{}}));
 }
 }
 

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -28,17 +28,18 @@ public:
 
     static RCP<const UIntPolyFlint> from_dict(const RCP<const Symbol> &var,
                                               map_uint_mpz &&d);
-    static RCP<const UIntPolyFlint>
-    from_vec(const RCP<const Symbol> &var, const std::vector<integer_class> &v);
+    static RCP<const UIntPolyFlint> from_vec(const RCP<const Symbol> &var,
+                                             const vec_integer_class &v);
 
     integer_class eval(const integer_class &x) const;
-    std::vector<integer_class> multieval(const std::vector<integer_class> &v) const;
+    vec_integer_class multieval(const vec_integer_class &v) const;
 
     integer_class get_coeff(unsigned int x) const;
     flint::fmpzxx_srcref get_coeff_ref(unsigned int x) const;
 
     typedef ContainerForIter<UIntPolyFlint, flint::fmpzxx_srcref> iterator;
-    typedef ContainerRevIter<UIntPolyFlint, flint::fmpzxx_srcref> reverse_iterator;
+    typedef ContainerRevIter<UIntPolyFlint, flint::fmpzxx_srcref>
+        reverse_iterator;
     iterator begin() const
     {
         return iterator(rcp_from_this_cast<UIntPolyFlint>(), 0);
@@ -49,7 +50,8 @@ public:
     }
     reverse_iterator obegin() const
     {
-        return reverse_iterator(rcp_from_this_cast<UIntPolyFlint>(), (long)size() - 1);
+        return reverse_iterator(rcp_from_this_cast<UIntPolyFlint>(),
+                                (long)size() - 1);
     }
     reverse_iterator oend() const
     {
@@ -63,23 +65,32 @@ public:
 
 }; // UIntPolyFLint
 
-inline RCP<const UIntPolyFlint> gcd_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
-{   
+inline RCP<const UIntPolyFlint> gcd_upoly(const UIntPolyFlint &a,
+                                          const UIntPolyFlint &b)
+{
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
-    return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::gcd(a.get_poly(), b.get_poly()))));
+    return make_rcp<const UIntPolyFlint>(
+        a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(
+                         flint::gcd(a.get_poly(), b.get_poly()))));
 }
 
-inline RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
-{   
+inline RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a,
+                                          const UIntPolyFlint &b)
+{
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
-    return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::lcm(a.get_poly(), b.get_poly()))));
+    return make_rcp<const UIntPolyFlint>(
+        a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(
+                         flint::lcm(a.get_poly(), b.get_poly()))));
 }
 
-inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a, unsigned int p)
-{   
-    return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::pow(a.get_poly(), p))));
+inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a,
+                                          unsigned int p)
+{
+    return make_rcp<const UIntPolyFlint>(
+        a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(
+                         flint::pow(a.get_poly(), p))));
 }
 
 inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -93,16 +93,21 @@ inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a,
                          flint::pow(a.get_poly(), p))));
 }
 
-inline std::pair<bool, RCP<const UIntPolyFlint>> divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
-{   
+inline std::pair<bool, RCP<const UIntPolyFlint>>
+divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+{
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
 
     auto t = flint::divides(b.get_poly(), a.get_poly());
-    if(t.get<0>())
-        return std::make_pair(true, UIntPolyFlint::from_container(a.get_var(), static_cast<flint::fmpz_polyxx>(t.get<1>())));
+    if (t.get<0>())
+        return std::make_pair(
+            true,
+            UIntPolyFlint::from_container(
+                a.get_var(), static_cast<flint::fmpz_polyxx>(t.get<1>())));
     else
-        return std::make_pair(false, UIntPolyFlint::from_dict(a.get_var(), {{}}));
+        return std::make_pair(false,
+                              UIntPolyFlint::from_dict(a.get_var(), {{}}));
 }
 }
 

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -93,21 +93,20 @@ inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a,
                          flint::pow(a.get_poly(), p))));
 }
 
-inline std::pair<bool, RCP<const UIntPolyFlint>>
-divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b,
+                          const Ptr<RCP<const UIntPolyFlint>> &res)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
 
     auto t = flint::divides(b.get_poly(), a.get_poly());
-    if (t.get<0>())
-        return std::make_pair(
-            true,
-            UIntPolyFlint::from_container(
-                a.get_var(), static_cast<flint::fmpz_polyxx>(t.get<1>())));
-    else
-        return std::make_pair(false,
-                              UIntPolyFlint::from_dict(a.get_var(), {{}}));
+    if (t.get<0>()) {
+        *res = UIntPolyFlint::from_container(
+            a.get_var(), static_cast<flint::fmpz_polyxx>(t.get<1>()));
+        return true;
+    } else {
+        return false;
+    }
 }
 }
 

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -84,7 +84,7 @@ inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a, unsigned int p
 
 inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
 {
-    return flint::divides(a.get_poly(), b.get_poly()).get<0>();
+    return flint::divides(b.get_poly(), a.get_poly()).get<0>();
 }
 }
 

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -32,6 +32,8 @@ public:
     from_vec(const RCP<const Symbol> &var, const std::vector<integer_class> &v);
 
     integer_class eval(const integer_class &x) const;
+    std::vector<integer_class> multieval(const std::vector<integer_class> &v) const;
+
     integer_class get_coeff(unsigned int x) const;
     flint::fmpzxx_srcref get_coeff_ref(unsigned int x) const;
 
@@ -60,6 +62,30 @@ public:
     }
 
 }; // UIntPolyFLint
+
+RCP<const UIntPolyFlint> gcd_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+{   
+    if (!(a.get_var()->__eq__(*b.get_var())))
+        throw std::runtime_error("Error: variables must agree.");
+    return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::gcd(a.get_poly(), b.get_poly()))));
+}
+
+RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+{   
+    if (!(a.get_var()->__eq__(*b.get_var())))
+        throw std::runtime_error("Error: variables must agree.");
+    return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::lcm(a.get_poly(), b.get_poly()))));
+}
+
+RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a, unsigned int p)
+{   
+    return make_rcp<const UIntPolyFlint>(a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(flint::pow(a.get_poly(), p))));
+}
+
+bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b)
+{
+    return flint::divides(a.get_poly(), b.get_poly()).get<0>();
+}
 }
 
 #endif // HAVE_SYMENGINE_FLINT

--- a/symengine/polys/uintpoly_piranha.cpp
+++ b/symengine/polys/uintpoly_piranha.cpp
@@ -46,7 +46,7 @@ UIntPolyPiranha::from_dict(const RCP<const Symbol> &var, map_uint_mpz &&d)
 
 RCP<const UIntPolyPiranha>
 UIntPolyPiranha::from_vec(const RCP<const Symbol> &var,
-                          const std::vector<integer_class> &v)
+                          const vec_integer_class &v)
 {
     pintpoly p;
     piranha::symbol_set ss({{piranha::symbol(var->get_name())}});
@@ -64,8 +64,8 @@ integer_class UIntPolyPiranha::get_coeff(unsigned int x) const
     return poly_.find_cf(pmonomial{x});
 }
 
-const integer_class& UIntPolyPiranha::get_coeff_ref(unsigned int x) const
-{       
+const integer_class &UIntPolyPiranha::get_coeff_ref(unsigned int x) const
+{
     static integer_class PZERO(0);
 
     pterm temp = pterm{0, pmonomial{x}};

--- a/symengine/polys/uintpoly_piranha.cpp
+++ b/symengine/polys/uintpoly_piranha.cpp
@@ -85,9 +85,9 @@ vec_integer_class UIntPolyPiranha::multieval(const vec_integer_class &v) const
 {
     vec_integer_class res(v.size());
     for (unsigned int i = 0; i < v.size(); ++i)
-        res[i] = piranha::math::evaluate<integer_class>(poly_, {{var_->get_name(), v[i]}});
+        res[i] = piranha::math::evaluate<integer_class>(
+            poly_, {{var_->get_name(), v[i]}});
     return res;
 }
-
 }
 #endif

--- a/symengine/polys/uintpoly_piranha.cpp
+++ b/symengine/polys/uintpoly_piranha.cpp
@@ -80,5 +80,14 @@ integer_class UIntPolyPiranha::eval(const integer_class &x) const
     return piranha::math::evaluate<integer_class>(poly_,
                                                   {{var_->get_name(), x}});
 }
+
+vec_integer_class UIntPolyPiranha::multieval(const vec_integer_class &v) const
+{
+    vec_integer_class res(v.size());
+    for (unsigned int i = 0; i < v.size(); ++i)
+        res[i] = piranha::math::evaluate<integer_class>(poly_, {{var_->get_name(), v[i]}});
+    return res;
+}
+
 }
 #endif

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -25,9 +25,8 @@ namespace piranha
 namespace math
 {
 template <typename U>
-struct pow_impl<SymEngine::integer_class, U, 
-                SymEngine::enable_if_t<std::is_integral<U>::value>>
-{
+struct pow_impl<SymEngine::integer_class, U,
+                SymEngine::enable_if_t<std::is_integral<U>::value>> {
     template <typename T2>
     SymEngine::integer_class operator()(const SymEngine::integer_class &r,
                                         const T2 &x) const
@@ -39,8 +38,7 @@ struct pow_impl<SymEngine::integer_class, U,
 };
 
 template <>
-struct gcd_impl<SymEngine::integer_class, SymEngine::integer_class>
-{
+struct gcd_impl<SymEngine::integer_class, SymEngine::integer_class> {
     SymEngine::integer_class operator()(const SymEngine::integer_class &r,
                                         const SymEngine::integer_class &x) const
     {
@@ -51,15 +49,14 @@ struct gcd_impl<SymEngine::integer_class, SymEngine::integer_class>
 };
 
 template <>
-struct divexact_impl<SymEngine::integer_class>
-{
+struct divexact_impl<SymEngine::integer_class> {
     void operator()(SymEngine::integer_class &r,
-                    const SymEngine::integer_class &x, const SymEngine::integer_class &y) const
+                    const SymEngine::integer_class &x,
+                    const SymEngine::integer_class &y) const
     {
         SymEngine::integer_class rem;
         mp_tdiv_qr(r, rem, x, y);
-        if (rem != SymEngine::integer_class(0))
-        {
+        if (rem != SymEngine::integer_class(0)) {
             piranha_throw(inexact_division);
         }
     }
@@ -67,8 +64,7 @@ struct divexact_impl<SymEngine::integer_class>
 }
 
 template <>
-struct has_exact_ring_operations<SymEngine::integer_class>
-{
+struct has_exact_ring_operations<SymEngine::integer_class> {
     static const bool value = true;
 };
 }
@@ -176,38 +172,41 @@ public:
 }; // UIntPolyPiranha
 
 inline RCP<const UIntPolyPiranha> gcd_upoly(const UIntPolyPiranha &a,
-                                          const UIntPolyPiranha &b)
+                                            const UIntPolyPiranha &b)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
 
     pintpoly gcdx(std::get<0>(pintpoly::gcd(a.get_poly(), b.get_poly())));
     // following the convention, that leading coefficient should be positive
-    if(gcdx.find_cf(pmonomial{gcdx.degree()}) < 0)
+    if (gcdx.find_cf(pmonomial{gcdx.degree()}) < 0)
         gcdx = -gcdx;
     return make_rcp<const UIntPolyPiranha>(a.get_var(), std::move(gcdx));
 }
 
 inline RCP<const UIntPolyPiranha> lcm_upoly(const UIntPolyPiranha &a,
-                                          const UIntPolyPiranha &b)
+                                            const UIntPolyPiranha &b)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
 
     pintpoly gcdx(std::get<0>(pintpoly::gcd(a.get_poly(), b.get_poly())));
-    if(gcdx.find_cf(pmonomial{gcdx.degree()}) < 0)
+    if (gcdx.find_cf(pmonomial{gcdx.degree()}) < 0)
         gcdx = -gcdx;
     pintpoly mulx(a.get_poly() * b.get_poly());
-    return make_rcp<const UIntPolyPiranha>(a.get_var(), std::move(pintpoly::udivrem(mulx, gcdx)).first);
+    return make_rcp<const UIntPolyPiranha>(
+        a.get_var(), std::move(pintpoly::udivrem(mulx, gcdx)).first);
 }
 
 inline RCP<const UIntPolyPiranha> pow_upoly(const UIntPolyPiranha &a,
-                                          unsigned int p)
+                                            unsigned int p)
 {
-    return make_rcp<const UIntPolyPiranha>(a.get_var(), std::move(piranha::math::pow(a.get_poly(), p)));
+    return make_rcp<const UIntPolyPiranha>(
+        a.get_var(), std::move(piranha::math::pow(a.get_poly(), p)));
 }
 
-inline std::pair<bool, RCP<const UIntPolyPiranha>> divides_upoly(const UIntPolyPiranha &a, const UIntPolyPiranha &b)
+inline std::pair<bool, RCP<const UIntPolyPiranha>>
+divides_upoly(const UIntPolyPiranha &a, const UIntPolyPiranha &b)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
@@ -215,12 +214,13 @@ inline std::pair<bool, RCP<const UIntPolyPiranha>> divides_upoly(const UIntPolyP
     try {
         pintpoly res;
         piranha::math::divexact(res, b.get_poly(), a.get_poly());
-        return std::make_pair(true, UIntPolyPiranha::from_container(a.get_var(), std::move(res)));
+        return std::make_pair(
+            true, UIntPolyPiranha::from_container(a.get_var(), std::move(res)));
     } catch (const piranha::math::inexact_division &) {
-        return std::make_pair(false, UIntPolyPiranha::from_dict(a.get_var(), {{}}));
+        return std::make_pair(false,
+                              UIntPolyPiranha::from_dict(a.get_var(), {{}}));
     }
 }
-
 }
 
 #endif // HAVE_SYMENGINE_PIRANHA

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -25,10 +25,10 @@ namespace piranha
 namespace math
 {
 template <typename T, typename U>
-struct pow_impl<T, U, SymEngine::enable_if_t
-                      <std::is_same<T, SymEngine::integer_class>::value 
-                      && std::is_integral<U>::value>> 
-{
+struct pow_impl<T, U,
+                SymEngine::
+                    enable_if_t<std::is_same<T, SymEngine::integer_class>::value
+                                && std::is_integral<U>::value>> {
     template <typename T2>
     SymEngine::integer_class operator()(const SymEngine::integer_class &r,
                                         const T2 &x) const
@@ -73,14 +73,14 @@ public:
         return *this;
     }
 
-    std::pair<unsigned int, const integer_class&> operator*()
+    std::pair<unsigned int, const integer_class &> operator*()
     {
         return std::make_pair(*(ptr_->m_key.begin()), ptr_->m_cf);
     }
 
-    std::shared_ptr<std::pair<unsigned int, const integer_class&>> operator->()
+    std::shared_ptr<std::pair<unsigned int, const integer_class &>> operator->()
     {
-        return std::make_shared<std::pair<unsigned int, const integer_class&>>(
+        return std::make_shared<std::pair<unsigned int, const integer_class &>>(
             *(ptr_->m_key.begin()), ptr_->m_cf);
     }
 };
@@ -97,12 +97,12 @@ public:
 
     static RCP<const UIntPolyPiranha> from_dict(const RCP<const Symbol> &var,
                                                 map_uint_mpz &&d);
-    static RCP<const UIntPolyPiranha>
-    from_vec(const RCP<const Symbol> &var, const std::vector<integer_class> &v);
+    static RCP<const UIntPolyPiranha> from_vec(const RCP<const Symbol> &var,
+                                               const vec_integer_class &v);
 
     integer_class eval(const integer_class &x) const;
     integer_class get_coeff(unsigned int x) const;
-    const integer_class& get_coeff_ref(unsigned int x) const;
+    const integer_class &get_coeff_ref(unsigned int x) const;
 
     inline unsigned int get_degree() const
     {
@@ -112,7 +112,8 @@ public:
     // begin() and end() are unordered
     // obegin() and oend() are ordered, from highest degree to lowest
     typedef PiranhaForIter iterator;
-    typedef ContainerRevIter<UIntPolyPiranha, const integer_class&> reverse_iterator;
+    typedef ContainerRevIter<UIntPolyPiranha, const integer_class &>
+        reverse_iterator;
     iterator begin() const
     {
         return iterator(poly_._container().begin());
@@ -123,7 +124,8 @@ public:
     }
     reverse_iterator obegin() const
     {
-        return reverse_iterator(rcp_from_this_cast<UIntPolyPiranha>(), (long)size() - 1);
+        return reverse_iterator(rcp_from_this_cast<UIntPolyPiranha>(),
+                                (long)size() - 1);
     }
     reverse_iterator oend() const
     {

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -205,20 +205,19 @@ inline RCP<const UIntPolyPiranha> pow_upoly(const UIntPolyPiranha &a,
         a.get_var(), std::move(piranha::math::pow(a.get_poly(), p)));
 }
 
-inline std::pair<bool, RCP<const UIntPolyPiranha>>
-divides_upoly(const UIntPolyPiranha &a, const UIntPolyPiranha &b)
+inline bool divides_upoly(const UIntPolyPiranha &a, const UIntPolyPiranha &b,
+                          const Ptr<RCP<const UIntPolyPiranha>> &res)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
 
     try {
-        pintpoly res;
-        piranha::math::divexact(res, b.get_poly(), a.get_poly());
-        return std::make_pair(
-            true, UIntPolyPiranha::from_container(a.get_var(), std::move(res)));
+        pintpoly z;
+        piranha::math::divexact(z, b.get_poly(), a.get_poly());
+        *res = UIntPolyPiranha::from_container(a.get_var(), std::move(z));
+        return true;
     } catch (const piranha::math::inexact_division &) {
-        return std::make_pair(false,
-                              UIntPolyPiranha::from_dict(a.get_var(), {{}}));
+        return false;
     }
 }
 }

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -180,7 +180,7 @@ inline RCP<const UIntPolyPiranha> gcd_upoly(const UIntPolyPiranha &a,
     pintpoly gcdx(std::get<0>(pintpoly::gcd(a.get_poly(), b.get_poly())));
     // following the convention, that leading coefficient should be positive
     if (gcdx.find_cf(pmonomial{gcdx.degree()}) < 0)
-        gcdx = -gcdx;
+        piranha::math::negate(gcdx);
     return make_rcp<const UIntPolyPiranha>(a.get_var(), std::move(gcdx));
 }
 
@@ -192,7 +192,7 @@ inline RCP<const UIntPolyPiranha> lcm_upoly(const UIntPolyPiranha &a,
 
     pintpoly gcdx(std::get<0>(pintpoly::gcd(a.get_poly(), b.get_poly())));
     if (gcdx.find_cf(pmonomial{gcdx.degree()}) < 0)
-        gcdx = -gcdx;
+        piranha::math::negate(gcdx);
     pintpoly mulx(a.get_poly() * b.get_poly());
     return make_rcp<const UIntPolyPiranha>(
         a.get_var(), std::move(pintpoly::udivrem(mulx, gcdx)).first);

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -207,14 +207,17 @@ inline RCP<const UIntPolyPiranha> pow_upoly(const UIntPolyPiranha &a,
     return make_rcp<const UIntPolyPiranha>(a.get_var(), std::move(piranha::math::pow(a.get_poly(), p)));
 }
 
-inline bool divides_upoly(const UIntPolyPiranha &a, const UIntPolyPiranha &b)
+inline std::pair<bool, RCP<const UIntPolyPiranha>> divides_upoly(const UIntPolyPiranha &a, const UIntPolyPiranha &b)
 {
+    if (!(a.get_var()->__eq__(*b.get_var())))
+        throw std::runtime_error("Error: variables must agree.");
+
     try {
         pintpoly res;
         piranha::math::divexact(res, b.get_poly(), a.get_poly());
-        return true;
+        return std::make_pair(true, UIntPolyPiranha::from_container(a.get_var(), std::move(res)));
     } catch (const piranha::math::inexact_division &) {
-        return false;
+        return std::make_pair(false, UIntPolyPiranha::from_dict(a.get_var(), {{}}));
     }
 }
 

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -22,7 +22,7 @@
 namespace SymEngine
 {
 // misc methods
-inline const integer_class& to_integer_class(const integer_class &i)
+inline const integer_class &to_integer_class(const integer_class &i)
 {
     return i;
 }
@@ -357,16 +357,15 @@ public:
                 if (m == 1) {
                     args.push_back(this->var_);
                 } else {
-                    args.push_back(Mul::from_dict(integer(m),
-                                                  {{this->var_, one}}));
+                    args.push_back(
+                        Mul::from_dict(integer(m), {{this->var_, one}}));
                 }
             } else {
                 if (m == 1) {
                     args.push_back(pow(this->var_, integer(it->first)));
                 } else {
-                    args.push_back(
-                        Mul::from_dict(integer(m),
-                                       {{this->var_, integer(it->first)}}));
+                    args.push_back(Mul::from_dict(
+                        integer(m), {{this->var_, integer(it->first)}}));
                 }
             }
         }
@@ -403,7 +402,8 @@ public:
 
     std::shared_ptr<std::pair<long, Int>> operator->()
     {
-        return std::make_shared<std::pair<long, Int>>(i_, ptr_->get_coeff_ref(i_));
+        return std::make_shared<std::pair<long, Int>>(i_,
+                                                      ptr_->get_coeff_ref(i_));
     }
 };
 
@@ -411,7 +411,8 @@ template <typename T, typename Int>
 class ContainerForIter : public ContainerBaseIter<T, Int>
 {
 public:
-    ContainerForIter(RCP<const T> ptr, long x) : ContainerBaseIter<T, Int>(ptr, x)
+    ContainerForIter(RCP<const T> ptr, long x)
+        : ContainerBaseIter<T, Int>(ptr, x)
     {
     }
 
@@ -431,7 +432,8 @@ template <typename T, typename Int>
 class ContainerRevIter : public ContainerBaseIter<T, Int>
 {
 public:
-    ContainerRevIter(RCP<const T> ptr, long x) : ContainerBaseIter<T, Int>(ptr, x)
+    ContainerRevIter(RCP<const T> ptr, long x)
+        : ContainerBaseIter<T, Int>(ptr, x)
     {
     }
 

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -339,6 +339,7 @@ public:
     virtual integer_class get_coeff(unsigned int i) const = 0;
     // return value of poly when ealudated at `x`
     virtual integer_class eval(const integer_class &x) const = 0;
+    virtual vec_integer_class multieval(const vec_integer_class &x) const = 0;
     // return `degree` + 1. `0` returned for zero poly.
     virtual unsigned int size() const = 0;
 

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -343,6 +343,11 @@ public:
     // return `degree` + 1. `0` returned for zero poly.
     virtual unsigned int size() const = 0;
 
+    integer_class get_lc() const
+    {
+        return get_coeff(get_degree());
+    }
+
     RCP<const Basic> as_symbolic() const
     {
         auto it = (static_cast<const Poly &>(*this)).begin();

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -316,8 +316,7 @@ void uintpoly_print(const T &x, std::ostringstream &s)
             if (first) {
                 s << m;
             } else {
-                s << " " << _print_sign(m) << " "
-                  << mp_abs(m);
+                s << " " << _print_sign(m) << " " << mp_abs(m);
             }
             first = false;
             continue;
@@ -331,8 +330,7 @@ void uintpoly_print(const T &x, std::ostringstream &s)
                     s << "-";
                 s << x.get_var()->get_name();
             } else {
-                s << " " << _print_sign(m) << " "
-                  << x.get_var()->get_name();
+                s << " " << _print_sign(m) << " " << x.get_var()->get_name();
             }
         }
         // same logic is followed as above
@@ -342,8 +340,8 @@ void uintpoly_print(const T &x, std::ostringstream &s)
             if (first) {
                 s << m << "*" << x.get_var()->get_name();
             } else {
-                s << " " << _print_sign(m) << " " << mp_abs(m)
-                  << "*" << x.get_var()->get_name();
+                s << " " << _print_sign(m) << " " << mp_abs(m) << "*"
+                  << x.get_var()->get_name();
             }
         }
         // if exponent is not 1, print the exponent;

--- a/symengine/tests/ntheory/test_ntheory.cpp
+++ b/symengine/tests/ntheory/test_ntheory.cpp
@@ -40,6 +40,7 @@ using SymEngine::carmichael;
 using SymEngine::mertens;
 using SymEngine::integer_class;
 using SymEngine::harmonic;
+using SymEngine::vec_integer_class;
 
 TEST_CASE("test_gcd_lcm(): ntheory", "[ntheory]")
 {
@@ -653,15 +654,15 @@ TEST_CASE("test_powermod(): ntheory", "[ntheory]")
 TEST_CASE("test_quadratic_residues(): ntheory", "[ntheory]")
 {
 
-    std::vector<integer_class> i1 = {integer_class(0)};
-    std::vector<integer_class> i2 = {integer_class(0), integer_class(1)};
-    std::vector<integer_class> i3 = {integer_class(0), integer_class(1)};
-    std::vector<integer_class> i4 = {integer_class(0), integer_class(1)};
-    std::vector<integer_class> i5
+    vec_integer_class i1 = {integer_class(0)};
+    vec_integer_class i2 = {integer_class(0), integer_class(1)};
+    vec_integer_class i3 = {integer_class(0), integer_class(1)};
+    vec_integer_class i4 = {integer_class(0), integer_class(1)};
+    vec_integer_class i5
         = {integer_class(0), integer_class(1), integer_class(4)};
-    std::vector<integer_class> i7 = {integer_class(0), integer_class(1),
-                                     integer_class(2), integer_class(4)};
-    std::vector<integer_class> i100
+    vec_integer_class i7 = {integer_class(0), integer_class(1),
+                            integer_class(2), integer_class(4)};
+    vec_integer_class i100
         = {integer_class(0),  integer_class(1),  integer_class(4),
            integer_class(9),  integer_class(16), integer_class(21),
            integer_class(24), integer_class(25), integer_class(29),

--- a/symengine/tests/polynomial/test_mintpoly.cpp
+++ b/symengine/tests/polynomial/test_mintpoly.cpp
@@ -523,7 +523,8 @@ TEST_CASE("Testing addition, subtraction, multiplication of two "
 {
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
-    RCP<const UIntPoly> p1 = UIntPoly::from_dict(x, {{1, -1_z}, {2, 3_z}, {0, 0_z}});
+    RCP<const UIntPoly> p1
+        = UIntPoly::from_dict(x, {{1, -1_z}, {2, 3_z}, {0, 0_z}});
     RCP<const UIntPoly> p2 = UIntPoly::from_dict(y, {{0, 1_z}, {1, 1_z}});
 
     RCP<const MultivariateIntPolynomial> q1 = MultivariateIntPolynomial::create(
@@ -548,7 +549,8 @@ TEST_CASE("Testing addition, subtraction, multiplication of two "
           "[MultivariateIntPolynomial][UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> p1 = UIntPoly::from_dict(x, {{1, -1_z}, {2, 3_z}, {0, 0_z}});
+    RCP<const UIntPoly> p1
+        = UIntPoly::from_dict(x, {{1, -1_z}, {2, 3_z}, {0, 0_z}});
     RCP<const UIntPoly> p2 = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}});
 
     RCP<const MultivariateIntPolynomial> q1

--- a/symengine/tests/polynomial/test_mintpoly.cpp
+++ b/symengine/tests/polynomial/test_mintpoly.cpp
@@ -11,7 +11,6 @@
 
 using SymEngine::Expression;
 using SymEngine::UIntPoly;
-using SymEngine::uint_poly;
 using SymEngine::Symbol;
 using SymEngine::symbol;
 using SymEngine::Pow;
@@ -414,8 +413,8 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
                                                         {{0, 0, 0}, 3_z},
                                                         {{2, 0, 0}, 2_z},
                                                         {{1, 0, 0}, 1_z}});
-    RCP<const UIntPoly> p2 = uint_poly(x, {{1, 1_z}, {2, 1_z}});
-    RCP<const UIntPoly> p3 = uint_poly(y, {{1, 1_z}, {2, 1_z}});
+    RCP<const UIntPoly> p2 = UIntPoly::from_dict(x, {{1, 1_z}, {2, 1_z}});
+    RCP<const UIntPoly> p3 = UIntPoly::from_dict(y, {{1, 1_z}, {2, 1_z}});
 
     RCP<const MultivariateIntPolynomial> q1
         = MultivariateIntPolynomial::create({x, y, z}, {{{1, 2, 3}, 1_z},
@@ -478,7 +477,7 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const Symbol> z = symbol("z");
     RCP<const MultivariateIntPolynomial> p1 = MultivariateIntPolynomial::create(
         {x, y}, {{{1, 2}, 1_z}, {{2, 1}, -2_z}, {{0, 1}, 1_z}, {{0, 0}, 3_z}});
-    RCP<const UIntPoly> p2 = uint_poly(z, {{1, 1_z}, {2, 1_z}});
+    RCP<const UIntPoly> p2 = UIntPoly::from_dict(z, {{1, 1_z}, {2, 1_z}});
 
     RCP<const MultivariateIntPolynomial> q1
         = MultivariateIntPolynomial::create({x, y, z}, {{{1, 2, 0}, 1_z},
@@ -524,8 +523,8 @@ TEST_CASE("Testing addition, subtraction, multiplication of two "
 {
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
-    RCP<const UIntPoly> p1 = uint_poly(x, {{1, -1_z}, {2, 3_z}, {0, 0_z}});
-    RCP<const UIntPoly> p2 = uint_poly(y, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPoly> p1 = UIntPoly::from_dict(x, {{1, -1_z}, {2, 3_z}, {0, 0_z}});
+    RCP<const UIntPoly> p2 = UIntPoly::from_dict(y, {{0, 1_z}, {1, 1_z}});
 
     RCP<const MultivariateIntPolynomial> q1 = MultivariateIntPolynomial::create(
         {x, y}, {{{1, 0}, -1_z}, {{2, 0}, 3_z}, {{0, 0}, 1_z}, {{0, 1}, 1_z}});
@@ -549,8 +548,8 @@ TEST_CASE("Testing addition, subtraction, multiplication of two "
           "[MultivariateIntPolynomial][UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> p1 = uint_poly(x, {{1, -1_z}, {2, 3_z}, {0, 0_z}});
-    RCP<const UIntPoly> p2 = uint_poly(x, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPoly> p1 = UIntPoly::from_dict(x, {{1, -1_z}, {2, 3_z}, {0, 0_z}});
+    RCP<const UIntPoly> p2 = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}});
 
     RCP<const MultivariateIntPolynomial> q1
         = MultivariateIntPolynomial::create({x}, {{{0}, 1_z}, {{2}, 3_z}});

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -296,3 +296,23 @@ TEST_CASE("UIntPoly pow", "[UIntPoly]")
     REQUIRE(aaa->__str__() == "x**3 + 3*x**2 + 3*x + 1");
     REQUIRE(bb->__str__() == "x**4 + 6*x**2 + 9");
 }
+
+TEST_CASE("UIntPoly divides", "[UIntPoly]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const UIntPoly> a
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 4_z}});
+    RCP<const UIntPoly> c
+        = UIntPoly::from_dict(x, {{0, 8_z}, {1, 8_z}});
+
+    std::pair<bool, RCP<const UIntPoly>> ac = divides_upoly(*a, *c);
+    std::pair<bool, RCP<const UIntPoly>> bc = divides_upoly(*b, *c);
+    std::pair<bool, RCP<const UIntPoly>> ba = divides_upoly(*b, *a);
+
+    REQUIRE(ac.first);
+    REQUIRE(ac.second->__str__() == "8");
+    REQUIRE(bc.first);
+    REQUIRE(bc.second->__str__() == "2*x + 2");
+    REQUIRE(!ba.first);
+}

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -9,7 +9,6 @@
 #include <symengine/dict.h>
 
 using SymEngine::UIntPoly;
-using SymEngine::uint_poly;
 using SymEngine::Symbol;
 using SymEngine::symbol;
 using SymEngine::Pow;
@@ -31,7 +30,7 @@ using namespace SymEngine::literals;
 TEST_CASE("Constructor of UIntPoly", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> P = uint_poly(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> P = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
     REQUIRE(P->__str__() == "x**2 + 2*x + 1");
 
     RCP<const UIntPoly> Q = UIntPoly::from_vec(x, {1_z, 0_z, 2_z, 1_z});
@@ -40,13 +39,13 @@ TEST_CASE("Constructor of UIntPoly", "[UIntPoly]")
     RCP<const UIntPoly> R = UIntPoly::from_vec(x, {1_z, 0_z, 2_z, 1_z});
     REQUIRE(R->__str__() == "x**3 + 2*x**2 + 1");
 
-    RCP<const UIntPoly> S = uint_poly(x, {{0, 2_z}});
+    RCP<const UIntPoly> S = UIntPoly::from_dict(x, {{0, 2_z}});
     REQUIRE(S->__str__() == "2");
 
-    RCP<const UIntPoly> T = uint_poly(x, map_uint_mpz{});
+    RCP<const UIntPoly> T = UIntPoly::from_dict(x, map_uint_mpz{});
     REQUIRE(T->__str__() == "0");
 
-    RCP<const UIntPoly> U = uint_poly(x, {{0, 2_z}, {1, 0_z}, {2, 0_z}});
+    RCP<const UIntPoly> U = UIntPoly::from_dict(x, {{0, 2_z}, {1, 0_z}, {2, 0_z}});
     REQUIRE(U->__str__() == "2");
 }
 
@@ -63,7 +62,7 @@ TEST_CASE("Adding two UIntPoly", "[UIntPoly]")
     RCP<const Basic> c = add_upoly(a, b);
     REQUIRE(c->__str__() == "5*x**2 + 5*x + 3");
 
-    RCP<const UIntPoly> d = uint_poly(x, {{0, 1_z}});
+    RCP<const UIntPoly> d = UIntPoly::from_dict(x, {{0, 1_z}});
     RCP<const Basic> e = add_upoly(a, *d);
     RCP<const Basic> f = add_upoly(*d, a);
     REQUIRE(e->__str__() == "x**2 + 2*x + 2");
@@ -139,11 +138,11 @@ TEST_CASE("Multiplication of two UIntPoly", "[UIntPoly]")
     REQUIRE(l->__str__() == "-300*x**4 + 194*x**3 - 599*x**2 - 10*x - 6");
     REQUIRE(m->__str__() == "10000*x**4 + 400*x**3 + 204*x**2 + 4*x + 1");
 
-    c = uint_poly(x, {{0, -1_z}});
+    c = UIntPoly::from_dict(x, {{0, -1_z}});
     REQUIRE(mul_upoly(a, *c)->__str__() == "-x**2 - 2*x - 1");
     REQUIRE(mul_upoly(*c, a)->__str__() == "-x**2 - 2*x - 1");
 
-    c = uint_poly(y, {{0, -1_z}});
+    c = UIntPoly::from_dict(y, {{0, -1_z}});
     CHECK_THROWS_AS(mul_upoly(a, *c), std::runtime_error);
 }
 
@@ -151,44 +150,44 @@ TEST_CASE("Comparing two UIntPoly", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
-    RCP<const UIntPoly> P = uint_poly(x, {{0, 1_z}, {1, 2_z}});
-    RCP<const UIntPoly> Q = uint_poly(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> P = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}});
+    RCP<const UIntPoly> Q = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE(P->compare(*Q) == -1);
 
-    P = uint_poly(x, {{0, 1_z}, {1, 2_z}, {2, 3_z}, {3, 2_z}});
+    P = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 3_z}, {3, 2_z}});
     REQUIRE(P->compare(*Q) == 1);
 
-    P = uint_poly(x, {{0, 1_z}, {1, 2_z}, {3, 3_z}});
+    P = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {3, 3_z}});
     REQUIRE(P->compare(*Q) == 1);
 
-    P = uint_poly(y, {{0, 1_z}, {1, 2_z}, {3, 3_z}});
+    P = UIntPoly::from_dict(y, {{0, 1_z}, {1, 2_z}, {3, 3_z}});
     REQUIRE(P->compare(*Q) == 1);
 }
 
 TEST_CASE("UIntPoly as_symbolic", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> a = uint_poly(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE(eq(*a->as_symbolic(),
                *add({one, mul(integer(2), x), pow(x, integer(2))})));
     REQUIRE(not eq(*a->as_symbolic(),
                    *add({one, mul(integer(3), x), pow(x, integer(2))})));
 
-    RCP<const UIntPoly> b = uint_poly(x, {{0, 1_z}, {1, 1_z}, {2, 2_z}});
+    RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}, {2, 2_z}});
     REQUIRE(eq(*b->as_symbolic(),
                *add({one, x, mul(integer(2), pow(x, integer(2)))})));
 
-    RCP<const UIntPoly> c = uint_poly(x, map_uint_mpz{});
+    RCP<const UIntPoly> c = UIntPoly::from_dict(x, map_uint_mpz{});
     REQUIRE(eq(*c->as_symbolic(), *zero));
 }
 
 TEST_CASE("Evaluation of UIntPoly", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> a = uint_poly(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
-    RCP<const UIntPoly> b = uint_poly(x, {{0, 1_z}, {1, 0_z}, {2, -1_z}});
+    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 1_z}, {1, 0_z}, {2, -1_z}});
 
     REQUIRE(a->eval(2_z) == 9);
     REQUIRE(a->eval(10_z) == 121);
@@ -201,31 +200,31 @@ TEST_CASE("Derivative of UIntPoly", "[UIntPoly]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> none = symbol("");
-    RCP<const UIntPoly> a = uint_poly(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
-    RCP<const UIntPoly> b = uint_poly(none, {{0, 1_z}});
+    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> b = UIntPoly::from_dict(none, {{0, 1_z}});
 
     REQUIRE(a->diff(x)->__str__() == "2*x + 2");
     REQUIRE(a->diff(y)->__str__() == "0");
     REQUIRE(b->diff(y)->__str__() == "0");
 
-    a = uint_poly(none, {{0, 1_z}});
+    a = UIntPoly::from_dict(none, {{0, 1_z}});
     REQUIRE(a->diff(y)->__str__() == "0");
-    a = uint_poly(none, map_uint_mpz{});
+    a = UIntPoly::from_dict(none, map_uint_mpz{});
     REQUIRE(a->diff(y)->__str__() == "0");
 }
 
 TEST_CASE("Bool checks specific UIntPoly cases", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> z = uint_poly(x, {{0, 0_z}});
-    RCP<const UIntPoly> o = uint_poly(x, {{0, 1_z}});
-    RCP<const UIntPoly> mo = uint_poly(x, {{0, -1_z}});
-    RCP<const UIntPoly> i = uint_poly(x, {{0, 6_z}});
-    RCP<const UIntPoly> s = uint_poly(x, {{1, 1_z}});
-    RCP<const UIntPoly> m1 = uint_poly(x, {{1, 6_z}});
-    RCP<const UIntPoly> m2 = uint_poly(x, {{3, 5_z}});
-    RCP<const UIntPoly> po = uint_poly(x, {{5, 1_z}});
-    RCP<const UIntPoly> poly = uint_poly(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> z = UIntPoly::from_dict(x, {{0, 0_z}});
+    RCP<const UIntPoly> o = UIntPoly::from_dict(x, {{0, 1_z}});
+    RCP<const UIntPoly> mo = UIntPoly::from_dict(x, {{0, -1_z}});
+    RCP<const UIntPoly> i = UIntPoly::from_dict(x, {{0, 6_z}});
+    RCP<const UIntPoly> s = UIntPoly::from_dict(x, {{1, 1_z}});
+    RCP<const UIntPoly> m1 = UIntPoly::from_dict(x, {{1, 6_z}});
+    RCP<const UIntPoly> m2 = UIntPoly::from_dict(x, {{3, 5_z}});
+    RCP<const UIntPoly> po = UIntPoly::from_dict(x, {{5, 1_z}});
+    RCP<const UIntPoly> poly = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE((z->is_zero() and not z->is_one() and not z->is_minus_one()
              and z->is_integer() and not z->is_symbol() and not z->is_mul()
@@ -260,7 +259,7 @@ TEST_CASE("Bool checks specific UIntPoly cases", "[UIntPoly]")
 TEST_CASE("UIntPoly expand", "[UIntPoly][expand]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> a = uint_poly(x, {{1, 1_z}, {2, 1_z}, {3, 1_z}});
+    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{1, 1_z}, {2, 1_z}, {3, 1_z}});
     RCP<const Basic> b = make_rcp<const Pow>(a, integer(3));
     RCP<const Basic> c = expand(b);
 

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -303,14 +303,11 @@ TEST_CASE("UIntPoly divides", "[UIntPoly]")
     RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}});
     RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 4_z}});
     RCP<const UIntPoly> c = UIntPoly::from_dict(x, {{0, 8_z}, {1, 8_z}});
+    RCP<const UIntPoly> res;
 
-    std::pair<bool, RCP<const UIntPoly>> ac = divides_upoly(*a, *c);
-    std::pair<bool, RCP<const UIntPoly>> bc = divides_upoly(*b, *c);
-    std::pair<bool, RCP<const UIntPoly>> ba = divides_upoly(*b, *a);
-
-    REQUIRE(ac.first);
-    REQUIRE(ac.second->__str__() == "8");
-    REQUIRE(bc.first);
-    REQUIRE(bc.second->__str__() == "2*x + 2");
-    REQUIRE(!ba.first);
+    REQUIRE(divides_upoly(*a, *c, outArg(res)));
+    REQUIRE(res->__str__() == "8");
+    REQUIRE(divides_upoly(*b, *c, outArg(res)));
+    REQUIRE(res->__str__() == "2*x + 2");
+    REQUIRE(!divides_upoly(*b, *a, outArg(res)));
 }

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -212,19 +212,13 @@ TEST_CASE("Derivative of UIntPoly", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
-    RCP<const Symbol> none = symbol("");
     RCP<const UIntPoly> a
         = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
-    RCP<const UIntPoly> b = UIntPoly::from_dict(none, {{0, 1_z}});
+    RCP<const UIntPoly> b = UIntPoly::from_dict(y, {{2, 4_z}});
 
     REQUIRE(a->diff(x)->__str__() == "2*x + 2");
     REQUIRE(a->diff(y)->__str__() == "0");
-    REQUIRE(b->diff(y)->__str__() == "0");
-
-    a = UIntPoly::from_dict(none, {{0, 1_z}});
-    REQUIRE(a->diff(y)->__str__() == "0");
-    a = UIntPoly::from_dict(none, map_uint_mpz{});
-    REQUIRE(a->diff(y)->__str__() == "0");
+    REQUIRE(b->diff(y)->__str__() == "8*y");
 }
 
 TEST_CASE("Bool checks specific UIntPoly cases", "[UIntPoly]")

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -24,13 +24,15 @@ using SymEngine::vec_basic_eq_perm;
 using SymEngine::integer_class;
 using SymEngine::UIntDict;
 using SymEngine::add;
+using SymEngine::vec_integer_class;
 
 using namespace SymEngine::literals;
 
 TEST_CASE("Constructor of UIntPoly", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> P = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> P
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
     REQUIRE(P->__str__() == "x**2 + 2*x + 1");
 
     RCP<const UIntPoly> Q = UIntPoly::from_vec(x, {1_z, 0_z, 2_z, 1_z});
@@ -45,7 +47,8 @@ TEST_CASE("Constructor of UIntPoly", "[UIntPoly]")
     RCP<const UIntPoly> T = UIntPoly::from_dict(x, map_uint_mpz{});
     REQUIRE(T->__str__() == "0");
 
-    RCP<const UIntPoly> U = UIntPoly::from_dict(x, {{0, 2_z}, {1, 0_z}, {2, 0_z}});
+    RCP<const UIntPoly> U
+        = UIntPoly::from_dict(x, {{0, 2_z}, {1, 0_z}, {2, 0_z}});
     REQUIRE(U->__str__() == "2");
 }
 
@@ -151,7 +154,8 @@ TEST_CASE("Comparing two UIntPoly", "[UIntPoly]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const UIntPoly> P = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}});
-    RCP<const UIntPoly> Q = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> Q
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE(P->compare(*Q) == -1);
 
@@ -168,14 +172,16 @@ TEST_CASE("Comparing two UIntPoly", "[UIntPoly]")
 TEST_CASE("UIntPoly as_symbolic", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> a
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE(eq(*a->as_symbolic(),
                *add({one, mul(integer(2), x), pow(x, integer(2))})));
     REQUIRE(not eq(*a->as_symbolic(),
                    *add({one, mul(integer(3), x), pow(x, integer(2))})));
 
-    RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}, {2, 2_z}});
+    RCP<const UIntPoly> b
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}, {2, 2_z}});
     REQUIRE(eq(*b->as_symbolic(),
                *add({one, x, mul(integer(2), pow(x, integer(2)))})));
 
@@ -186,16 +192,18 @@ TEST_CASE("UIntPoly as_symbolic", "[UIntPoly]")
 TEST_CASE("Evaluation of UIntPoly", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
-    RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 1_z}, {1, 0_z}, {2, -1_z}});
+    RCP<const UIntPoly> a
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> b
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 0_z}, {2, -1_z}});
 
     REQUIRE(a->eval(2_z) == 9);
     REQUIRE(a->eval(10_z) == 121);
     REQUIRE(b->eval(-1_z) == 0);
     REQUIRE(b->eval(0_z) == 1);
 
-    std::vector<integer_class> resa = {9_z, 121_z, 0_z, 1_z};
-    std::vector<integer_class> resb = {-3_z, -99_z, 0_z, 1_z};
+    vec_integer_class resa = {9_z, 121_z, 0_z, 1_z};
+    vec_integer_class resb = {-3_z, -99_z, 0_z, 1_z};
     REQUIRE(a->multieval({2_z, 10_z, -1_z, 0_z}) == resa);
     REQUIRE(b->multieval({2_z, 10_z, -1_z, 0_z}) == resb);
 }
@@ -205,7 +213,8 @@ TEST_CASE("Derivative of UIntPoly", "[UIntPoly]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> none = symbol("");
-    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> a
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
     RCP<const UIntPoly> b = UIntPoly::from_dict(none, {{0, 1_z}});
 
     REQUIRE(a->diff(x)->__str__() == "2*x + 2");
@@ -229,7 +238,8 @@ TEST_CASE("Bool checks specific UIntPoly cases", "[UIntPoly]")
     RCP<const UIntPoly> m1 = UIntPoly::from_dict(x, {{1, 6_z}});
     RCP<const UIntPoly> m2 = UIntPoly::from_dict(x, {{3, 5_z}});
     RCP<const UIntPoly> po = UIntPoly::from_dict(x, {{5, 1_z}});
-    RCP<const UIntPoly> poly = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPoly> poly
+        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE((z->is_zero() and not z->is_one() and not z->is_minus_one()
              and z->is_integer() and not z->is_symbol() and not z->is_mul()
@@ -264,7 +274,8 @@ TEST_CASE("Bool checks specific UIntPoly cases", "[UIntPoly]")
 TEST_CASE("UIntPoly expand", "[UIntPoly][expand]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{1, 1_z}, {2, 1_z}, {3, 1_z}});
+    RCP<const UIntPoly> a
+        = UIntPoly::from_dict(x, {{1, 1_z}, {2, 1_z}, {3, 1_z}});
     RCP<const Basic> b = make_rcp<const Pow>(a, integer(3));
     RCP<const Basic> c = expand(b);
 
@@ -279,7 +290,7 @@ TEST_CASE("UIntPoly pow", "[UIntPoly]")
     RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}});
     RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 3_z}, {2, 1_z}});
 
-    RCP<const UIntPoly> aaa = pow_upoly(*a, 3);   
+    RCP<const UIntPoly> aaa = pow_upoly(*a, 3);
     RCP<const UIntPoly> bb = pow_upoly(*b, 2);
 
     REQUIRE(aaa->__str__() == "x**3 + 3*x**2 + 3*x + 1");

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -300,11 +300,9 @@ TEST_CASE("UIntPoly pow", "[UIntPoly]")
 TEST_CASE("UIntPoly divides", "[UIntPoly]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPoly> a
-        = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}});
     RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 4_z}});
-    RCP<const UIntPoly> c
-        = UIntPoly::from_dict(x, {{0, 8_z}, {1, 8_z}});
+    RCP<const UIntPoly> c = UIntPoly::from_dict(x, {{0, 8_z}, {1, 8_z}});
 
     std::pair<bool, RCP<const UIntPoly>> ac = divides_upoly(*a, *c);
     std::pair<bool, RCP<const UIntPoly>> bc = divides_upoly(*b, *c);

--- a/symengine/tests/polynomial/test_uintpoly.cpp
+++ b/symengine/tests/polynomial/test_uintpoly.cpp
@@ -193,6 +193,11 @@ TEST_CASE("Evaluation of UIntPoly", "[UIntPoly]")
     REQUIRE(a->eval(10_z) == 121);
     REQUIRE(b->eval(-1_z) == 0);
     REQUIRE(b->eval(0_z) == 1);
+
+    std::vector<integer_class> resa = {9_z, 121_z, 0_z, 1_z};
+    std::vector<integer_class> resb = {-3_z, -99_z, 0_z, 1_z};
+    REQUIRE(a->multieval({2_z, 10_z, -1_z, 0_z}) == resa);
+    REQUIRE(b->multieval({2_z, 10_z, -1_z, 0_z}) == resb);
 }
 
 TEST_CASE("Derivative of UIntPoly", "[UIntPoly]")
@@ -266,4 +271,17 @@ TEST_CASE("UIntPoly expand", "[UIntPoly][expand]")
     REQUIRE(b->__str__() == "(x**3 + x**2 + x)**3");
     REQUIRE(c->__str__()
             == "x**9 + 3*x**8 + 6*x**7 + 7*x**6 + 6*x**5 + 3*x**4 + x**3");
+}
+
+TEST_CASE("UIntPoly pow", "[UIntPoly]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const UIntPoly> a = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPoly> b = UIntPoly::from_dict(x, {{0, 3_z}, {2, 1_z}});
+
+    RCP<const UIntPoly> aaa = pow_upoly(*a, 3);   
+    RCP<const UIntPoly> bb = pow_upoly(*b, 2);
+
+    REQUIRE(aaa->__str__() == "x**3 + 3*x**2 + 3*x + 1");
+    REQUIRE(bb->__str__() == "x**4 + 6*x**2 + 9");
 }

--- a/symengine/tests/polynomial/test_uintpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_flint.cpp
@@ -241,9 +241,15 @@ TEST_CASE("UIntPolyFlint divides", "[UIntPolyFlint]")
     RCP<const UIntPolyFlint> c
         = UIntPolyFlint::from_dict(x, {{0, 8_z}, {1, 8_z}});
 
-    REQUIRE(divides_upoly(*a, *c));
-    REQUIRE(divides_upoly(*b, *c));
-    REQUIRE(!divides_upoly(*b, *a));
+    std::pair<bool, RCP<const UIntPolyFlint>> ac = divides_upoly(*a, *c);
+    std::pair<bool, RCP<const UIntPolyFlint>> bc = divides_upoly(*b, *c);
+    std::pair<bool, RCP<const UIntPolyFlint>> ba = divides_upoly(*b, *a);
+
+    REQUIRE(ac.first);
+    REQUIRE(ac.second->__str__() == "8");
+    REQUIRE(bc.first);
+    REQUIRE(bc.second->__str__() == "2*x + 2");
+    REQUIRE(!ba.first);
 }
 
 TEST_CASE("UIntPolyFlint pow", "[UIntPolyFlint]")

--- a/symengine/tests/polynomial/test_uintpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_flint.cpp
@@ -263,3 +263,16 @@ TEST_CASE("UIntPolyFlint pow", "[UIntPolyFlint]")
     REQUIRE(aaa->__str__() == "x**3 + 3*x**2 + 3*x + 1");
     REQUIRE(bb->__str__() == "x**4 + 6*x**2 + 9");
 }
+
+TEST_CASE("Derivative of UIntPolyFlint", "[UIntPolyFlint]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Symbol> y = symbol("y");
+    RCP<const UIntPolyFlint> a
+        = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPolyFlint> b = UIntPolyFlint::from_dict(y, {{2, 4_z}});
+
+    REQUIRE(a->diff(x)->__str__() == "2*x + 2");
+    REQUIRE(a->diff(y)->__str__() == "0");
+    REQUIRE(b->diff(y)->__str__() == "8*y");
+}

--- a/symengine/tests/polynomial/test_uintpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_flint.cpp
@@ -27,6 +27,7 @@ using SymEngine::gcd_upoly;
 using SymEngine::lcm_upoly;
 using SymEngine::divides_upoly;
 using SymEngine::pow_upoly;
+using SymEngine::vec_integer_class;
 
 using namespace SymEngine::literals;
 
@@ -167,8 +168,8 @@ TEST_CASE("Evaluation of UIntPolyFlint", "[UIntPolyFlint]")
     REQUIRE(b->eval(-1_z) == 0);
     REQUIRE(b->eval(0_z) == 1);
 
-    std::vector<integer_class> resa = {9_z, 121_z, 0_z, 1_z};
-    std::vector<integer_class> resb = {-3_z, -99_z, 0_z, 1_z};
+    vec_integer_class resa = {9_z, 121_z, 0_z, 1_z};
+    vec_integer_class resb = {-3_z, -99_z, 0_z, 1_z};
     REQUIRE(a->multieval({2_z, 10_z, -1_z, 0_z}) == resa);
     REQUIRE(b->multieval({2_z, 10_z, -1_z, 0_z}) == resb);
 }
@@ -176,14 +177,16 @@ TEST_CASE("Evaluation of UIntPolyFlint", "[UIntPolyFlint]")
 TEST_CASE("UIntPolyFlint as_symbolic", "[UIntPolyFlint]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPolyFlint> a = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPolyFlint> a
+        = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE(eq(*a->as_symbolic(),
                *add({one, mul(integer(2), x), pow(x, integer(2))})));
     REQUIRE(not eq(*a->as_symbolic(),
                    *add({one, mul(integer(3), x), pow(x, integer(2))})));
 
-    RCP<const UIntPolyFlint> b = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 1_z}, {2, 2_z}});
+    RCP<const UIntPolyFlint> b
+        = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 1_z}, {2, 2_z}});
     REQUIRE(eq(*b->as_symbolic(),
                *add({one, x, mul(integer(2), pow(x, integer(2)))})));
 
@@ -196,12 +199,14 @@ TEST_CASE("UIntPolyFlint gcd", "[UIntPolyFlint]")
     RCP<const Symbol> x = symbol("x");
     RCP<const UIntPolyFlint> a = UIntPolyFlint::from_dict(x, {{2, 2_z}});
     RCP<const UIntPolyFlint> b = UIntPolyFlint::from_dict(x, {{1, 3_z}});
-    RCP<const UIntPolyFlint> c = UIntPolyFlint::from_dict(x, {{0, 6_z}, {1, 8_z}, {2, 2_z}});
-    RCP<const UIntPolyFlint> d = UIntPolyFlint::from_dict(x, {{1, 4_z}, {2, 4_z}});
+    RCP<const UIntPolyFlint> c
+        = UIntPolyFlint::from_dict(x, {{0, 6_z}, {1, 8_z}, {2, 2_z}});
+    RCP<const UIntPolyFlint> d
+        = UIntPolyFlint::from_dict(x, {{1, 4_z}, {2, 4_z}});
 
-    RCP<const UIntPolyFlint> ab = gcd_upoly(*a, *b);   
-    RCP<const UIntPolyFlint> cd = gcd_upoly(*c, *d);   
-    RCP<const UIntPolyFlint> ad = gcd_upoly(*a, *d);   
+    RCP<const UIntPolyFlint> ab = gcd_upoly(*a, *b);
+    RCP<const UIntPolyFlint> cd = gcd_upoly(*c, *d);
+    RCP<const UIntPolyFlint> ad = gcd_upoly(*a, *d);
     RCP<const UIntPolyFlint> bc = gcd_upoly(*b, *c);
 
     REQUIRE(ab->__str__() == "x");
@@ -215,9 +220,10 @@ TEST_CASE("UIntPolyFlint lcm", "[UIntPolyFlint]")
     RCP<const Symbol> x = symbol("x");
     RCP<const UIntPolyFlint> a = UIntPolyFlint::from_dict(x, {{2, 6_z}});
     RCP<const UIntPolyFlint> b = UIntPolyFlint::from_dict(x, {{1, 8_z}});
-    RCP<const UIntPolyFlint> c = UIntPolyFlint::from_dict(x, {{0, 8_z}, {1, 8_z}});
+    RCP<const UIntPolyFlint> c
+        = UIntPolyFlint::from_dict(x, {{0, 8_z}, {1, 8_z}});
 
-    RCP<const UIntPolyFlint> ab = lcm_upoly(*a, *b);   
+    RCP<const UIntPolyFlint> ab = lcm_upoly(*a, *b);
     RCP<const UIntPolyFlint> bc = lcm_upoly(*b, *c);
     RCP<const UIntPolyFlint> ac = lcm_upoly(*a, *c);
 
@@ -229,9 +235,11 @@ TEST_CASE("UIntPolyFlint lcm", "[UIntPolyFlint]")
 TEST_CASE("UIntPolyFlint divides", "[UIntPolyFlint]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPolyFlint> a = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPolyFlint> a
+        = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 1_z}});
     RCP<const UIntPolyFlint> b = UIntPolyFlint::from_dict(x, {{0, 4_z}});
-    RCP<const UIntPolyFlint> c = UIntPolyFlint::from_dict(x, {{0, 8_z}, {1, 8_z}});
+    RCP<const UIntPolyFlint> c
+        = UIntPolyFlint::from_dict(x, {{0, 8_z}, {1, 8_z}});
 
     REQUIRE(divides_upoly(*a, *c));
     REQUIRE(divides_upoly(*b, *c));
@@ -241,13 +249,14 @@ TEST_CASE("UIntPolyFlint divides", "[UIntPolyFlint]")
 TEST_CASE("UIntPolyFlint pow", "[UIntPolyFlint]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPolyFlint> a = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 1_z}});
-    RCP<const UIntPolyFlint> b = UIntPolyFlint::from_dict(x, {{0, 3_z}, {2, 1_z}});
+    RCP<const UIntPolyFlint> a
+        = UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPolyFlint> b
+        = UIntPolyFlint::from_dict(x, {{0, 3_z}, {2, 1_z}});
 
-    RCP<const UIntPolyFlint> aaa = pow_upoly(*a, 3);   
+    RCP<const UIntPolyFlint> aaa = pow_upoly(*a, 3);
     RCP<const UIntPolyFlint> bb = pow_upoly(*b, 2);
 
     REQUIRE(aaa->__str__() == "x**3 + 3*x**2 + 3*x + 1");
     REQUIRE(bb->__str__() == "x**4 + 6*x**2 + 9");
 }
-

--- a/symengine/tests/polynomial/test_uintpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_flint.cpp
@@ -233,10 +233,9 @@ TEST_CASE("UIntPolyFlint divides", "[UIntPolyFlint]")
     RCP<const UIntPolyFlint> b = UIntPolyFlint::from_dict(x, {{0, 4_z}});
     RCP<const UIntPolyFlint> c = UIntPolyFlint::from_dict(x, {{0, 8_z}, {1, 8_z}});
 
-    // seems like a flint BUG
-    REQUIRE(divides_upoly(*c, *a));
-    REQUIRE(divides_upoly(*c, *b));
-    REQUIRE(!divides_upoly(*a, *b));
+    REQUIRE(divides_upoly(*a, *c));
+    REQUIRE(divides_upoly(*b, *c));
+    REQUIRE(!divides_upoly(*b, *a));
 }
 
 TEST_CASE("UIntPolyFlint pow", "[UIntPolyFlint]")
@@ -248,7 +247,6 @@ TEST_CASE("UIntPolyFlint pow", "[UIntPolyFlint]")
     RCP<const UIntPolyFlint> aaa = pow_upoly(*a, 3);   
     RCP<const UIntPolyFlint> bb = pow_upoly(*b, 2);
 
-    // seems like a flint BUG
     REQUIRE(aaa->__str__() == "x**3 + 3*x**2 + 3*x + 1");
     REQUIRE(bb->__str__() == "x**4 + 6*x**2 + 9");
 }

--- a/symengine/tests/polynomial/test_uintpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_flint.cpp
@@ -240,16 +240,13 @@ TEST_CASE("UIntPolyFlint divides", "[UIntPolyFlint]")
     RCP<const UIntPolyFlint> b = UIntPolyFlint::from_dict(x, {{0, 4_z}});
     RCP<const UIntPolyFlint> c
         = UIntPolyFlint::from_dict(x, {{0, 8_z}, {1, 8_z}});
+    RCP<const UIntPolyFlint> res;
 
-    std::pair<bool, RCP<const UIntPolyFlint>> ac = divides_upoly(*a, *c);
-    std::pair<bool, RCP<const UIntPolyFlint>> bc = divides_upoly(*b, *c);
-    std::pair<bool, RCP<const UIntPolyFlint>> ba = divides_upoly(*b, *a);
-
-    REQUIRE(ac.first);
-    REQUIRE(ac.second->__str__() == "8");
-    REQUIRE(bc.first);
-    REQUIRE(bc.second->__str__() == "2*x + 2");
-    REQUIRE(!ba.first);
+    REQUIRE(divides_upoly(*a, *c, outArg(res)));
+    REQUIRE(res->__str__() == "8");
+    REQUIRE(divides_upoly(*b, *c, outArg(res)));
+    REQUIRE(res->__str__() == "2*x + 2");
+    REQUIRE(!divides_upoly(*b, *a, outArg(res)));
 }
 
 TEST_CASE("UIntPolyFlint pow", "[UIntPolyFlint]")

--- a/symengine/tests/polynomial/test_uintpoly_piranha.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_piranha.cpp
@@ -184,3 +184,56 @@ TEST_CASE("UIntPolyPiranha as_symbolic", "[UIntPolyPiranha]")
         = UIntPolyPiranha::from_dict(x, map_uint_mpz{});
     REQUIRE(eq(*c->as_symbolic(), *zero));
 }
+
+TEST_CASE("UIntPolyPiranha gcd", "[UIntPolyPiranha]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const UIntPolyPiranha> a = UIntPolyPiranha::from_dict(x, {{2, 2_z}});
+    RCP<const UIntPolyPiranha> b = UIntPolyPiranha::from_dict(x, {{1, 3_z}});
+    RCP<const UIntPolyPiranha> c
+        = UIntPolyPiranha::from_dict(x, {{0, 6_z}, {1, 8_z}, {2, 2_z}});
+    RCP<const UIntPolyPiranha> d
+        = UIntPolyPiranha::from_dict(x, {{1, 4_z}, {2, 4_z}});
+
+    RCP<const UIntPolyPiranha> ab = gcd_upoly(*a, *b);
+    RCP<const UIntPolyPiranha> cd = gcd_upoly(*c, *d);
+    RCP<const UIntPolyPiranha> ad = gcd_upoly(*a, *d);
+    RCP<const UIntPolyPiranha> bc = gcd_upoly(*b, *c);
+
+    REQUIRE(ab->__str__() == "x");
+    REQUIRE(cd->__str__() == "2*x + 2");
+    REQUIRE(ad->__str__() == "2*x");
+    REQUIRE(bc->__str__() == "1");
+}
+
+TEST_CASE("UIntPolyPiranha lcm", "[UIntPolyPiranha]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const UIntPolyPiranha> a = UIntPolyPiranha::from_dict(x, {{2, 6_z}});
+    RCP<const UIntPolyPiranha> b = UIntPolyPiranha::from_dict(x, {{1, 8_z}});
+    RCP<const UIntPolyPiranha> c
+        = UIntPolyPiranha::from_dict(x, {{0, 8_z}, {1, 8_z}});
+
+    RCP<const UIntPolyPiranha> ab = lcm_upoly(*a, *b);
+    RCP<const UIntPolyPiranha> bc = lcm_upoly(*b, *c);
+    RCP<const UIntPolyPiranha> ac = lcm_upoly(*a, *c);
+
+    REQUIRE(ab->__str__() == "24*x**2");
+    REQUIRE(bc->__str__() == "8*x**2 + 8*x");
+    REQUIRE(ac->__str__() == "24*x**3 + 24*x**2");
+}
+
+TEST_CASE("UIntPolyPiranha pow", "[UIntPolyPiranha]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const UIntPolyPiranha> a
+        = UIntPolyPiranha::from_dict(x, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPolyPiranha> b
+        = UIntPolyPiranha::from_dict(x, {{0, 3_z}, {2, 1_z}});
+
+    RCP<const UIntPolyPiranha> aaa = pow_upoly(*a, 3);
+    RCP<const UIntPolyPiranha> bb = pow_upoly(*b, 2);
+
+    REQUIRE(aaa->__str__() == "x**3 + 3*x**2 + 3*x + 1");
+    REQUIRE(bb->__str__() == "x**4 + 6*x**2 + 9");
+}

--- a/symengine/tests/polynomial/test_uintpoly_piranha.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_piranha.cpp
@@ -253,7 +253,13 @@ TEST_CASE("UIntPolyPiranha divides", "[UIntPolyPiranha]")
     RCP<const UIntPolyPiranha> c
         = UIntPolyPiranha::from_dict(x, {{0, 8_z}, {1, 8_z}});
 
-    REQUIRE(divides_upoly(*a, *c));
-    REQUIRE(divides_upoly(*b, *c));
-    REQUIRE(!divides_upoly(*b, *a));
+    std::pair<bool, RCP<const UIntPolyPiranha>> ac = divides_upoly(*a, *c);
+    std::pair<bool, RCP<const UIntPolyPiranha>> bc = divides_upoly(*b, *c);
+    std::pair<bool, RCP<const UIntPolyPiranha>> ba = divides_upoly(*b, *a);
+
+    REQUIRE(ac.first);
+    REQUIRE(ac.second->__str__() == "8");
+    REQUIRE(bc.first);
+    REQUIRE(bc.second->__str__() == "2*x + 2");
+    REQUIRE(!ba.first);
 }

--- a/symengine/tests/polynomial/test_uintpoly_piranha.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_piranha.cpp
@@ -23,6 +23,7 @@ using SymEngine::zero;
 using SymEngine::integer;
 using SymEngine::vec_basic_eq_perm;
 using SymEngine::integer_class;
+using SymEngine::vec_integer_class;
 
 using namespace SymEngine::literals;
 
@@ -162,6 +163,11 @@ TEST_CASE("Evaluation of UIntPolyPiranha", "[UIntPolyPiranha]")
     REQUIRE(a->eval(10_z) == 121);
     REQUIRE(b->eval(-1_z) == 0);
     REQUIRE(b->eval(0_z) == 1);
+
+    vec_integer_class resa = {9_z, 121_z, 0_z, 1_z};
+    vec_integer_class resb = {-3_z, -99_z, 0_z, 1_z};
+    REQUIRE(a->multieval({2_z, 10_z, -1_z, 0_z}) == resa);
+    REQUIRE(b->multieval({2_z, 10_z, -1_z, 0_z}) == resb);
 }
 
 TEST_CASE("UIntPolyPiranha as_symbolic", "[UIntPolyPiranha]")
@@ -236,4 +242,18 @@ TEST_CASE("UIntPolyPiranha pow", "[UIntPolyPiranha]")
 
     REQUIRE(aaa->__str__() == "x**3 + 3*x**2 + 3*x + 1");
     REQUIRE(bb->__str__() == "x**4 + 6*x**2 + 9");
+}
+
+TEST_CASE("UIntPolyPiranha divides", "[UIntPolyPiranha]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const UIntPolyPiranha> a
+        = UIntPolyPiranha::from_dict(x, {{0, 1_z}, {1, 1_z}});
+    RCP<const UIntPolyPiranha> b = UIntPolyPiranha::from_dict(x, {{0, 4_z}});
+    RCP<const UIntPolyPiranha> c
+        = UIntPolyPiranha::from_dict(x, {{0, 8_z}, {1, 8_z}});
+
+    REQUIRE(divides_upoly(*a, *c));
+    REQUIRE(divides_upoly(*b, *c));
+    REQUIRE(!divides_upoly(*b, *a));
 }

--- a/symengine/tests/polynomial/test_uintpoly_piranha.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_piranha.cpp
@@ -260,3 +260,17 @@ TEST_CASE("UIntPolyPiranha divides", "[UIntPolyPiranha]")
     REQUIRE(res->__str__() == "2*x + 2");
     REQUIRE(!divides_upoly(*b, *a, outArg(res)));
 }
+
+TEST_CASE("Derivative of UIntPolyPiranha", "[UIntPolyPiranha]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Symbol> y = symbol("y");
+    RCP<const Symbol> none = symbol("");
+    RCP<const UIntPolyPiranha> a
+        = UIntPolyPiranha::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPolyPiranha> b = UIntPolyPiranha::from_dict(y, {{2, 4_z}});
+
+    REQUIRE(a->diff(x)->__str__() == "2*x + 2");
+    REQUIRE(a->diff(y)->__str__() == "0");
+    REQUIRE(b->diff(y)->__str__() == "8*y");
+}

--- a/symengine/tests/polynomial/test_uintpoly_piranha.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_piranha.cpp
@@ -252,14 +252,11 @@ TEST_CASE("UIntPolyPiranha divides", "[UIntPolyPiranha]")
     RCP<const UIntPolyPiranha> b = UIntPolyPiranha::from_dict(x, {{0, 4_z}});
     RCP<const UIntPolyPiranha> c
         = UIntPolyPiranha::from_dict(x, {{0, 8_z}, {1, 8_z}});
+    RCP<const UIntPolyPiranha> res;
 
-    std::pair<bool, RCP<const UIntPolyPiranha>> ac = divides_upoly(*a, *c);
-    std::pair<bool, RCP<const UIntPolyPiranha>> bc = divides_upoly(*b, *c);
-    std::pair<bool, RCP<const UIntPolyPiranha>> ba = divides_upoly(*b, *a);
-
-    REQUIRE(ac.first);
-    REQUIRE(ac.second->__str__() == "8");
-    REQUIRE(bc.first);
-    REQUIRE(bc.second->__str__() == "2*x + 2");
-    REQUIRE(!ba.first);
+    REQUIRE(divides_upoly(*a, *c, outArg(res)));
+    REQUIRE(res->__str__() == "8");
+    REQUIRE(divides_upoly(*b, *c, outArg(res)));
+    REQUIRE(res->__str__() == "2*x + 2");
+    REQUIRE(!divides_upoly(*b, *a, outArg(res)));
 }

--- a/symengine/tests/polynomial/test_uintpoly_piranha.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_piranha.cpp
@@ -167,17 +167,20 @@ TEST_CASE("Evaluation of UIntPolyPiranha", "[UIntPolyPiranha]")
 TEST_CASE("UIntPolyPiranha as_symbolic", "[UIntPolyPiranha]")
 {
     RCP<const Symbol> x = symbol("x");
-    RCP<const UIntPolyPiranha> a = UIntPolyPiranha::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    RCP<const UIntPolyPiranha> a
+        = UIntPolyPiranha::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
 
     REQUIRE(eq(*a->as_symbolic(),
                *add({one, mul(integer(2), x), pow(x, integer(2))})));
     REQUIRE(not eq(*a->as_symbolic(),
                    *add({one, mul(integer(3), x), pow(x, integer(2))})));
 
-    RCP<const UIntPolyPiranha> b = UIntPolyPiranha::from_dict(x, {{0, 1_z}, {1, 1_z}, {2, 2_z}});
+    RCP<const UIntPolyPiranha> b
+        = UIntPolyPiranha::from_dict(x, {{0, 1_z}, {1, 1_z}, {2, 2_z}});
     REQUIRE(eq(*b->as_symbolic(),
                *add({one, x, mul(integer(2), pow(x, integer(2)))})));
 
-    RCP<const UIntPolyPiranha> c = UIntPolyPiranha::from_dict(x, map_uint_mpz{});
+    RCP<const UIntPolyPiranha> c
+        = UIntPolyPiranha::from_dict(x, map_uint_mpz{});
     REQUIRE(eq(*c->as_symbolic(), *zero));
 }

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -23,7 +23,7 @@ using SymEngine::Basic;
 using SymEngine::div;
 using SymEngine::Expression;
 using SymEngine::pow;
-using SymEngine::uint_poly;
+using SymEngine::UIntPoly;
 using SymEngine::uexpr_poly;
 using SymEngine::mul;
 using SymEngine::integer;
@@ -250,48 +250,48 @@ TEST_CASE("test_matrix(): printing", "[printing]")
     REQUIRE(A.__str__() == "[1, 0]\n[0, 1]\n");
 }
 
-TEST_CASE("test_uint_poly(): printing", "[printing]")
+TEST_CASE("test_UIntPoly::from_dict(): printing", "[printing]")
 {
     RCP<const Basic> p;
     RCP<const Symbol> x = symbol("x");
 
-    p = uint_poly(x, {{0, 0_z}});
+    p = UIntPoly::from_dict(x, {{0, 0_z}});
     REQUIRE(p->__str__() == "0");
 
-    p = uint_poly(x, {{0, 1_z}});
+    p = UIntPoly::from_dict(x, {{0, 1_z}});
     REQUIRE(p->__str__() == "1");
 
-    p = uint_poly(x, {{1, 1_z}});
+    p = UIntPoly::from_dict(x, {{1, 1_z}});
     REQUIRE(p->__str__() == "x");
 
-    p = uint_poly(x, {{0, 1_z}, {1, 2_z}});
+    p = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}});
     REQUIRE(p->__str__() == "2*x + 1");
 
-    p = uint_poly(x, {{0, -1_z}, {1, 2_z}});
+    p = UIntPoly::from_dict(x, {{0, -1_z}, {1, 2_z}});
     REQUIRE(p->__str__() == "2*x - 1");
 
-    p = uint_poly(x, {{0, -1_z}});
+    p = UIntPoly::from_dict(x, {{0, -1_z}});
     REQUIRE(p->__str__() == "-1");
 
-    p = uint_poly(x, {{1, -1_z}});
+    p = UIntPoly::from_dict(x, {{1, -1_z}});
     REQUIRE(p->__str__() == "-x");
 
-    p = uint_poly(x, {{0, -1_z}, {1, 1_z}});
+    p = UIntPoly::from_dict(x, {{0, -1_z}, {1, 1_z}});
     REQUIRE(p->__str__() == "x - 1");
 
-    p = uint_poly(x, {{0, 1_z}, {1, 1_z}, {2, 1_z}});
+    p = UIntPoly::from_dict(x, {{0, 1_z}, {1, 1_z}, {2, 1_z}});
     REQUIRE(p->__str__() == "x**2 + x + 1");
 
-    p = uint_poly(x, {{0, 1_z}, {1, -1_z}, {2, 1_z}});
+    p = UIntPoly::from_dict(x, {{0, 1_z}, {1, -1_z}, {2, 1_z}});
     REQUIRE(p->__str__() == "x**2 - x + 1");
 
-    p = uint_poly(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
+    p = UIntPoly::from_dict(x, {{0, 1_z}, {1, 2_z}, {2, 1_z}});
     REQUIRE(p->__str__() == "x**2 + 2*x + 1");
 
-    p = uint_poly(x, {{1, 2_z}, {2, 1_z}});
+    p = UIntPoly::from_dict(x, {{1, 2_z}, {2, 1_z}});
     REQUIRE(p->__str__() == "x**2 + 2*x");
 
-    p = uint_poly(x, {{0, -1_z}, {1, -2_z}, {2, -1_z}});
+    p = UIntPoly::from_dict(x, {{0, -1_z}, {1, -2_z}, {2, -1_z}});
 
     REQUIRE(p->__str__() == "-x**2 - 2*x - 1");
 }


### PR DESCRIPTION
flint : `gcd`, `lcm`, `multieval`, `pow` and `divides` 
symengine : `pow` and `multieval`(slow) (`gcd`, `lcm` & `divides` requires rational polys)
nothing new for piranha as of yet

new typedef `vec_integer_class`
removed function `uint_poly`

Edit : All 3 classes now have `multieval`, `pow` and `divides` and `get_lc`
Flint and piranha also have `gcd` and `lcm`