### PR TITLE
polys: use Flint C API instead of C++ API 

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -54,6 +54,9 @@ fi
 if [[ "${WITH_PIRANHA}" != "" ]]; then
     cmake_line="$cmake_line -DWITH_PIRANHA=${WITH_PIRANHA}"
 fi
+if [[ "${WITH_FLINT}" != "" ]]; then
+    cmake_line="$cmake_line -DWITH_FLINT=${WITH_FLINT}"
+fi
 if [[ "${WITH_BENCHMARKS_NONIUS}" != "" ]]; then
     cmake_line="$cmake_line -DBUILD_BENCHMARKS_NONIUS=${WITH_BENCHMARKS_NONIUS}"
 fi

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -497,10 +497,7 @@ public:
                                  const RCP<const Symbol> &x)
     {
         if (self.get_var()->__eq__(*x)) {
-            flint::fmpz_polyxx d;
-            d = static_cast<flint::fmpz_polyxx>(
-                flint::derivative(self.get_poly()));
-            return UIntPolyFlint::from_container(self.get_var(), std::move(d));
+            return UIntPolyFlint::from_container(self.get_var(), self.get_poly().derivative());
         } else {
             return UIntPolyFlint::from_dict(self.get_var(), {{}});
         }

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -641,6 +641,11 @@ public:
         fmpq_poly_init(poly);
         fmpq_poly_set_str(poly, cp);
     }
+    fmpq_poly_wrapper(const mpq_t q)
+    {
+        fmpq_poly_init(poly);
+        fmpq_poly_set_mpq(poly, q);
+    }
     fmpq_poly_wrapper(const fmpq_wrapper& q)
     {
         fmpq_poly_init(poly);

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -641,6 +641,11 @@ public:
         fmpq_poly_init(poly);
         fmpq_poly_set_str(poly, cp);
     }
+    fmpq_poly_wrapper(const mpz_t z)
+    {
+        fmpq_poly_init(poly);
+        fmpq_poly_set_mpz(poly, z);
+    }
     fmpq_poly_wrapper(const mpq_t q)
     {
         fmpq_poly_init(poly);

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -475,6 +475,149 @@ private:
     mpq_t m;
 };
 
+class fmpz_poly_wrapper
+{
+private:
+    fmpz_poly_t poly;
+
+public:
+    fmpz_poly_wrapper()
+    {
+        fmpz_poly_init(poly);
+    }
+    fmpz_poly_wrapper(int i)
+    {
+        fmpz_poly_init(poly);
+        fmpz_poly_set_si(poly, i);
+    }
+    fmpz_poly_wrapper(const char* cp)
+    {
+        fmpz_poly_init(poly);
+        fmpz_poly_set_str(poly, cp);
+    }
+    fmpz_poly_wrapper(const fmpz_wrapper& z)
+    {
+        fmpz_poly_init(poly);
+        fmpz_poly_set_fmpz(poly, z.get_fmpz_t());
+    }
+    fmpz_poly_wrapper(const fmpz_poly_wrapper &other)
+    {
+        fmpz_poly_init(poly);
+        fmpz_poly_set(poly, *other.get_fmpz_poly_t());
+    }
+    fmpz_poly_wrapper(fmpz_poly_wrapper &&other)
+    {
+        fmpz_poly_init(poly);
+        fmpz_poly_swap(poly, *other.get_fmpz_poly_t());
+    }
+    fmpz_poly_wrapper &operator=(const fmpz_poly_wrapper &other)
+    {
+        fmpz_poly_set(poly, *other.get_fmpz_poly_t());
+        return *this;
+    }
+    fmpz_poly_wrapper &operator=(fmpz_poly_wrapper &&other)
+    {
+        fmpz_poly_swap(poly, *other.get_fmpz_poly_t());
+        return *this;
+    }
+    ~fmpz_poly_wrapper()
+    {
+        fmpz_poly_clear(poly);
+    }
+
+    const fmpz_poly_t *get_fmpz_poly_t() const
+    {
+        return &poly;
+    }
+    fmpz_poly_t *get_fmpz_poly_t()
+    {
+        return &poly;
+    }
+    bool operator==(const fmpz_poly_wrapper& other) const
+    {
+        return fmpz_poly_equal(poly, *other.get_fmpz_poly_t()) == 1;
+    }
+    long degree() const
+    {
+        return fmpz_poly_degree(poly);
+    }
+    long length() const
+    {
+        return fmpz_poly_length(poly);
+    }
+    std::string to_string() const
+    {
+        return fmpz_poly_get_str(poly);
+    }
+    fmpz_wrapper coeff(unsigned int n) const
+    {
+        fmpz_wrapper z;
+        fmpz_poly_get_coeff_fmpz(z.get_fmpz_t(), poly, n);
+        return z;
+    }
+    void set_coeff(unsigned int n, const fmpz_wrapper& z)
+    {
+        fmpz_poly_set_coeff_fmpz(poly, n, z.get_fmpz_t());
+    }
+    fmpz_wrapper eval(const fmpz_wrapper& z) const
+    {
+        fmpz_wrapper r;
+        fmpz_poly_evaluate_fmpz(r.get_fmpz_t(), poly, z.get_fmpz_t());
+        return r;
+    }
+
+    fmpz_poly_wrapper operator-() const
+    {
+        fmpz_poly_wrapper r;
+        fmpz_poly_neg(*r.get_fmpz_poly_t(), *get_fmpz_poly_t());
+        return r;
+    }
+    void operator+=(const fmpz_poly_wrapper& other)
+    {
+        fmpz_poly_add(*get_fmpz_poly_t(), *get_fmpz_poly_t(),
+                *other.get_fmpz_poly_t());
+    }
+    void operator-=(const fmpz_poly_wrapper& other)
+    {
+        fmpz_poly_sub(*get_fmpz_poly_t(), *get_fmpz_poly_t(),
+                *other.get_fmpz_poly_t());
+    }
+    void operator*=(const fmpz_poly_wrapper& other)
+    {
+        fmpz_poly_mul(*get_fmpz_poly_t(), *get_fmpz_poly_t(),
+                *other.get_fmpz_poly_t());
+    }
+
+    fmpz_poly_wrapper gcd(const fmpz_poly_wrapper& other) const
+    {
+        fmpz_poly_wrapper r;
+        fmpz_poly_gcd(*r.get_fmpz_poly_t(), poly, *other.get_fmpz_poly_t());
+        return r;
+    }
+    fmpz_poly_wrapper lcm(const fmpz_poly_wrapper& other) const
+    {
+        fmpz_poly_wrapper r;
+        fmpz_poly_lcm(*r.get_fmpz_poly_t(), poly, *other.get_fmpz_poly_t());
+        return r;
+    }
+    fmpz_poly_wrapper pow(unsigned int n) const
+    {
+        fmpz_poly_wrapper r;
+        fmpz_poly_pow(*r.get_fmpz_poly_t(), poly, n);
+        return r;
+    }
+    bool divides(const fmpz_poly_wrapper& other, fmpz_poly_wrapper& r) const
+    {
+        return fmpz_poly_divides(*r.get_fmpz_poly_t(), *other.get_fmpz_poly_t(), poly) == 1;
+    }
+    fmpz_poly_wrapper derivative() const
+    {
+        fmpz_poly_wrapper r;
+        fmpz_poly_derivative(*r.get_fmpz_poly_t(), poly);
+        return r;
+    }
+};
+
 class fmpq_poly_wrapper
 {
 private:

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -565,7 +565,10 @@ public:
         fmpz_poly_evaluate_fmpz(r.get_fmpz_t(), poly, z.get_fmpz_t());
         return r;
     }
-
+    void eval_vec(fmpz* ovec, fmpz *ivec, unsigned int n) const
+    {
+        fmpz_poly_evaluate_fmpz_vec(ovec, *get_fmpz_poly_t(), ivec, n);
+    }
     fmpz_poly_wrapper operator-() const
     {
         fmpz_poly_wrapper r;

--- a/symengine/polys/uintpoly_flint.cpp
+++ b/symengine/polys/uintpoly_flint.cpp
@@ -38,15 +38,16 @@ int UIntPolyFlint::compare(const Basic &o) const
     return 0;
 }
 
+static const fz_t zero_poly(0);
+
 RCP<const UIntPolyFlint> UIntPolyFlint::from_dict(const RCP<const Symbol> &var,
                                                   map_uint_mpz &&d)
 {
     // benchmark this against dict->str->fmpz_polyxx
-    unsigned int deg = 0;
-    if (not d.empty())
-        deg = d.rbegin()->first;
+    if (d.empty())
+        return make_rcp<const UIntPolyFlint>(var, zero_poly);
 
-    fp_t f(deg + 1);
+    fp_t f;
     for (auto const &p : d) {
         fz_t r(get_mpz_t(p.second));
         f.set_coeff(p.first, r);
@@ -90,8 +91,6 @@ integer_class UIntPolyFlint::get_coeff(unsigned int x) const
 {
     return to_integer_class(poly_.coeff(x));
 }
-
-static fz_t zero_poly(0);
 
 fz_t UIntPolyFlint::get_coeff_ref(unsigned int x) const
 {

--- a/symengine/polys/uintpoly_flint.cpp
+++ b/symengine/polys/uintpoly_flint.cpp
@@ -5,8 +5,7 @@
 namespace SymEngine
 {
 
-UIntPolyFlint::UIntPolyFlint(const RCP<const Symbol> &var,
-                             flint::fmpz_polyxx &&dict)
+UIntPolyFlint::UIntPolyFlint(const RCP<const Symbol> &var, fp_t &&dict)
     : UIntPolyBase(var, std::move(dict))
 {
 }
@@ -47,10 +46,9 @@ RCP<const UIntPolyFlint> UIntPolyFlint::from_dict(const RCP<const Symbol> &var,
     if (not d.empty())
         deg = d.rbegin()->first;
 
-    flint::fmpz_polyxx f(deg + 1);
-    flint::fmpzxx r;
+    fp_t f(deg + 1);
     for (auto const &p : d) {
-        fmpz_set_mpz(r._data().inner, get_mpz_t(p.second));
+        fz_t r(get_mpz_t(p.second));
         f.set_coeff(p.first, r);
     }
     return make_rcp<const UIntPolyFlint>(var, std::move(f));
@@ -64,11 +62,10 @@ RCP<const UIntPolyFlint> UIntPolyFlint::from_vec(const RCP<const Symbol> &var,
     while (v[deg] == integer_class(0))
         deg--;
 
-    flint::fmpz_polyxx f(deg + 1);
-    flint::fmpzxx r;
+    fp_t f(deg + 1);
     for (unsigned int i = 0; i <= deg; i++) {
         if (v[i] != integer_class(0)) {
-            fmpz_set_mpz(r._data().inner, get_mpz_t(v[i]));
+            fz_t r(get_mpz_t(v[i]));
             f.set_coeff(i, r);
         }
     }
@@ -77,23 +74,15 @@ RCP<const UIntPolyFlint> UIntPolyFlint::from_vec(const RCP<const Symbol> &var,
 
 integer_class UIntPolyFlint::eval(const integer_class &x) const
 {
-    flint::fmpzxx r;
-    fmpz_set_mpz(r._data().inner, get_mpz_t(x));
-    return to_integer_class(static_cast<flint::fmpzxx>(poly_(r)));
+    fz_t r(get_mpz_t(x));
+    return to_integer_class(poly_.eval(r));
 }
 
 vec_integer_class UIntPolyFlint::multieval(const vec_integer_class &v) const
 {
-    flint::fmpz_vecxx t(v.size());
-    for (unsigned int i = 0; i < v.size(); ++i)
-        fmpz_set_mpz(t[i]._data().inner, get_mpz_t(v[i]));
-
-    flint::fmpz_vecxx nn(flint::evaluate(poly_, t));
-
     vec_integer_class res(v.size());
     for (unsigned int i = 0; i < v.size(); ++i)
-        res[i] = to_integer_class(nn[i]);
-
+        res[i] = eval(v[i]);
     return res;
 }
 
@@ -102,11 +91,12 @@ integer_class UIntPolyFlint::get_coeff(unsigned int x) const
     return to_integer_class(poly_.coeff(x));
 }
 
-flint::fmpzxx_srcref UIntPolyFlint::get_coeff_ref(unsigned int x) const
+static fz_t zero_poly(0);
+
+fz_t UIntPolyFlint::get_coeff_ref(unsigned int x) const
 {
-    static flint::fmpzxx FZERO(0);
     if (x > poly_.degree())
-        return FZERO;
+        return zero_poly;
     return poly_.coeff(x);
 }
 }

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -96,7 +96,7 @@ inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b,
         throw std::runtime_error("Error: variables must agree.");
 
     fp_t divres;
-    bool div_f = b.get_poly().divides(a.get_poly(), divres);
+    bool div_f = a.get_poly().divides(b.get_poly(), divres);
     if (div_f) {
         *res = make_rcp<UIntPolyFlint>(a.get_var(), std::move(divres));
         return true;

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -8,17 +8,19 @@
 #include <symengine/polys/upolybase.h>
 
 #ifdef HAVE_SYMENGINE_FLINT
-#include <flint/fmpz_polyxx.h>
+#include <symengine/flint_wrapper.h>
+using fp_t = SymEngine::fmpz_poly_wrapper;
+using fz_t = SymEngine::fmpz_wrapper;
 
 namespace SymEngine
 {
 
-class UIntPolyFlint : public UIntPolyBase<flint::fmpz_polyxx, UIntPolyFlint>
+class UIntPolyFlint : public UIntPolyBase<fp_t, UIntPolyFlint>
 {
 public:
     IMPLEMENT_TYPEID(UINTPOLYFLINT)
     //! Constructor of UIntPolyFlint class
-    UIntPolyFlint(const RCP<const Symbol> &var, flint::fmpz_polyxx &&dict);
+    UIntPolyFlint(const RCP<const Symbol> &var, fp_t &&dict);
     //! \return size of the hash
     std::size_t __hash__() const;
     int compare(const Basic &o) const;
@@ -32,10 +34,10 @@ public:
     vec_integer_class multieval(const vec_integer_class &v) const;
 
     integer_class get_coeff(unsigned int x) const;
-    flint::fmpzxx_srcref get_coeff_ref(unsigned int x) const;
+    fz_t get_coeff_ref(unsigned int x) const;
 
-    typedef ContainerForIter<UIntPolyFlint, flint::fmpzxx_srcref> iterator;
-    typedef ContainerRevIter<UIntPolyFlint, flint::fmpzxx_srcref>
+    typedef ContainerForIter<UIntPolyFlint, fz_t> iterator;
+    typedef ContainerRevIter<UIntPolyFlint, fz_t>
         reverse_iterator;
     iterator begin() const
     {
@@ -68,8 +70,7 @@ inline RCP<const UIntPolyFlint> gcd_upoly(const UIntPolyFlint &a,
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
     return make_rcp<const UIntPolyFlint>(
-        a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(
-                         flint::gcd(a.get_poly(), b.get_poly()))));
+        a.get_var(), a.get_poly().gcd(b.get_poly()));
 }
 
 inline RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a,
@@ -78,16 +79,14 @@ inline RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a,
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
     return make_rcp<const UIntPolyFlint>(
-        a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(
-                         flint::lcm(a.get_poly(), b.get_poly()))));
+        a.get_var(), a.get_poly().lcm(b.get_poly()));
 }
 
 inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a,
                                           unsigned int p)
 {
     return make_rcp<const UIntPolyFlint>(
-        a.get_var(), std::move(static_cast<flint::fmpz_polyxx>(
-                         flint::pow(a.get_poly(), p))));
+        a.get_var(), a.get_poly().pow(p));
 }
 
 inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b,
@@ -96,10 +95,10 @@ inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b,
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
 
-    auto t = flint::divides(b.get_poly(), a.get_poly());
-    if (t.get<0>()) {
-        *res = UIntPolyFlint::from_container(
-            a.get_var(), static_cast<flint::fmpz_polyxx>(t.get<1>()));
+    fp_t divres;
+    bool div_f = b.get_poly().divides(a.get_poly(), divres);
+    if (div_f) {
+        *res = make_rcp<UIntPolyFlint>(a.get_var(), std::move(divres));
         return true;
     } else {
         return false;

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -23,6 +23,12 @@ using fz_t = SymEngine::fmpz_wrapper;
 namespace SymEngine
 {
 // misc methods
+
+inline integer_class to_integer_class(const integer_class &i)
+{
+    return i;
+}
+
 #if SYMENGINE_INTEGER_CLASS == SYMENGINE_GMPXX                                 \
     || SYMENGINE_INTEGER_CLASS == SYMENGINE_GMP
 #ifdef HAVE_SYMENGINE_FLINT
@@ -61,16 +67,6 @@ inline integer_class to_integer_class(const piranha::integer &x)
 }
 #endif
 
-inline integer_class to_integer_class(const fz_t& i)
-{
-    return integer_class(i.get_fmpz_t());
-}
-
-#else
-inline integer_class to_integer_class(const integer_class &i)
-{
-    return i;
-}
 #endif
 
 // dict wrapper

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -11,8 +11,9 @@
 #include <memory>
 
 #ifdef HAVE_SYMENGINE_FLINT
-#include <flint/flint.h>
-#include <flint/fmpzxx.h>
+#include <symengine/flint_wrapper.h>
+using fp_t = SymEngine::fmpz_poly_wrapper;
+using fz_t = SymEngine::fmpz_wrapper;
 #endif
 #ifdef HAVE_SYMENGINE_PIRANHA
 #include <piranha/mp_integer.hpp>
@@ -22,17 +23,13 @@
 namespace SymEngine
 {
 // misc methods
-inline const integer_class &to_integer_class(const integer_class &i)
-{
-    return i;
-}
 #if SYMENGINE_INTEGER_CLASS == SYMENGINE_GMPXX                                 \
     || SYMENGINE_INTEGER_CLASS == SYMENGINE_GMP
 #ifdef HAVE_SYMENGINE_FLINT
-inline integer_class to_integer_class(flint::fmpzxx_srcref i)
+inline integer_class to_integer_class(const fz_t& i)
 {
     integer_class x;
-    fmpz_get_mpz(x.get_mpz_t(), i._data().inner);
+    fmpz_get_mpz(x.get_mpz_t(), i.get_fmpz_t());
     return x;
 }
 #endif
@@ -48,10 +45,10 @@ inline integer_class to_integer_class(const piranha::integer &i)
 
 #elif SYMENGINE_INTEGER_CLASS == SYMENGINE_PIRANHA
 #ifdef HAVE_SYMENGINE_FLINT
-inline integer_class to_integer_class(flint::fmpzxx_srcref i)
+inline integer_class to_integer_class(const fz_t& i)
 {
     integer_class x;
-    fmpz_get_mpz(get_mpz_t(x), i._data().inner);
+    fmpz_get_mpz(get_mpz_t(x), i.get_fmpz_t());
     return x;
 }
 #endif
@@ -64,9 +61,15 @@ inline integer_class to_integer_class(const piranha::integer &x)
 }
 #endif
 
-inline integer_class to_integer_class(flint::fmpzxx_srcref i)
+inline integer_class to_integer_class(const fz_t& i)
 {
-    return integer_class(i._data().inner);
+    return integer_class(i.get_fmpz_t());
+}
+
+#else
+inline integer_class to_integer_class(const integer_class &i)
+{
+    return i;
 }
 #endif
 

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -42,7 +42,7 @@ public:
     static RCP<const Number> from_two_ints(const Integer &n, const Integer &d);
     static RCP<const Number> from_two_ints(const long n, const long d);
     //! Convert to `rational_class`.
-    inline rational_class as_mpq() const
+    inline rational_class as_rational_class() const
     {
         return this->i;
     }

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -116,7 +116,7 @@ fp_t URatPSeriesFlint::convert(const Integer &x)
 
 fp_t URatPSeriesFlint::convert(const Rational &x)
 {
-    return fmpq_wrapper(x.as_rational_class());
+    return convert(x.as_rational_class());
 }
 
 fp_t URatPSeriesFlint::convert(const Basic &x)

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -101,7 +101,7 @@ fp_t URatPSeriesFlint::var(const std::string &s)
 
 fp_t URatPSeriesFlint::convert(const rational_class &x)
 {
-    return fp_t(x);
+    return fp_t(get_mpq_t(x));
 }
 
 fp_t URatPSeriesFlint::convert(const Integer &x)

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -111,7 +111,7 @@ fp_t URatPSeriesFlint::convert(const rational_class &x)
 
 fp_t URatPSeriesFlint::convert(const Integer &x)
 {
-    return fmpq_wrapper(x.as_mpz());
+    return convert(x.as_mpz());
 }
 
 fp_t URatPSeriesFlint::convert(const Rational &x)

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -99,6 +99,11 @@ fp_t URatPSeriesFlint::var(const std::string &s)
     return r;
 }
 
+fp_t URatPSeriesFlint::convert(const integer_class &x)
+{
+    return fp_t(get_mpz_t(x));
+}
+
 fp_t URatPSeriesFlint::convert(const rational_class &x)
 {
     return fp_t(get_mpq_t(x));

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -111,7 +111,7 @@ fp_t URatPSeriesFlint::convert(const Integer &x)
 
 fp_t URatPSeriesFlint::convert(const Rational &x)
 {
-    return fmpq_wrapper(x.as_mpq());
+    return fmpq_wrapper(x.as_rational_class());
 }
 
 fp_t URatPSeriesFlint::convert(const Basic &x)

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -28,6 +28,7 @@ public:
     static RCP<const URatPSeriesFlint>
     series(const RCP<const Basic> &t, const std::string &x, unsigned int prec);
     static fp_t var(const std::string &s);
+    static fp_t convert(const integer_class &x);
     static fp_t convert(const rational_class &x);
     static fp_t convert(const Rational &x);
     static fp_t convert(const Integer &x);

--- a/symengine/series_piranha.cpp
+++ b/symengine/series_piranha.cpp
@@ -60,7 +60,7 @@ pp_t URatPSeriesPiranha::var(const std::string &s)
 
 piranha::rational URatPSeriesPiranha::convert(const Rational &x)
 {
-    return convert(x.as_mpq());
+    return convert(x.as_rational_class());
 }
 
 piranha::rational URatPSeriesPiranha::convert(const Basic &x)

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -404,7 +404,7 @@ TEST_CASE("Rational: Basic", "[basic]")
     REQUIRE(is_a<Rational>(*r1));
     r = rcp_static_cast<const Rational>(r1);
     a = rational_class(3, 5);
-    b = r->as_mpq();
+    b = r->as_rational_class();
     REQUIRE(a == b);
 }
 

--- a/symengine/tests/polynomial/test_uintpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_flint.cpp
@@ -240,6 +240,9 @@ TEST_CASE("UIntPolyFlint divides", "[UIntPolyFlint]")
         = UIntPolyFlint::from_dict(x, {{0, 8_z}, {1, 8_z}});
     RCP<const UIntPolyFlint> res;
 
+    REQUIRE(a->__str__() == "x + 1");
+    REQUIRE(b->__str__() == "4");
+    REQUIRE(c->__str__() == "8*x + 8");
     REQUIRE(divides_upoly(*a, *c, outArg(res)));
     REQUIRE(res->__str__() == "8");
     REQUIRE(divides_upoly(*b, *c, outArg(res)));


### PR DESCRIPTION
This removes any use of flintxx, so please don't reintroduce it.