### PR TITLE
Moving clang-format back to main tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,19 +55,21 @@ matrix:
     - compiler: clang
     - os: osx
   include:
-    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" WITH_COVERAGE="yes" WITH_MPC="yes"
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" TEST_CLANG_FORMAT="yes" WITH_COVERAGE="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
       addons:
         apt:
           sources:
           - ubuntu-toolchain-r-test
+          - llvm-toolchain-precise-3.7
           packages:
           - libgmp-dev
           - libmpfr-dev
           - libmpc-dev
           - binutils-dev
           - g++-5
+          - clang-format-3.7
     - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_PIRANHA="yes" WITH_BENCHMARKS_NONIUS="yes" WITH_COVERAGE="yes" TEST_IN_TREE="yes" WITH_FLINT="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
@@ -134,31 +136,6 @@ matrix:
     - env: BUILD_TYPE="Release"
       compiler: gcc
       os: osx
-    - env: BUILD_TYPE="Release" TEST_CLANG_FORMAT="yes"
-      compiler: gcc
-      os: linux
-      addons:
-        apt:
-          sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-precise-3.7
-          packages:
-          - g++-4.7
-          - libgmp-dev
-          - clang-format-3.7
-  allow_failures:
-    - env: BUILD_TYPE="Release" TEST_CLANG_FORMAT="yes"
-      compiler: gcc
-      os: linux
-      addons:
-        apt:
-          sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-precise-3.7
-          packages:
-          - g++-4.7
-          - libgmp-dev
-          - clang-format-3.7
 
 install:
   - source bin/install_travis.sh

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -490,12 +490,12 @@ public:
         fmpq_poly_init(poly);
         fmpq_poly_set_si(poly, i);
     }
-    fmpq_poly_wrapper(const char* cp)
+    fmpq_poly_wrapper(const char *cp)
     {
         fmpq_poly_init(poly);
         fmpq_poly_set_str(poly, cp);
     }
-    fmpq_poly_wrapper(const fmpq_wrapper& q)
+    fmpq_poly_wrapper(const fmpq_wrapper &q)
     {
         fmpq_poly_init(poly);
         fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
@@ -548,11 +548,12 @@ public:
         return q;
     }
 
-    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper& o, unsigned int prec) const
+    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper &o,
+                             unsigned int prec) const
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly,
-                *o.get_fmpq_poly_t(), prec);
+        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(),
+                         prec);
         return r;
     }
     fmpq_poly_wrapper pow(unsigned int n) const
@@ -658,11 +659,11 @@ public:
         fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
         return r;
     }
-    fmpq_poly_wrapper subs(const fmpq_poly_wrapper& o, unsigned int prec) const
+    fmpq_poly_wrapper subs(const fmpq_poly_wrapper &o, unsigned int prec) const
     {
         fmpq_poly_wrapper r;
         fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly,
-                *o.get_fmpq_poly_t(), prec);
+                                 *o.get_fmpq_poly_t(), prec);
         return r;
     }
     void set_zero()
@@ -674,55 +675,65 @@ public:
         fmpq_poly_one(poly);
     }
 
-    bool operator==(const fmpq_poly_wrapper& o) const
+    bool operator==(const fmpq_poly_wrapper &o) const
     {
         return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
     }
-    bool operator<(const fmpq_poly_wrapper& o) const
+    bool operator<(const fmpq_poly_wrapper &o) const
     {
         return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
     }
 
-    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
+    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper &a,
+                                       const fmpq_poly_wrapper &o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
+        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                      *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
+    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper &a,
+                                       const fmpq_poly_wrapper &o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
+        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                      *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a, const fmpq_wrapper& q)
+    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
+                                       const fmpq_wrapper &q)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), q.get_fmpq_t());
+        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                                  q.get_fmpq_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
+    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
+                                       const fmpq_poly_wrapper &o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
+        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                      *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper& a, const fmpq_wrapper& q)
+    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper &a,
+                                       const fmpq_wrapper &q)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), q.get_fmpq_t());
+        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                                  q.get_fmpq_t());
         return r;
     }
 
-    void operator+=(const fmpq_poly_wrapper& o)
+    void operator+=(const fmpq_poly_wrapper &o)
     {
         fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
     }
-    void operator-=(const fmpq_poly_wrapper& o)
+    void operator-=(const fmpq_poly_wrapper &o)
     {
         fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
     }
-    void operator*=(const fmpq_poly_wrapper& o)
+    void operator*=(const fmpq_poly_wrapper &o)
     {
         fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
     }

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -12,547 +12,654 @@ namespace SymEngine {
 
 class fmpz_wrapper {
 private:
-  fmpz_t mp;
+    fmpz_t mp;
 
 public:
-  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
-                                                    std::is_unsigned<T>::value,
-                                                int>::type = 0>
-  inline fmpz_wrapper(const T i) {
-    fmpz_init(mp);
-    fmpz_set_ui(mp, i);
-  }
-  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
-                                                    std::is_signed<T>::value,
-                                                int>::type = 0>
-  inline fmpz_wrapper(const T i) {
-    fmpz_init(mp);
-    fmpz_set_si(mp, i);
-  }
-  inline fmpz_wrapper() { fmpz_init(mp); }
-  inline fmpz_wrapper(const mpz_t m) {
-    fmpz_init(mp);
-    fmpz_set_mpz(mp, m);
-  }
-  inline fmpz_wrapper(const fmpz_t m) {
-    fmpz_init(mp);
-    fmpz_set(mp, m);
-  }
-  inline fmpz_wrapper(const std::string &s, unsigned base = 10) {
-    fmpz_init(mp);
-    fmpz_set_str(mp, s.c_str(), base);
-  }
-  inline fmpz_wrapper(const fmpz_wrapper &other) {
-    fmpz_init(mp);
-    fmpz_set(mp, other.get_fmpz_t());
-  }
-  inline fmpz_wrapper(fmpz_wrapper &&other) SYMENGINE_NOEXCEPT {
-    fmpz_init(mp);
-    fmpz_swap(mp, other.get_fmpz_t());
-  }
-  inline fmpz_wrapper &operator=(const fmpz_wrapper &other) {
-    fmpz_set(mp, other.get_fmpz_t());
-    return *this;
-  }
-  inline fmpz_wrapper &operator=(fmpz_wrapper &&other) SYMENGINE_NOEXCEPT {
-    fmpz_swap(mp, other.get_fmpz_t());
-    return *this;
-  }
-  inline ~fmpz_wrapper() SYMENGINE_NOEXCEPT { fmpz_clear(mp); }
-  inline fmpz *get_fmpz_t() { return mp; }
-  inline const fmpz *get_fmpz_t() const { return mp; }
-  inline friend fmpz_wrapper operator+(const fmpz_wrapper &a,
-                                       const fmpz_wrapper &b) {
-    fmpz_wrapper res;
-    fmpz_add(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-    return res;
-  }
-  inline fmpz_wrapper operator+=(const fmpz_wrapper &a) {
-    fmpz_add(mp, mp, a.get_fmpz_t());
-    return *this;
-  }
-  inline friend fmpz_wrapper operator-(const fmpz_wrapper &a,
-                                       const fmpz_wrapper &b) {
-    fmpz_wrapper res;
-    fmpz_sub(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-    return res;
-  }
-  inline fmpz_wrapper operator-=(const fmpz_wrapper &a) {
-    fmpz_sub(mp, mp, a.get_fmpz_t());
-    return *this;
-  }
-  inline fmpz_wrapper operator-() const {
-    fmpz_wrapper res;
-    fmpz_neg(res.get_fmpz_t(), mp);
-    return res;
-  }
-  inline friend fmpz_wrapper operator*(const fmpz_wrapper &a,
-                                       const fmpz_wrapper &b) {
-    fmpz_wrapper res;
-    fmpz_mul(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-    return res;
-  }
-  inline fmpz_wrapper operator*=(const fmpz_wrapper &a) {
-    fmpz_mul(mp, mp, a.get_fmpz_t());
-    return *this;
-  }
-  inline friend fmpz_wrapper operator/(const fmpz_wrapper &a,
-                                       const fmpz_wrapper &b) {
-    fmpz_wrapper res;
-    fmpz_tdiv_q(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-    return res;
-  }
-  inline fmpz_wrapper operator/=(const fmpz_wrapper &a) {
-    fmpz_tdiv_q(mp, mp, a.get_fmpz_t());
-    return *this;
-  }
-  inline friend fmpz_wrapper operator%(const fmpz_wrapper &a,
-                                       const fmpz_wrapper &b) {
-    fmpz_wrapper res, tmp;
-    fmpz_tdiv_qr(tmp.get_fmpz_t(), res.get_fmpz_t(), a.get_fmpz_t(),
-                 b.get_fmpz_t());
-    return res;
-  }
-  inline fmpz_wrapper operator%=(const fmpz_wrapper &a) {
-    fmpz_wrapper tmp;
-    fmpz_tdiv_qr(tmp.get_fmpz_t(), mp, mp, a.get_fmpz_t());
-    return *this;
-  }
-  inline fmpz_wrapper operator++() {
-    fmpz_add_ui(mp, mp, 1);
-    return *this;
-  }
-  inline fmpz_wrapper operator++(int) {
-    fmpz_wrapper orig = *this;
-    ++(*this);
-    return orig;
-  }
-  inline fmpz_wrapper operator--() {
-    fmpz_sub_ui(mp, mp, 1);
-    return *this;
-  }
-  inline fmpz_wrapper operator--(int) {
-    fmpz_wrapper orig = *this;
-    --(*this);
-    return orig;
-  }
-  inline friend bool operator==(const fmpz_wrapper &a, const fmpz_wrapper &b) {
-    return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) == 1;
-  }
-  inline friend bool operator!=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
-    return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) != 1;
-  }
-  inline friend bool operator<(const fmpz_wrapper &a, const fmpz_wrapper &b) {
-    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) < 0;
-  }
-  inline friend bool operator<=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
-    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) <= 0;
-  }
-  inline friend bool operator>(const fmpz_wrapper &a, const fmpz_wrapper &b) {
-    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) > 0;
-  }
-  inline friend bool operator>=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
-    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) >= 0;
-  }
-  inline fmpz_wrapper operator<<=(unsigned long u) {
-    fmpz_mul_2exp(mp, mp, u);
-    return *this;
-  }
-  inline fmpz_wrapper operator<<(unsigned long u) const {
-    fmpz_wrapper res;
-    fmpz_mul_2exp(res.get_fmpz_t(), mp, u);
-    return res;
-  }
-  inline fmpz_wrapper operator>>=(unsigned long u) {
-    fmpz_tdiv_q_2exp(mp, mp, u);
-    return *this;
-  }
-  inline fmpz_wrapper operator>>(unsigned long u) const {
-    fmpz_wrapper res;
-    fmpz_tdiv_q_2exp(res.get_fmpz_t(), mp, u);
-    return res;
-  }
-  inline fmpz_wrapper root(unsigned int n) const {
-    fmpz_wrapper res;
-    fmpz_root(res.get_fmpz_t(), mp, n);
-    return res;
-  }
+    template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value,
+                              int>::type
+        = 0>
+    inline fmpz_wrapper(const T i)
+    {
+        fmpz_init(mp);
+        fmpz_set_ui(mp, i);
+    }
+    template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value,
+                              int>::type
+        = 0>
+    inline fmpz_wrapper(const T i)
+    {
+        fmpz_init(mp);
+        fmpz_set_si(mp, i);
+    }
+    inline fmpz_wrapper() { fmpz_init(mp); }
+    inline fmpz_wrapper(const mpz_t m)
+    {
+        fmpz_init(mp);
+        fmpz_set_mpz(mp, m);
+    }
+    inline fmpz_wrapper(const fmpz_t m)
+    {
+        fmpz_init(mp);
+        fmpz_set(mp, m);
+    }
+    inline fmpz_wrapper(const std::string& s, unsigned base = 10)
+    {
+        fmpz_init(mp);
+        fmpz_set_str(mp, s.c_str(), base);
+    }
+    inline fmpz_wrapper(const fmpz_wrapper& other)
+    {
+        fmpz_init(mp);
+        fmpz_set(mp, other.get_fmpz_t());
+    }
+    inline fmpz_wrapper(fmpz_wrapper&& other) SYMENGINE_NOEXCEPT
+    {
+        fmpz_init(mp);
+        fmpz_swap(mp, other.get_fmpz_t());
+    }
+    inline fmpz_wrapper& operator=(const fmpz_wrapper& other)
+    {
+        fmpz_set(mp, other.get_fmpz_t());
+        return *this;
+    }
+    inline fmpz_wrapper& operator=(fmpz_wrapper&& other) SYMENGINE_NOEXCEPT
+    {
+        fmpz_swap(mp, other.get_fmpz_t());
+        return *this;
+    }
+    inline ~fmpz_wrapper() SYMENGINE_NOEXCEPT { fmpz_clear(mp); }
+    inline fmpz* get_fmpz_t() { return mp; }
+    inline const fmpz* get_fmpz_t() const { return mp; }
+    inline friend fmpz_wrapper operator+(const fmpz_wrapper& a,
+        const fmpz_wrapper& b)
+    {
+        fmpz_wrapper res;
+        fmpz_add(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+        return res;
+    }
+    inline fmpz_wrapper operator+=(const fmpz_wrapper& a)
+    {
+        fmpz_add(mp, mp, a.get_fmpz_t());
+        return *this;
+    }
+    inline friend fmpz_wrapper operator-(const fmpz_wrapper& a,
+        const fmpz_wrapper& b)
+    {
+        fmpz_wrapper res;
+        fmpz_sub(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+        return res;
+    }
+    inline fmpz_wrapper operator-=(const fmpz_wrapper& a)
+    {
+        fmpz_sub(mp, mp, a.get_fmpz_t());
+        return *this;
+    }
+    inline fmpz_wrapper operator-() const
+    {
+        fmpz_wrapper res;
+        fmpz_neg(res.get_fmpz_t(), mp);
+        return res;
+    }
+    inline friend fmpz_wrapper operator*(const fmpz_wrapper& a,
+        const fmpz_wrapper& b)
+    {
+        fmpz_wrapper res;
+        fmpz_mul(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+        return res;
+    }
+    inline fmpz_wrapper operator*=(const fmpz_wrapper& a)
+    {
+        fmpz_mul(mp, mp, a.get_fmpz_t());
+        return *this;
+    }
+    inline friend fmpz_wrapper operator/(const fmpz_wrapper& a,
+        const fmpz_wrapper& b)
+    {
+        fmpz_wrapper res;
+        fmpz_tdiv_q(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+        return res;
+    }
+    inline fmpz_wrapper operator/=(const fmpz_wrapper& a)
+    {
+        fmpz_tdiv_q(mp, mp, a.get_fmpz_t());
+        return *this;
+    }
+    inline friend fmpz_wrapper operator%(const fmpz_wrapper& a,
+        const fmpz_wrapper& b)
+    {
+        fmpz_wrapper res, tmp;
+        fmpz_tdiv_qr(tmp.get_fmpz_t(), res.get_fmpz_t(), a.get_fmpz_t(),
+            b.get_fmpz_t());
+        return res;
+    }
+    inline fmpz_wrapper operator%=(const fmpz_wrapper& a)
+    {
+        fmpz_wrapper tmp;
+        fmpz_tdiv_qr(tmp.get_fmpz_t(), mp, mp, a.get_fmpz_t());
+        return *this;
+    }
+    inline fmpz_wrapper operator++()
+    {
+        fmpz_add_ui(mp, mp, 1);
+        return *this;
+    }
+    inline fmpz_wrapper operator++(int)
+    {
+        fmpz_wrapper orig = *this;
+        ++(*this);
+        return orig;
+    }
+    inline fmpz_wrapper operator--()
+    {
+        fmpz_sub_ui(mp, mp, 1);
+        return *this;
+    }
+    inline fmpz_wrapper operator--(int)
+    {
+        fmpz_wrapper orig = *this;
+        --(*this);
+        return orig;
+    }
+    inline friend bool operator==(const fmpz_wrapper& a, const fmpz_wrapper& b)
+    {
+        return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) == 1;
+    }
+    inline friend bool operator!=(const fmpz_wrapper& a, const fmpz_wrapper& b)
+    {
+        return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) != 1;
+    }
+    inline friend bool operator<(const fmpz_wrapper& a, const fmpz_wrapper& b)
+    {
+        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) < 0;
+    }
+    inline friend bool operator<=(const fmpz_wrapper& a, const fmpz_wrapper& b)
+    {
+        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) <= 0;
+    }
+    inline friend bool operator>(const fmpz_wrapper& a, const fmpz_wrapper& b)
+    {
+        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) > 0;
+    }
+    inline friend bool operator>=(const fmpz_wrapper& a, const fmpz_wrapper& b)
+    {
+        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) >= 0;
+    }
+    inline fmpz_wrapper operator<<=(unsigned long u)
+    {
+        fmpz_mul_2exp(mp, mp, u);
+        return *this;
+    }
+    inline fmpz_wrapper operator<<(unsigned long u) const
+    {
+        fmpz_wrapper res;
+        fmpz_mul_2exp(res.get_fmpz_t(), mp, u);
+        return res;
+    }
+    inline fmpz_wrapper operator>>=(unsigned long u)
+    {
+        fmpz_tdiv_q_2exp(mp, mp, u);
+        return *this;
+    }
+    inline fmpz_wrapper operator>>(unsigned long u) const
+    {
+        fmpz_wrapper res;
+        fmpz_tdiv_q_2exp(res.get_fmpz_t(), mp, u);
+        return res;
+    }
+    inline fmpz_wrapper root(unsigned int n) const
+    {
+        fmpz_wrapper res;
+        fmpz_root(res.get_fmpz_t(), mp, n);
+        return res;
+    }
 };
 
 class mpz_view_flint {
 
 public:
-  mpz_view_flint(const fmpz_wrapper &i) {
-    if (!COEFF_IS_MPZ(*i.get_fmpz_t())) {
-      mpz_init_set_si(m, *i.get_fmpz_t());
-    } else {
-      ptr = COEFF_TO_PTR(*i.get_fmpz_t());
+    mpz_view_flint(const fmpz_wrapper& i)
+    {
+        if (!COEFF_IS_MPZ(*i.get_fmpz_t())) {
+            mpz_init_set_si(m, *i.get_fmpz_t());
+        }
+        else {
+            ptr = COEFF_TO_PTR(*i.get_fmpz_t());
+        }
     }
-  }
-  operator mpz_srcptr() const {
-    if (ptr == nullptr)
-      return m;
-    return ptr;
-  }
-  ~mpz_view_flint() {
-    if (ptr == nullptr)
-      mpz_clear(m);
-  }
+    operator mpz_srcptr() const
+    {
+        if (ptr == nullptr)
+            return m;
+        return ptr;
+    }
+    ~mpz_view_flint()
+    {
+        if (ptr == nullptr)
+            mpz_clear(m);
+    }
 
 private:
-  mpz_srcptr ptr = nullptr;
-  mpz_t m;
+    mpz_srcptr ptr = nullptr;
+    mpz_t m;
 };
 
 class fmpq_wrapper {
 private:
-  fmpq_t mp;
+    fmpq_t mp;
 
 public:
-  fmpq *get_fmpq_t() { return mp; }
-  const fmpq *get_fmpq_t() const { return mp; }
-  fmpq_wrapper() { fmpq_init(mp); }
-  fmpq_wrapper(const mpz_t m) {
-    fmpq_init(mp);
-    fmpz_set_mpz(fmpq_numref(mp), m);
-  }
-  fmpq_wrapper(const fmpz_t m) {
-    fmpq_init(mp);
-    fmpz_set(fmpq_numref(mp), m);
-  }
-  fmpq_wrapper(const mpq_t m) {
-    fmpq_init(mp);
-    fmpq_set_mpq(mp, m);
-  }
-  fmpq_wrapper(const fmpq_t m) {
-    fmpq_init(mp);
-    fmpq_set(mp, m);
-  }
-  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
-                                                    std::is_unsigned<T>::value,
-                                                int>::type = 0>
-  fmpq_wrapper(const T i) {
-    fmpq_init(mp);
-    fmpz_set_ui(fmpq_numref(mp), i);
-  }
-  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
-                                                    std::is_signed<T>::value,
-                                                int>::type = 0>
-  fmpq_wrapper(const T i) {
-    fmpq_init(mp);
-    fmpz_set_si(fmpq_numref(mp), i);
-  }
-  fmpq_wrapper(const fmpz_wrapper &n, const fmpz_wrapper &d = 1) {
-    fmpq_init(mp);
-    fmpz_set(fmpq_numref(mp), n.get_fmpz_t());
-    fmpz_set(fmpq_denref(mp), d.get_fmpz_t());
-  }
-  fmpq_wrapper(const fmpq_wrapper &other) {
-    fmpq_init(mp);
-    fmpq_set(mp, other.get_fmpq_t());
-  }
-  fmpq_wrapper(fmpq_wrapper &&other) {
-    fmpq_init(mp);
-    fmpq_swap(mp, other.get_fmpq_t());
-  }
-  fmpq_wrapper &operator=(const fmpq_wrapper &other) {
-    fmpq_set(mp, other.get_fmpq_t());
-    return *this;
-  }
-  fmpq_wrapper &operator=(fmpq_wrapper &&other) {
-    fmpq_swap(mp, other.get_fmpq_t());
-    return *this;
-  }
-  ~fmpq_wrapper() { fmpq_clear(mp); }
-  void canonicalise() { fmpq_canonicalise(mp); }
-  const fmpz_wrapper &get_den() const {
-    return reinterpret_cast<const fmpz_wrapper &>(*fmpq_denref(mp));
-  }
-  const fmpz_wrapper &get_num() const {
-    return reinterpret_cast<const fmpz_wrapper &>(*fmpq_numref(mp));
-  }
-  fmpz_wrapper &get_den() {
-    return reinterpret_cast<fmpz_wrapper &>(*fmpq_denref(mp));
-  }
-  fmpz_wrapper &get_num() {
-    return reinterpret_cast<fmpz_wrapper &>(*fmpq_numref(mp));
-  }
-  friend fmpq_wrapper operator+(const fmpq_wrapper &a, const fmpq_wrapper &b) {
-    fmpq_wrapper res;
-    fmpq_add(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-    return res;
-  }
-  fmpq_wrapper operator+=(const fmpq_wrapper &a) {
-    fmpq_add(mp, mp, a.get_fmpq_t());
-    return *this;
-  }
-  friend fmpq_wrapper operator-(const fmpq_wrapper &a, const fmpq_wrapper &b) {
-    fmpq_wrapper res;
-    fmpq_sub(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-    return res;
-  }
-  fmpq_wrapper operator-=(const fmpq_wrapper &a) {
-    fmpq_sub(mp, mp, a.get_fmpq_t());
-    return *this;
-  }
-  fmpq_wrapper operator-() const {
-    fmpq_wrapper res;
-    fmpq_neg(res.get_fmpq_t(), mp);
-    return res;
-  }
-  friend fmpq_wrapper operator*(const fmpq_wrapper &a, const fmpq_wrapper &b) {
-    fmpq_wrapper res;
-    fmpq_mul(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-    return res;
-  }
-  fmpq_wrapper operator*=(const fmpq_wrapper &a) {
-    fmpq_mul(mp, mp, a.get_fmpq_t());
-    return *this;
-  }
-  friend fmpq_wrapper operator/(const fmpq_wrapper &a, const fmpq_wrapper &b) {
-    fmpq_wrapper res;
-    fmpq_div(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-    return res;
-  }
-  fmpq_wrapper operator/=(const fmpq_wrapper &a) {
-    fmpq_div(mp, mp, a.get_fmpq_t());
-    return *this;
-  }
-  bool operator==(const fmpq_wrapper &other) const {
-    return fmpq_equal(mp, other.get_fmpq_t());
-  }
-  bool operator!=(const fmpq_wrapper &other) const {
-    return not(*this == other);
-  }
-  bool operator<(const fmpq_wrapper &other) const {
-    return fmpq_cmp(mp, other.get_fmpq_t()) < 0;
-  }
-  bool operator<=(const fmpq_wrapper &other) const {
-    return fmpq_cmp(mp, other.get_fmpq_t()) <= 0;
-  }
-  bool operator>(const fmpq_wrapper &other) const {
-    return fmpq_cmp(mp, other.get_fmpq_t()) > 0;
-  }
-  bool operator>=(const fmpq_wrapper &other) const {
-    return fmpq_cmp(mp, other.get_fmpq_t()) >= 0;
-  }
-  bool is_zero() const { return fmpq_is_zero(mp); }
-  bool is_one() const { return fmpq_is_one(mp); }
+    fmpq* get_fmpq_t() { return mp; }
+    const fmpq* get_fmpq_t() const { return mp; }
+    fmpq_wrapper() { fmpq_init(mp); }
+    fmpq_wrapper(const mpz_t m)
+    {
+        fmpq_init(mp);
+        fmpz_set_mpz(fmpq_numref(mp), m);
+    }
+    fmpq_wrapper(const fmpz_t m)
+    {
+        fmpq_init(mp);
+        fmpz_set(fmpq_numref(mp), m);
+    }
+    fmpq_wrapper(const mpq_t m)
+    {
+        fmpq_init(mp);
+        fmpq_set_mpq(mp, m);
+    }
+    fmpq_wrapper(const fmpq_t m)
+    {
+        fmpq_init(mp);
+        fmpq_set(mp, m);
+    }
+    template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value,
+                              int>::type
+        = 0>
+    fmpq_wrapper(const T i)
+    {
+        fmpq_init(mp);
+        fmpz_set_ui(fmpq_numref(mp), i);
+    }
+    template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value,
+                              int>::type
+        = 0>
+    fmpq_wrapper(const T i)
+    {
+        fmpq_init(mp);
+        fmpz_set_si(fmpq_numref(mp), i);
+    }
+    fmpq_wrapper(const fmpz_wrapper& n, const fmpz_wrapper& d = 1)
+    {
+        fmpq_init(mp);
+        fmpz_set(fmpq_numref(mp), n.get_fmpz_t());
+        fmpz_set(fmpq_denref(mp), d.get_fmpz_t());
+    }
+    fmpq_wrapper(const fmpq_wrapper& other)
+    {
+        fmpq_init(mp);
+        fmpq_set(mp, other.get_fmpq_t());
+    }
+    fmpq_wrapper(fmpq_wrapper&& other)
+    {
+        fmpq_init(mp);
+        fmpq_swap(mp, other.get_fmpq_t());
+    }
+    fmpq_wrapper& operator=(const fmpq_wrapper& other)
+    {
+        fmpq_set(mp, other.get_fmpq_t());
+        return *this;
+    }
+    fmpq_wrapper& operator=(fmpq_wrapper&& other)
+    {
+        fmpq_swap(mp, other.get_fmpq_t());
+        return *this;
+    }
+    ~fmpq_wrapper() { fmpq_clear(mp); }
+    void canonicalise() { fmpq_canonicalise(mp); }
+    const fmpz_wrapper& get_den() const
+    {
+        return reinterpret_cast<const fmpz_wrapper&>(*fmpq_denref(mp));
+    }
+    const fmpz_wrapper& get_num() const
+    {
+        return reinterpret_cast<const fmpz_wrapper&>(*fmpq_numref(mp));
+    }
+    fmpz_wrapper& get_den()
+    {
+        return reinterpret_cast<fmpz_wrapper&>(*fmpq_denref(mp));
+    }
+    fmpz_wrapper& get_num()
+    {
+        return reinterpret_cast<fmpz_wrapper&>(*fmpq_numref(mp));
+    }
+    friend fmpq_wrapper operator+(const fmpq_wrapper& a, const fmpq_wrapper& b)
+    {
+        fmpq_wrapper res;
+        fmpq_add(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+        return res;
+    }
+    fmpq_wrapper operator+=(const fmpq_wrapper& a)
+    {
+        fmpq_add(mp, mp, a.get_fmpq_t());
+        return *this;
+    }
+    friend fmpq_wrapper operator-(const fmpq_wrapper& a, const fmpq_wrapper& b)
+    {
+        fmpq_wrapper res;
+        fmpq_sub(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+        return res;
+    }
+    fmpq_wrapper operator-=(const fmpq_wrapper& a)
+    {
+        fmpq_sub(mp, mp, a.get_fmpq_t());
+        return *this;
+    }
+    fmpq_wrapper operator-() const
+    {
+        fmpq_wrapper res;
+        fmpq_neg(res.get_fmpq_t(), mp);
+        return res;
+    }
+    friend fmpq_wrapper operator*(const fmpq_wrapper& a, const fmpq_wrapper& b)
+    {
+        fmpq_wrapper res;
+        fmpq_mul(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+        return res;
+    }
+    fmpq_wrapper operator*=(const fmpq_wrapper& a)
+    {
+        fmpq_mul(mp, mp, a.get_fmpq_t());
+        return *this;
+    }
+    friend fmpq_wrapper operator/(const fmpq_wrapper& a, const fmpq_wrapper& b)
+    {
+        fmpq_wrapper res;
+        fmpq_div(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+        return res;
+    }
+    fmpq_wrapper operator/=(const fmpq_wrapper& a)
+    {
+        fmpq_div(mp, mp, a.get_fmpq_t());
+        return *this;
+    }
+    bool operator==(const fmpq_wrapper& other) const
+    {
+        return fmpq_equal(mp, other.get_fmpq_t());
+    }
+    bool operator!=(const fmpq_wrapper& other) const
+    {
+        return not(*this == other);
+    }
+    bool operator<(const fmpq_wrapper& other) const
+    {
+        return fmpq_cmp(mp, other.get_fmpq_t()) < 0;
+    }
+    bool operator<=(const fmpq_wrapper& other) const
+    {
+        return fmpq_cmp(mp, other.get_fmpq_t()) <= 0;
+    }
+    bool operator>(const fmpq_wrapper& other) const
+    {
+        return fmpq_cmp(mp, other.get_fmpq_t()) > 0;
+    }
+    bool operator>=(const fmpq_wrapper& other) const
+    {
+        return fmpq_cmp(mp, other.get_fmpq_t()) >= 0;
+    }
+    bool is_zero() const { return fmpq_is_zero(mp); }
+    bool is_one() const { return fmpq_is_one(mp); }
 };
 
 class mpq_view_flint {
 
 public:
-  mpq_view_flint(const fmpq_wrapper &i) {
-    mpq_init(m);
-    fmpq_get_mpq(m, i.get_fmpq_t());
-  }
-  operator mpq_srcptr() const { return m; }
-  ~mpq_view_flint() { mpq_clear(m); }
+    mpq_view_flint(const fmpq_wrapper& i)
+    {
+        mpq_init(m);
+        fmpq_get_mpq(m, i.get_fmpq_t());
+    }
+    operator mpq_srcptr() const { return m; }
+    ~mpq_view_flint() { mpq_clear(m); }
 
 private:
-  mpq_t m;
+    mpq_t m;
 };
 
 class fmpq_poly_wrapper {
 private:
-  fmpq_poly_t poly;
+    fmpq_poly_t poly;
 
 public:
-  fmpq_poly_wrapper() { fmpq_poly_init(poly); }
-  fmpq_poly_wrapper(int i) {
-    fmpq_poly_init(poly);
-    fmpq_poly_set_si(poly, i);
-  }
-  fmpq_poly_wrapper(const char *cp) {
-    fmpq_poly_init(poly);
-    fmpq_poly_set_str(poly, cp);
-  }
-  fmpq_poly_wrapper(const fmpq_wrapper &q) {
-    fmpq_poly_init(poly);
-    fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
-  }
-  fmpq_poly_wrapper(const fmpq_poly_wrapper &other) {
-    fmpq_poly_init(poly);
-    fmpq_poly_set(poly, *other.get_fmpq_poly_t());
-  }
-  fmpq_poly_wrapper(fmpq_poly_wrapper &&other) {
-    fmpq_poly_init(poly);
-    fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
-  }
-  fmpq_poly_wrapper &operator=(const fmpq_poly_wrapper &other) {
-    fmpq_poly_set(poly, *other.get_fmpq_poly_t());
-    return *this;
-  }
-  fmpq_poly_wrapper &operator=(fmpq_poly_wrapper &&other) {
-    fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
-    return *this;
-  }
-  ~fmpq_poly_wrapper() { fmpq_poly_clear(poly); }
+    fmpq_poly_wrapper() { fmpq_poly_init(poly); }
+    fmpq_poly_wrapper(int i)
+    {
+        fmpq_poly_init(poly);
+        fmpq_poly_set_si(poly, i);
+    }
+    fmpq_poly_wrapper(const char* cp)
+    {
+        fmpq_poly_init(poly);
+        fmpq_poly_set_str(poly, cp);
+    }
+    fmpq_poly_wrapper(const fmpq_wrapper& q)
+    {
+        fmpq_poly_init(poly);
+        fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
+    }
+    fmpq_poly_wrapper(const fmpq_poly_wrapper& other)
+    {
+        fmpq_poly_init(poly);
+        fmpq_poly_set(poly, *other.get_fmpq_poly_t());
+    }
+    fmpq_poly_wrapper(fmpq_poly_wrapper&& other)
+    {
+        fmpq_poly_init(poly);
+        fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
+    }
+    fmpq_poly_wrapper& operator=(const fmpq_poly_wrapper& other)
+    {
+        fmpq_poly_set(poly, *other.get_fmpq_poly_t());
+        return *this;
+    }
+    fmpq_poly_wrapper& operator=(fmpq_poly_wrapper&& other)
+    {
+        fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
+        return *this;
+    }
+    ~fmpq_poly_wrapper() { fmpq_poly_clear(poly); }
 
-  const fmpq_poly_t *get_fmpq_poly_t() const { return &poly; }
-  fmpq_poly_t *get_fmpq_poly_t() { return &poly; }
-  std::string to_string() const { return fmpq_poly_get_str(poly); }
-  long degree() const { return fmpq_poly_degree(poly); }
-  fmpq_wrapper get_coeff(unsigned int deg) const {
-    fmpq_wrapper q;
-    fmpq_poly_get_coeff_fmpq(q.get_fmpq_t(), poly, deg);
-    return q;
-  }
+    const fmpq_poly_t* get_fmpq_poly_t() const { return &poly; }
+    fmpq_poly_t* get_fmpq_poly_t() { return &poly; }
+    std::string to_string() const { return fmpq_poly_get_str(poly); }
+    long degree() const { return fmpq_poly_degree(poly); }
+    fmpq_wrapper get_coeff(unsigned int deg) const
+    {
+        fmpq_wrapper q;
+        fmpq_poly_get_coeff_fmpq(q.get_fmpq_t(), poly, deg);
+        return q;
+    }
 
-  fmpq_poly_wrapper mullow(const fmpq_poly_wrapper &o,
-                           unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(), prec);
-    return r;
-  }
-  fmpq_poly_wrapper pow(unsigned int n) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_pow(*r.get_fmpq_poly_t(), poly, n);
-    return r;
-  }
-  fmpq_poly_wrapper derivative() const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_derivative(*r.get_fmpq_poly_t(), poly);
-    return r;
-  }
-  fmpq_poly_wrapper integral() const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_integral(*r.get_fmpq_poly_t(), poly);
-    return r;
-  }
+    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper& o,
+        unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(), prec);
+        return r;
+    }
+    fmpq_poly_wrapper pow(unsigned int n) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_pow(*r.get_fmpq_poly_t(), poly, n);
+        return r;
+    }
+    fmpq_poly_wrapper derivative() const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_derivative(*r.get_fmpq_poly_t(), poly);
+        return r;
+    }
+    fmpq_poly_wrapper integral() const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_integral(*r.get_fmpq_poly_t(), poly);
+        return r;
+    }
 
-  fmpq_poly_wrapper inv_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_inv_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper revert_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_revert_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper log_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_log_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper exp_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_exp_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper sin_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_sin_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper cos_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_cos_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper tan_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_tan_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper asin_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_asin_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper atan_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_atan_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper sinh_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_sinh_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper cosh_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_cosh_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper tanh_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_tanh_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper asinh_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_asinh_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper atanh_series(unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
-    return r;
-  }
-  fmpq_poly_wrapper subs(const fmpq_poly_wrapper &o, unsigned int prec) const {
-    fmpq_poly_wrapper r;
-    fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(),
-                             prec);
-    return r;
-  }
-  void set_zero() { fmpq_poly_zero(poly); }
-  void set_one() { fmpq_poly_one(poly); }
+    fmpq_poly_wrapper inv_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_inv_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper revert_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_revert_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper log_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_log_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper exp_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_exp_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper sin_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_sin_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper cos_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_cos_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper tan_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_tan_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper asin_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_asin_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper atan_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_atan_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper sinh_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_sinh_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper cosh_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_cosh_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper tanh_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_tanh_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper asinh_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_asinh_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper atanh_series(unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
+        return r;
+    }
+    fmpq_poly_wrapper subs(const fmpq_poly_wrapper& o, unsigned int prec) const
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(),
+            prec);
+        return r;
+    }
+    void set_zero() { fmpq_poly_zero(poly); }
+    void set_one() { fmpq_poly_one(poly); }
 
-  bool operator==(const fmpq_poly_wrapper &o) const {
-    return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
-  }
-  bool operator<(const fmpq_poly_wrapper &o) const {
-    return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
-  }
+    bool operator==(const fmpq_poly_wrapper& o) const
+    {
+        return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
+    }
+    bool operator<(const fmpq_poly_wrapper& o) const
+    {
+        return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
+    }
 
-  friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper &a,
-                                     const fmpq_poly_wrapper &o) {
-    fmpq_poly_wrapper r;
-    fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                  *o.get_fmpq_poly_t());
-    return r;
-  }
-  friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper &a,
-                                     const fmpq_poly_wrapper &o) {
-    fmpq_poly_wrapper r;
-    fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                  *o.get_fmpq_poly_t());
-    return r;
-  }
-  friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
-                                     const fmpq_wrapper &q) {
-    fmpq_poly_wrapper r;
-    fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                              q.get_fmpq_t());
-    return r;
-  }
-  friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
-                                     const fmpq_poly_wrapper &o) {
-    fmpq_poly_wrapper r;
-    fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                  *o.get_fmpq_poly_t());
-    return r;
-  }
-  friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper &a,
-                                     const fmpq_wrapper &q) {
-    fmpq_poly_wrapper r;
-    fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                              q.get_fmpq_t());
-    return r;
-  }
+    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper& a,
+        const fmpq_poly_wrapper& o)
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+            *o.get_fmpq_poly_t());
+        return r;
+    }
+    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper& a,
+        const fmpq_poly_wrapper& o)
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+            *o.get_fmpq_poly_t());
+        return r;
+    }
+    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a,
+        const fmpq_wrapper& q)
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+            q.get_fmpq_t());
+        return r;
+    }
+    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a,
+        const fmpq_poly_wrapper& o)
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+            *o.get_fmpq_poly_t());
+        return r;
+    }
+    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper& a,
+        const fmpq_wrapper& q)
+    {
+        fmpq_poly_wrapper r;
+        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+            q.get_fmpq_t());
+        return r;
+    }
 
-  void operator+=(const fmpq_poly_wrapper &o) {
-    fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
-  }
-  void operator-=(const fmpq_poly_wrapper &o) {
-    fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
-  }
-  void operator*=(const fmpq_poly_wrapper &o) {
-    fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
-  }
+    void operator+=(const fmpq_poly_wrapper& o)
+    {
+        fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
+    }
+    void operator-=(const fmpq_poly_wrapper& o)
+    {
+        fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
+    }
+    void operator*=(const fmpq_poly_wrapper& o)
+    {
+        fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
+    }
 };
 
 } // SymEngine

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -12,654 +12,547 @@ namespace SymEngine {
 
 class fmpz_wrapper {
 private:
-    fmpz_t mp;
+  fmpz_t mp;
 
 public:
-    template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value,
-                              int>::type
-        = 0>
-    inline fmpz_wrapper(const T i)
-    {
-        fmpz_init(mp);
-        fmpz_set_ui(mp, i);
-    }
-    template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value,
-                              int>::type
-        = 0>
-    inline fmpz_wrapper(const T i)
-    {
-        fmpz_init(mp);
-        fmpz_set_si(mp, i);
-    }
-    inline fmpz_wrapper() { fmpz_init(mp); }
-    inline fmpz_wrapper(const mpz_t m)
-    {
-        fmpz_init(mp);
-        fmpz_set_mpz(mp, m);
-    }
-    inline fmpz_wrapper(const fmpz_t m)
-    {
-        fmpz_init(mp);
-        fmpz_set(mp, m);
-    }
-    inline fmpz_wrapper(const std::string& s, unsigned base = 10)
-    {
-        fmpz_init(mp);
-        fmpz_set_str(mp, s.c_str(), base);
-    }
-    inline fmpz_wrapper(const fmpz_wrapper& other)
-    {
-        fmpz_init(mp);
-        fmpz_set(mp, other.get_fmpz_t());
-    }
-    inline fmpz_wrapper(fmpz_wrapper&& other) SYMENGINE_NOEXCEPT
-    {
-        fmpz_init(mp);
-        fmpz_swap(mp, other.get_fmpz_t());
-    }
-    inline fmpz_wrapper& operator=(const fmpz_wrapper& other)
-    {
-        fmpz_set(mp, other.get_fmpz_t());
-        return *this;
-    }
-    inline fmpz_wrapper& operator=(fmpz_wrapper&& other) SYMENGINE_NOEXCEPT
-    {
-        fmpz_swap(mp, other.get_fmpz_t());
-        return *this;
-    }
-    inline ~fmpz_wrapper() SYMENGINE_NOEXCEPT { fmpz_clear(mp); }
-    inline fmpz* get_fmpz_t() { return mp; }
-    inline const fmpz* get_fmpz_t() const { return mp; }
-    inline friend fmpz_wrapper operator+(const fmpz_wrapper& a,
-        const fmpz_wrapper& b)
-    {
-        fmpz_wrapper res;
-        fmpz_add(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator+=(const fmpz_wrapper& a)
-    {
-        fmpz_add(mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline friend fmpz_wrapper operator-(const fmpz_wrapper& a,
-        const fmpz_wrapper& b)
-    {
-        fmpz_wrapper res;
-        fmpz_sub(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator-=(const fmpz_wrapper& a)
-    {
-        fmpz_sub(mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline fmpz_wrapper operator-() const
-    {
-        fmpz_wrapper res;
-        fmpz_neg(res.get_fmpz_t(), mp);
-        return res;
-    }
-    inline friend fmpz_wrapper operator*(const fmpz_wrapper& a,
-        const fmpz_wrapper& b)
-    {
-        fmpz_wrapper res;
-        fmpz_mul(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator*=(const fmpz_wrapper& a)
-    {
-        fmpz_mul(mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline friend fmpz_wrapper operator/(const fmpz_wrapper& a,
-        const fmpz_wrapper& b)
-    {
-        fmpz_wrapper res;
-        fmpz_tdiv_q(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator/=(const fmpz_wrapper& a)
-    {
-        fmpz_tdiv_q(mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline friend fmpz_wrapper operator%(const fmpz_wrapper& a,
-        const fmpz_wrapper& b)
-    {
-        fmpz_wrapper res, tmp;
-        fmpz_tdiv_qr(tmp.get_fmpz_t(), res.get_fmpz_t(), a.get_fmpz_t(),
-            b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator%=(const fmpz_wrapper& a)
-    {
-        fmpz_wrapper tmp;
-        fmpz_tdiv_qr(tmp.get_fmpz_t(), mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline fmpz_wrapper operator++()
-    {
-        fmpz_add_ui(mp, mp, 1);
-        return *this;
-    }
-    inline fmpz_wrapper operator++(int)
-    {
-        fmpz_wrapper orig = *this;
-        ++(*this);
-        return orig;
-    }
-    inline fmpz_wrapper operator--()
-    {
-        fmpz_sub_ui(mp, mp, 1);
-        return *this;
-    }
-    inline fmpz_wrapper operator--(int)
-    {
-        fmpz_wrapper orig = *this;
-        --(*this);
-        return orig;
-    }
-    inline friend bool operator==(const fmpz_wrapper& a, const fmpz_wrapper& b)
-    {
-        return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) == 1;
-    }
-    inline friend bool operator!=(const fmpz_wrapper& a, const fmpz_wrapper& b)
-    {
-        return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) != 1;
-    }
-    inline friend bool operator<(const fmpz_wrapper& a, const fmpz_wrapper& b)
-    {
-        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) < 0;
-    }
-    inline friend bool operator<=(const fmpz_wrapper& a, const fmpz_wrapper& b)
-    {
-        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) <= 0;
-    }
-    inline friend bool operator>(const fmpz_wrapper& a, const fmpz_wrapper& b)
-    {
-        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) > 0;
-    }
-    inline friend bool operator>=(const fmpz_wrapper& a, const fmpz_wrapper& b)
-    {
-        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) >= 0;
-    }
-    inline fmpz_wrapper operator<<=(unsigned long u)
-    {
-        fmpz_mul_2exp(mp, mp, u);
-        return *this;
-    }
-    inline fmpz_wrapper operator<<(unsigned long u) const
-    {
-        fmpz_wrapper res;
-        fmpz_mul_2exp(res.get_fmpz_t(), mp, u);
-        return res;
-    }
-    inline fmpz_wrapper operator>>=(unsigned long u)
-    {
-        fmpz_tdiv_q_2exp(mp, mp, u);
-        return *this;
-    }
-    inline fmpz_wrapper operator>>(unsigned long u) const
-    {
-        fmpz_wrapper res;
-        fmpz_tdiv_q_2exp(res.get_fmpz_t(), mp, u);
-        return res;
-    }
-    inline fmpz_wrapper root(unsigned int n) const
-    {
-        fmpz_wrapper res;
-        fmpz_root(res.get_fmpz_t(), mp, n);
-        return res;
-    }
+  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
+                                                    std::is_unsigned<T>::value,
+                                                int>::type = 0>
+  inline fmpz_wrapper(const T i) {
+    fmpz_init(mp);
+    fmpz_set_ui(mp, i);
+  }
+  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
+                                                    std::is_signed<T>::value,
+                                                int>::type = 0>
+  inline fmpz_wrapper(const T i) {
+    fmpz_init(mp);
+    fmpz_set_si(mp, i);
+  }
+  inline fmpz_wrapper() { fmpz_init(mp); }
+  inline fmpz_wrapper(const mpz_t m) {
+    fmpz_init(mp);
+    fmpz_set_mpz(mp, m);
+  }
+  inline fmpz_wrapper(const fmpz_t m) {
+    fmpz_init(mp);
+    fmpz_set(mp, m);
+  }
+  inline fmpz_wrapper(const std::string &s, unsigned base = 10) {
+    fmpz_init(mp);
+    fmpz_set_str(mp, s.c_str(), base);
+  }
+  inline fmpz_wrapper(const fmpz_wrapper &other) {
+    fmpz_init(mp);
+    fmpz_set(mp, other.get_fmpz_t());
+  }
+  inline fmpz_wrapper(fmpz_wrapper &&other) SYMENGINE_NOEXCEPT {
+    fmpz_init(mp);
+    fmpz_swap(mp, other.get_fmpz_t());
+  }
+  inline fmpz_wrapper &operator=(const fmpz_wrapper &other) {
+    fmpz_set(mp, other.get_fmpz_t());
+    return *this;
+  }
+  inline fmpz_wrapper &operator=(fmpz_wrapper &&other) SYMENGINE_NOEXCEPT {
+    fmpz_swap(mp, other.get_fmpz_t());
+    return *this;
+  }
+  inline ~fmpz_wrapper() SYMENGINE_NOEXCEPT { fmpz_clear(mp); }
+  inline fmpz *get_fmpz_t() { return mp; }
+  inline const fmpz *get_fmpz_t() const { return mp; }
+  inline friend fmpz_wrapper operator+(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res;
+    fmpz_add(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator+=(const fmpz_wrapper &a) {
+    fmpz_add(mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline friend fmpz_wrapper operator-(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res;
+    fmpz_sub(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator-=(const fmpz_wrapper &a) {
+    fmpz_sub(mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline fmpz_wrapper operator-() const {
+    fmpz_wrapper res;
+    fmpz_neg(res.get_fmpz_t(), mp);
+    return res;
+  }
+  inline friend fmpz_wrapper operator*(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res;
+    fmpz_mul(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator*=(const fmpz_wrapper &a) {
+    fmpz_mul(mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline friend fmpz_wrapper operator/(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res;
+    fmpz_tdiv_q(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator/=(const fmpz_wrapper &a) {
+    fmpz_tdiv_q(mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline friend fmpz_wrapper operator%(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res, tmp;
+    fmpz_tdiv_qr(tmp.get_fmpz_t(), res.get_fmpz_t(), a.get_fmpz_t(),
+                 b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator%=(const fmpz_wrapper &a) {
+    fmpz_wrapper tmp;
+    fmpz_tdiv_qr(tmp.get_fmpz_t(), mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline fmpz_wrapper operator++() {
+    fmpz_add_ui(mp, mp, 1);
+    return *this;
+  }
+  inline fmpz_wrapper operator++(int) {
+    fmpz_wrapper orig = *this;
+    ++(*this);
+    return orig;
+  }
+  inline fmpz_wrapper operator--() {
+    fmpz_sub_ui(mp, mp, 1);
+    return *this;
+  }
+  inline fmpz_wrapper operator--(int) {
+    fmpz_wrapper orig = *this;
+    --(*this);
+    return orig;
+  }
+  inline friend bool operator==(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) == 1;
+  }
+  inline friend bool operator!=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) != 1;
+  }
+  inline friend bool operator<(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) < 0;
+  }
+  inline friend bool operator<=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) <= 0;
+  }
+  inline friend bool operator>(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) > 0;
+  }
+  inline friend bool operator>=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) >= 0;
+  }
+  inline fmpz_wrapper operator<<=(unsigned long u) {
+    fmpz_mul_2exp(mp, mp, u);
+    return *this;
+  }
+  inline fmpz_wrapper operator<<(unsigned long u) const {
+    fmpz_wrapper res;
+    fmpz_mul_2exp(res.get_fmpz_t(), mp, u);
+    return res;
+  }
+  inline fmpz_wrapper operator>>=(unsigned long u) {
+    fmpz_tdiv_q_2exp(mp, mp, u);
+    return *this;
+  }
+  inline fmpz_wrapper operator>>(unsigned long u) const {
+    fmpz_wrapper res;
+    fmpz_tdiv_q_2exp(res.get_fmpz_t(), mp, u);
+    return res;
+  }
+  inline fmpz_wrapper root(unsigned int n) const {
+    fmpz_wrapper res;
+    fmpz_root(res.get_fmpz_t(), mp, n);
+    return res;
+  }
 };
 
 class mpz_view_flint {
 
 public:
-    mpz_view_flint(const fmpz_wrapper& i)
-    {
-        if (!COEFF_IS_MPZ(*i.get_fmpz_t())) {
-            mpz_init_set_si(m, *i.get_fmpz_t());
-        }
-        else {
-            ptr = COEFF_TO_PTR(*i.get_fmpz_t());
-        }
+  mpz_view_flint(const fmpz_wrapper &i) {
+    if (!COEFF_IS_MPZ(*i.get_fmpz_t())) {
+      mpz_init_set_si(m, *i.get_fmpz_t());
+    } else {
+      ptr = COEFF_TO_PTR(*i.get_fmpz_t());
     }
-    operator mpz_srcptr() const
-    {
-        if (ptr == nullptr)
-            return m;
-        return ptr;
-    }
-    ~mpz_view_flint()
-    {
-        if (ptr == nullptr)
-            mpz_clear(m);
-    }
+  }
+  operator mpz_srcptr() const {
+    if (ptr == nullptr)
+      return m;
+    return ptr;
+  }
+  ~mpz_view_flint() {
+    if (ptr == nullptr)
+      mpz_clear(m);
+  }
 
 private:
-    mpz_srcptr ptr = nullptr;
-    mpz_t m;
+  mpz_srcptr ptr = nullptr;
+  mpz_t m;
 };
 
 class fmpq_wrapper {
 private:
-    fmpq_t mp;
+  fmpq_t mp;
 
 public:
-    fmpq* get_fmpq_t() { return mp; }
-    const fmpq* get_fmpq_t() const { return mp; }
-    fmpq_wrapper() { fmpq_init(mp); }
-    fmpq_wrapper(const mpz_t m)
-    {
-        fmpq_init(mp);
-        fmpz_set_mpz(fmpq_numref(mp), m);
-    }
-    fmpq_wrapper(const fmpz_t m)
-    {
-        fmpq_init(mp);
-        fmpz_set(fmpq_numref(mp), m);
-    }
-    fmpq_wrapper(const mpq_t m)
-    {
-        fmpq_init(mp);
-        fmpq_set_mpq(mp, m);
-    }
-    fmpq_wrapper(const fmpq_t m)
-    {
-        fmpq_init(mp);
-        fmpq_set(mp, m);
-    }
-    template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value,
-                              int>::type
-        = 0>
-    fmpq_wrapper(const T i)
-    {
-        fmpq_init(mp);
-        fmpz_set_ui(fmpq_numref(mp), i);
-    }
-    template <typename T, typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value,
-                              int>::type
-        = 0>
-    fmpq_wrapper(const T i)
-    {
-        fmpq_init(mp);
-        fmpz_set_si(fmpq_numref(mp), i);
-    }
-    fmpq_wrapper(const fmpz_wrapper& n, const fmpz_wrapper& d = 1)
-    {
-        fmpq_init(mp);
-        fmpz_set(fmpq_numref(mp), n.get_fmpz_t());
-        fmpz_set(fmpq_denref(mp), d.get_fmpz_t());
-    }
-    fmpq_wrapper(const fmpq_wrapper& other)
-    {
-        fmpq_init(mp);
-        fmpq_set(mp, other.get_fmpq_t());
-    }
-    fmpq_wrapper(fmpq_wrapper&& other)
-    {
-        fmpq_init(mp);
-        fmpq_swap(mp, other.get_fmpq_t());
-    }
-    fmpq_wrapper& operator=(const fmpq_wrapper& other)
-    {
-        fmpq_set(mp, other.get_fmpq_t());
-        return *this;
-    }
-    fmpq_wrapper& operator=(fmpq_wrapper&& other)
-    {
-        fmpq_swap(mp, other.get_fmpq_t());
-        return *this;
-    }
-    ~fmpq_wrapper() { fmpq_clear(mp); }
-    void canonicalise() { fmpq_canonicalise(mp); }
-    const fmpz_wrapper& get_den() const
-    {
-        return reinterpret_cast<const fmpz_wrapper&>(*fmpq_denref(mp));
-    }
-    const fmpz_wrapper& get_num() const
-    {
-        return reinterpret_cast<const fmpz_wrapper&>(*fmpq_numref(mp));
-    }
-    fmpz_wrapper& get_den()
-    {
-        return reinterpret_cast<fmpz_wrapper&>(*fmpq_denref(mp));
-    }
-    fmpz_wrapper& get_num()
-    {
-        return reinterpret_cast<fmpz_wrapper&>(*fmpq_numref(mp));
-    }
-    friend fmpq_wrapper operator+(const fmpq_wrapper& a, const fmpq_wrapper& b)
-    {
-        fmpq_wrapper res;
-        fmpq_add(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-        return res;
-    }
-    fmpq_wrapper operator+=(const fmpq_wrapper& a)
-    {
-        fmpq_add(mp, mp, a.get_fmpq_t());
-        return *this;
-    }
-    friend fmpq_wrapper operator-(const fmpq_wrapper& a, const fmpq_wrapper& b)
-    {
-        fmpq_wrapper res;
-        fmpq_sub(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-        return res;
-    }
-    fmpq_wrapper operator-=(const fmpq_wrapper& a)
-    {
-        fmpq_sub(mp, mp, a.get_fmpq_t());
-        return *this;
-    }
-    fmpq_wrapper operator-() const
-    {
-        fmpq_wrapper res;
-        fmpq_neg(res.get_fmpq_t(), mp);
-        return res;
-    }
-    friend fmpq_wrapper operator*(const fmpq_wrapper& a, const fmpq_wrapper& b)
-    {
-        fmpq_wrapper res;
-        fmpq_mul(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-        return res;
-    }
-    fmpq_wrapper operator*=(const fmpq_wrapper& a)
-    {
-        fmpq_mul(mp, mp, a.get_fmpq_t());
-        return *this;
-    }
-    friend fmpq_wrapper operator/(const fmpq_wrapper& a, const fmpq_wrapper& b)
-    {
-        fmpq_wrapper res;
-        fmpq_div(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-        return res;
-    }
-    fmpq_wrapper operator/=(const fmpq_wrapper& a)
-    {
-        fmpq_div(mp, mp, a.get_fmpq_t());
-        return *this;
-    }
-    bool operator==(const fmpq_wrapper& other) const
-    {
-        return fmpq_equal(mp, other.get_fmpq_t());
-    }
-    bool operator!=(const fmpq_wrapper& other) const
-    {
-        return not(*this == other);
-    }
-    bool operator<(const fmpq_wrapper& other) const
-    {
-        return fmpq_cmp(mp, other.get_fmpq_t()) < 0;
-    }
-    bool operator<=(const fmpq_wrapper& other) const
-    {
-        return fmpq_cmp(mp, other.get_fmpq_t()) <= 0;
-    }
-    bool operator>(const fmpq_wrapper& other) const
-    {
-        return fmpq_cmp(mp, other.get_fmpq_t()) > 0;
-    }
-    bool operator>=(const fmpq_wrapper& other) const
-    {
-        return fmpq_cmp(mp, other.get_fmpq_t()) >= 0;
-    }
-    bool is_zero() const { return fmpq_is_zero(mp); }
-    bool is_one() const { return fmpq_is_one(mp); }
+  fmpq *get_fmpq_t() { return mp; }
+  const fmpq *get_fmpq_t() const { return mp; }
+  fmpq_wrapper() { fmpq_init(mp); }
+  fmpq_wrapper(const mpz_t m) {
+    fmpq_init(mp);
+    fmpz_set_mpz(fmpq_numref(mp), m);
+  }
+  fmpq_wrapper(const fmpz_t m) {
+    fmpq_init(mp);
+    fmpz_set(fmpq_numref(mp), m);
+  }
+  fmpq_wrapper(const mpq_t m) {
+    fmpq_init(mp);
+    fmpq_set_mpq(mp, m);
+  }
+  fmpq_wrapper(const fmpq_t m) {
+    fmpq_init(mp);
+    fmpq_set(mp, m);
+  }
+  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
+                                                    std::is_unsigned<T>::value,
+                                                int>::type = 0>
+  fmpq_wrapper(const T i) {
+    fmpq_init(mp);
+    fmpz_set_ui(fmpq_numref(mp), i);
+  }
+  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
+                                                    std::is_signed<T>::value,
+                                                int>::type = 0>
+  fmpq_wrapper(const T i) {
+    fmpq_init(mp);
+    fmpz_set_si(fmpq_numref(mp), i);
+  }
+  fmpq_wrapper(const fmpz_wrapper &n, const fmpz_wrapper &d = 1) {
+    fmpq_init(mp);
+    fmpz_set(fmpq_numref(mp), n.get_fmpz_t());
+    fmpz_set(fmpq_denref(mp), d.get_fmpz_t());
+  }
+  fmpq_wrapper(const fmpq_wrapper &other) {
+    fmpq_init(mp);
+    fmpq_set(mp, other.get_fmpq_t());
+  }
+  fmpq_wrapper(fmpq_wrapper &&other) {
+    fmpq_init(mp);
+    fmpq_swap(mp, other.get_fmpq_t());
+  }
+  fmpq_wrapper &operator=(const fmpq_wrapper &other) {
+    fmpq_set(mp, other.get_fmpq_t());
+    return *this;
+  }
+  fmpq_wrapper &operator=(fmpq_wrapper &&other) {
+    fmpq_swap(mp, other.get_fmpq_t());
+    return *this;
+  }
+  ~fmpq_wrapper() { fmpq_clear(mp); }
+  void canonicalise() { fmpq_canonicalise(mp); }
+  const fmpz_wrapper &get_den() const {
+    return reinterpret_cast<const fmpz_wrapper &>(*fmpq_denref(mp));
+  }
+  const fmpz_wrapper &get_num() const {
+    return reinterpret_cast<const fmpz_wrapper &>(*fmpq_numref(mp));
+  }
+  fmpz_wrapper &get_den() {
+    return reinterpret_cast<fmpz_wrapper &>(*fmpq_denref(mp));
+  }
+  fmpz_wrapper &get_num() {
+    return reinterpret_cast<fmpz_wrapper &>(*fmpq_numref(mp));
+  }
+  friend fmpq_wrapper operator+(const fmpq_wrapper &a, const fmpq_wrapper &b) {
+    fmpq_wrapper res;
+    fmpq_add(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+    return res;
+  }
+  fmpq_wrapper operator+=(const fmpq_wrapper &a) {
+    fmpq_add(mp, mp, a.get_fmpq_t());
+    return *this;
+  }
+  friend fmpq_wrapper operator-(const fmpq_wrapper &a, const fmpq_wrapper &b) {
+    fmpq_wrapper res;
+    fmpq_sub(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+    return res;
+  }
+  fmpq_wrapper operator-=(const fmpq_wrapper &a) {
+    fmpq_sub(mp, mp, a.get_fmpq_t());
+    return *this;
+  }
+  fmpq_wrapper operator-() const {
+    fmpq_wrapper res;
+    fmpq_neg(res.get_fmpq_t(), mp);
+    return res;
+  }
+  friend fmpq_wrapper operator*(const fmpq_wrapper &a, const fmpq_wrapper &b) {
+    fmpq_wrapper res;
+    fmpq_mul(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+    return res;
+  }
+  fmpq_wrapper operator*=(const fmpq_wrapper &a) {
+    fmpq_mul(mp, mp, a.get_fmpq_t());
+    return *this;
+  }
+  friend fmpq_wrapper operator/(const fmpq_wrapper &a, const fmpq_wrapper &b) {
+    fmpq_wrapper res;
+    fmpq_div(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+    return res;
+  }
+  fmpq_wrapper operator/=(const fmpq_wrapper &a) {
+    fmpq_div(mp, mp, a.get_fmpq_t());
+    return *this;
+  }
+  bool operator==(const fmpq_wrapper &other) const {
+    return fmpq_equal(mp, other.get_fmpq_t());
+  }
+  bool operator!=(const fmpq_wrapper &other) const {
+    return not(*this == other);
+  }
+  bool operator<(const fmpq_wrapper &other) const {
+    return fmpq_cmp(mp, other.get_fmpq_t()) < 0;
+  }
+  bool operator<=(const fmpq_wrapper &other) const {
+    return fmpq_cmp(mp, other.get_fmpq_t()) <= 0;
+  }
+  bool operator>(const fmpq_wrapper &other) const {
+    return fmpq_cmp(mp, other.get_fmpq_t()) > 0;
+  }
+  bool operator>=(const fmpq_wrapper &other) const {
+    return fmpq_cmp(mp, other.get_fmpq_t()) >= 0;
+  }
+  bool is_zero() const { return fmpq_is_zero(mp); }
+  bool is_one() const { return fmpq_is_one(mp); }
 };
 
 class mpq_view_flint {
 
 public:
-    mpq_view_flint(const fmpq_wrapper& i)
-    {
-        mpq_init(m);
-        fmpq_get_mpq(m, i.get_fmpq_t());
-    }
-    operator mpq_srcptr() const { return m; }
-    ~mpq_view_flint() { mpq_clear(m); }
+  mpq_view_flint(const fmpq_wrapper &i) {
+    mpq_init(m);
+    fmpq_get_mpq(m, i.get_fmpq_t());
+  }
+  operator mpq_srcptr() const { return m; }
+  ~mpq_view_flint() { mpq_clear(m); }
 
 private:
-    mpq_t m;
+  mpq_t m;
 };
 
 class fmpq_poly_wrapper {
 private:
-    fmpq_poly_t poly;
+  fmpq_poly_t poly;
 
 public:
-    fmpq_poly_wrapper() { fmpq_poly_init(poly); }
-    fmpq_poly_wrapper(int i)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_set_si(poly, i);
-    }
-    fmpq_poly_wrapper(const char* cp)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_set_str(poly, cp);
-    }
-    fmpq_poly_wrapper(const fmpq_wrapper& q)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
-    }
-    fmpq_poly_wrapper(const fmpq_poly_wrapper& other)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_set(poly, *other.get_fmpq_poly_t());
-    }
-    fmpq_poly_wrapper(fmpq_poly_wrapper&& other)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
-    }
-    fmpq_poly_wrapper& operator=(const fmpq_poly_wrapper& other)
-    {
-        fmpq_poly_set(poly, *other.get_fmpq_poly_t());
-        return *this;
-    }
-    fmpq_poly_wrapper& operator=(fmpq_poly_wrapper&& other)
-    {
-        fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
-        return *this;
-    }
-    ~fmpq_poly_wrapper() { fmpq_poly_clear(poly); }
+  fmpq_poly_wrapper() { fmpq_poly_init(poly); }
+  fmpq_poly_wrapper(int i) {
+    fmpq_poly_init(poly);
+    fmpq_poly_set_si(poly, i);
+  }
+  fmpq_poly_wrapper(const char *cp) {
+    fmpq_poly_init(poly);
+    fmpq_poly_set_str(poly, cp);
+  }
+  fmpq_poly_wrapper(const fmpq_wrapper &q) {
+    fmpq_poly_init(poly);
+    fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
+  }
+  fmpq_poly_wrapper(const fmpq_poly_wrapper &other) {
+    fmpq_poly_init(poly);
+    fmpq_poly_set(poly, *other.get_fmpq_poly_t());
+  }
+  fmpq_poly_wrapper(fmpq_poly_wrapper &&other) {
+    fmpq_poly_init(poly);
+    fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
+  }
+  fmpq_poly_wrapper &operator=(const fmpq_poly_wrapper &other) {
+    fmpq_poly_set(poly, *other.get_fmpq_poly_t());
+    return *this;
+  }
+  fmpq_poly_wrapper &operator=(fmpq_poly_wrapper &&other) {
+    fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
+    return *this;
+  }
+  ~fmpq_poly_wrapper() { fmpq_poly_clear(poly); }
 
-    const fmpq_poly_t* get_fmpq_poly_t() const { return &poly; }
-    fmpq_poly_t* get_fmpq_poly_t() { return &poly; }
-    std::string to_string() const { return fmpq_poly_get_str(poly); }
-    long degree() const { return fmpq_poly_degree(poly); }
-    fmpq_wrapper get_coeff(unsigned int deg) const
-    {
-        fmpq_wrapper q;
-        fmpq_poly_get_coeff_fmpq(q.get_fmpq_t(), poly, deg);
-        return q;
-    }
+  const fmpq_poly_t *get_fmpq_poly_t() const { return &poly; }
+  fmpq_poly_t *get_fmpq_poly_t() { return &poly; }
+  std::string to_string() const { return fmpq_poly_get_str(poly); }
+  long degree() const { return fmpq_poly_degree(poly); }
+  fmpq_wrapper get_coeff(unsigned int deg) const {
+    fmpq_wrapper q;
+    fmpq_poly_get_coeff_fmpq(q.get_fmpq_t(), poly, deg);
+    return q;
+  }
 
-    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper& o,
-        unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(), prec);
-        return r;
-    }
-    fmpq_poly_wrapper pow(unsigned int n) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_pow(*r.get_fmpq_poly_t(), poly, n);
-        return r;
-    }
-    fmpq_poly_wrapper derivative() const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_derivative(*r.get_fmpq_poly_t(), poly);
-        return r;
-    }
-    fmpq_poly_wrapper integral() const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_integral(*r.get_fmpq_poly_t(), poly);
-        return r;
-    }
+  fmpq_poly_wrapper mullow(const fmpq_poly_wrapper &o,
+                           unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(), prec);
+    return r;
+  }
+  fmpq_poly_wrapper pow(unsigned int n) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_pow(*r.get_fmpq_poly_t(), poly, n);
+    return r;
+  }
+  fmpq_poly_wrapper derivative() const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_derivative(*r.get_fmpq_poly_t(), poly);
+    return r;
+  }
+  fmpq_poly_wrapper integral() const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_integral(*r.get_fmpq_poly_t(), poly);
+    return r;
+  }
 
-    fmpq_poly_wrapper inv_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_inv_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper revert_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_revert_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper log_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_log_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper exp_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_exp_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper sin_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_sin_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper cos_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_cos_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper tan_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_tan_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper asin_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_asin_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper atan_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_atan_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper sinh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_sinh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper cosh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_cosh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper tanh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_tanh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper asinh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_asinh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper atanh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper subs(const fmpq_poly_wrapper& o, unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(),
-            prec);
-        return r;
-    }
-    void set_zero() { fmpq_poly_zero(poly); }
-    void set_one() { fmpq_poly_one(poly); }
+  fmpq_poly_wrapper inv_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_inv_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper revert_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_revert_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper log_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_log_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper exp_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_exp_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper sin_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_sin_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper cos_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_cos_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper tan_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_tan_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper asin_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_asin_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper atan_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_atan_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper sinh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_sinh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper cosh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_cosh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper tanh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_tanh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper asinh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_asinh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper atanh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper subs(const fmpq_poly_wrapper &o, unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(),
+                             prec);
+    return r;
+  }
+  void set_zero() { fmpq_poly_zero(poly); }
+  void set_one() { fmpq_poly_one(poly); }
 
-    bool operator==(const fmpq_poly_wrapper& o) const
-    {
-        return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
-    }
-    bool operator<(const fmpq_poly_wrapper& o) const
-    {
-        return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
-    }
+  bool operator==(const fmpq_poly_wrapper &o) const {
+    return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
+  }
+  bool operator<(const fmpq_poly_wrapper &o) const {
+    return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
+  }
 
-    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper& a,
-        const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-            *o.get_fmpq_poly_t());
-        return r;
-    }
-    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper& a,
-        const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-            *o.get_fmpq_poly_t());
-        return r;
-    }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a,
-        const fmpq_wrapper& q)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-            q.get_fmpq_t());
-        return r;
-    }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a,
-        const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-            *o.get_fmpq_poly_t());
-        return r;
-    }
-    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper& a,
-        const fmpq_wrapper& q)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-            q.get_fmpq_t());
-        return r;
-    }
+  friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper &a,
+                                     const fmpq_poly_wrapper &o) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                  *o.get_fmpq_poly_t());
+    return r;
+  }
+  friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper &a,
+                                     const fmpq_poly_wrapper &o) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                  *o.get_fmpq_poly_t());
+    return r;
+  }
+  friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
+                                     const fmpq_wrapper &q) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                              q.get_fmpq_t());
+    return r;
+  }
+  friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
+                                     const fmpq_poly_wrapper &o) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                  *o.get_fmpq_poly_t());
+    return r;
+  }
+  friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper &a,
+                                     const fmpq_wrapper &q) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                              q.get_fmpq_t());
+    return r;
+  }
 
-    void operator+=(const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
-    }
-    void operator-=(const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
-    }
-    void operator*=(const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
-    }
+  void operator+=(const fmpq_poly_wrapper &o) {
+    fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
+  }
+  void operator-=(const fmpq_poly_wrapper &o) {
+    fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
+  }
+  void operator*=(const fmpq_poly_wrapper &o) {
+    fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
+  }
 };
 
 } // SymEngine

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -490,12 +490,12 @@ public:
         fmpq_poly_init(poly);
         fmpq_poly_set_si(poly, i);
     }
-    fmpq_poly_wrapper(const char *cp)
+    fmpq_poly_wrapper(const char* cp)
     {
         fmpq_poly_init(poly);
         fmpq_poly_set_str(poly, cp);
     }
-    fmpq_poly_wrapper(const fmpq_wrapper &q)
+    fmpq_poly_wrapper(const fmpq_wrapper& q)
     {
         fmpq_poly_init(poly);
         fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
@@ -548,12 +548,11 @@ public:
         return q;
     }
 
-    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper &o,
-                             unsigned int prec) const
+    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper& o, unsigned int prec) const
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(),
-                         prec);
+        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly,
+                *o.get_fmpq_poly_t(), prec);
         return r;
     }
     fmpq_poly_wrapper pow(unsigned int n) const
@@ -659,11 +658,11 @@ public:
         fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
         return r;
     }
-    fmpq_poly_wrapper subs(const fmpq_poly_wrapper &o, unsigned int prec) const
+    fmpq_poly_wrapper subs(const fmpq_poly_wrapper& o, unsigned int prec) const
     {
         fmpq_poly_wrapper r;
         fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly,
-                                 *o.get_fmpq_poly_t(), prec);
+                *o.get_fmpq_poly_t(), prec);
         return r;
     }
     void set_zero()
@@ -675,65 +674,55 @@ public:
         fmpq_poly_one(poly);
     }
 
-    bool operator==(const fmpq_poly_wrapper &o) const
+    bool operator==(const fmpq_poly_wrapper& o) const
     {
         return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
     }
-    bool operator<(const fmpq_poly_wrapper &o) const
+    bool operator<(const fmpq_poly_wrapper& o) const
     {
         return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
     }
 
-    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper &a,
-                                       const fmpq_poly_wrapper &o)
+    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                      *o.get_fmpq_poly_t());
+        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper &a,
-                                       const fmpq_poly_wrapper &o)
+    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                      *o.get_fmpq_poly_t());
+        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
-                                       const fmpq_wrapper &q)
+    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a, const fmpq_wrapper& q)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                                  q.get_fmpq_t());
+        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), q.get_fmpq_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
-                                       const fmpq_poly_wrapper &o)
+    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                      *o.get_fmpq_poly_t());
+        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper &a,
-                                       const fmpq_wrapper &q)
+    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper& a, const fmpq_wrapper& q)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
-                                  q.get_fmpq_t());
+        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), q.get_fmpq_t());
         return r;
     }
 
-    void operator+=(const fmpq_poly_wrapper &o)
+    void operator+=(const fmpq_poly_wrapper& o)
     {
         fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
     }
-    void operator-=(const fmpq_poly_wrapper &o)
+    void operator-=(const fmpq_poly_wrapper& o)
     {
         fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
     }
-    void operator*=(const fmpq_poly_wrapper &o)
+    void operator*=(const fmpq_poly_wrapper& o)
     {
         fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
     }

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -1,731 +1,558 @@
 #ifndef SYMENGINE_FLINT_WRAPPER_H
 #define SYMENGINE_FLINT_WRAPPER_H
 
-#include <symengine/symengine_rcp.h>
 #include <gmp.h>
+#include <symengine/symengine_rcp.h>
 
-#include <flint/fmpz.h>
 #include <flint/fmpq.h>
 #include <flint/fmpq_poly.h>
+#include <flint/fmpz.h>
 
-namespace SymEngine
-{
+namespace SymEngine {
 
-class fmpz_wrapper
-{
+class fmpz_wrapper {
 private:
-    fmpz_t mp;
+  fmpz_t mp;
 
 public:
-    template <typename T,
-              typename std::enable_if<std::is_integral<T>::value
-                                          && std::is_unsigned<T>::value,
-                                      int>::type
-              = 0>
-    inline fmpz_wrapper(const T i)
-    {
-        fmpz_init(mp);
-        fmpz_set_ui(mp, i);
-    }
-    template <typename T,
-              typename std::enable_if<std::is_integral<T>::value
-                                          && std::is_signed<T>::value,
-                                      int>::type
-              = 0>
-    inline fmpz_wrapper(const T i)
-    {
-        fmpz_init(mp);
-        fmpz_set_si(mp, i);
-    }
-    inline fmpz_wrapper()
-    {
-        fmpz_init(mp);
-    }
-    inline fmpz_wrapper(const mpz_t m)
-    {
-        fmpz_init(mp);
-        fmpz_set_mpz(mp, m);
-    }
-    inline fmpz_wrapper(const fmpz_t m)
-    {
-        fmpz_init(mp);
-        fmpz_set(mp, m);
-    }
-    inline fmpz_wrapper(const std::string &s, unsigned base = 10)
-    {
-        fmpz_init(mp);
-        fmpz_set_str(mp, s.c_str(), base);
-    }
-    inline fmpz_wrapper(const fmpz_wrapper &other)
-    {
-        fmpz_init(mp);
-        fmpz_set(mp, other.get_fmpz_t());
-    }
-    inline fmpz_wrapper(fmpz_wrapper &&other) SYMENGINE_NOEXCEPT
-    {
-        fmpz_init(mp);
-        fmpz_swap(mp, other.get_fmpz_t());
-    }
-    inline fmpz_wrapper &operator=(const fmpz_wrapper &other)
-    {
-        fmpz_set(mp, other.get_fmpz_t());
-        return *this;
-    }
-    inline fmpz_wrapper &operator=(fmpz_wrapper &&other) SYMENGINE_NOEXCEPT
-    {
-        fmpz_swap(mp, other.get_fmpz_t());
-        return *this;
-    }
-    inline ~fmpz_wrapper() SYMENGINE_NOEXCEPT
-    {
-        fmpz_clear(mp);
-    }
-    inline fmpz *get_fmpz_t()
-    {
-        return mp;
-    }
-    inline const fmpz *get_fmpz_t() const
-    {
-        return mp;
-    }
-    inline friend fmpz_wrapper operator+(const fmpz_wrapper &a,
-                                         const fmpz_wrapper &b)
-    {
-        fmpz_wrapper res;
-        fmpz_add(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator+=(const fmpz_wrapper &a)
-    {
-        fmpz_add(mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline friend fmpz_wrapper operator-(const fmpz_wrapper &a,
-                                         const fmpz_wrapper &b)
-    {
-        fmpz_wrapper res;
-        fmpz_sub(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator-=(const fmpz_wrapper &a)
-    {
-        fmpz_sub(mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline fmpz_wrapper operator-() const
-    {
-        fmpz_wrapper res;
-        fmpz_neg(res.get_fmpz_t(), mp);
-        return res;
-    }
-    inline friend fmpz_wrapper operator*(const fmpz_wrapper &a,
-                                         const fmpz_wrapper &b)
-    {
-        fmpz_wrapper res;
-        fmpz_mul(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator*=(const fmpz_wrapper &a)
-    {
-        fmpz_mul(mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline friend fmpz_wrapper operator/(const fmpz_wrapper &a,
-                                         const fmpz_wrapper &b)
-    {
-        fmpz_wrapper res;
-        fmpz_tdiv_q(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator/=(const fmpz_wrapper &a)
-    {
-        fmpz_tdiv_q(mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline friend fmpz_wrapper operator%(const fmpz_wrapper &a,
-                                         const fmpz_wrapper &b)
-    {
-        fmpz_wrapper res, tmp;
-        fmpz_tdiv_qr(tmp.get_fmpz_t(), res.get_fmpz_t(), a.get_fmpz_t(),
-                     b.get_fmpz_t());
-        return res;
-    }
-    inline fmpz_wrapper operator%=(const fmpz_wrapper &a)
-    {
-        fmpz_wrapper tmp;
-        fmpz_tdiv_qr(tmp.get_fmpz_t(), mp, mp, a.get_fmpz_t());
-        return *this;
-    }
-    inline fmpz_wrapper operator++()
-    {
-        fmpz_add_ui(mp, mp, 1);
-        return *this;
-    }
-    inline fmpz_wrapper operator++(int)
-    {
-        fmpz_wrapper orig = *this;
-        ++(*this);
-        return orig;
-    }
-    inline fmpz_wrapper operator--()
-    {
-        fmpz_sub_ui(mp, mp, 1);
-        return *this;
-    }
-    inline fmpz_wrapper operator--(int)
-    {
-        fmpz_wrapper orig = *this;
-        --(*this);
-        return orig;
-    }
-    inline friend bool operator==(const fmpz_wrapper &a, const fmpz_wrapper &b)
-    {
-        return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) == 1;
-    }
-    inline friend bool operator!=(const fmpz_wrapper &a, const fmpz_wrapper &b)
-    {
-        return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) != 1;
-    }
-    inline friend bool operator<(const fmpz_wrapper &a, const fmpz_wrapper &b)
-    {
-        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) < 0;
-    }
-    inline friend bool operator<=(const fmpz_wrapper &a, const fmpz_wrapper &b)
-    {
-        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) <= 0;
-    }
-    inline friend bool operator>(const fmpz_wrapper &a, const fmpz_wrapper &b)
-    {
-        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) > 0;
-    }
-    inline friend bool operator>=(const fmpz_wrapper &a, const fmpz_wrapper &b)
-    {
-        return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) >= 0;
-    }
-    inline fmpz_wrapper operator<<=(unsigned long u)
-    {
-        fmpz_mul_2exp(mp, mp, u);
-        return *this;
-    }
-    inline fmpz_wrapper operator<<(unsigned long u) const
-    {
-        fmpz_wrapper res;
-        fmpz_mul_2exp(res.get_fmpz_t(), mp, u);
-        return res;
-    }
-    inline fmpz_wrapper operator>>=(unsigned long u)
-    {
-        fmpz_tdiv_q_2exp(mp, mp, u);
-        return *this;
-    }
-    inline fmpz_wrapper operator>>(unsigned long u) const
-    {
-        fmpz_wrapper res;
-        fmpz_tdiv_q_2exp(res.get_fmpz_t(), mp, u);
-        return res;
-    }
-    inline fmpz_wrapper root(unsigned int n) const
-    {
-        fmpz_wrapper res;
-        fmpz_root(res.get_fmpz_t(), mp, n);
-        return res;
-    }
+  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
+                                                    std::is_unsigned<T>::value,
+                                                int>::type = 0>
+  inline fmpz_wrapper(const T i) {
+    fmpz_init(mp);
+    fmpz_set_ui(mp, i);
+  }
+  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
+                                                    std::is_signed<T>::value,
+                                                int>::type = 0>
+  inline fmpz_wrapper(const T i) {
+    fmpz_init(mp);
+    fmpz_set_si(mp, i);
+  }
+  inline fmpz_wrapper() { fmpz_init(mp); }
+  inline fmpz_wrapper(const mpz_t m) {
+    fmpz_init(mp);
+    fmpz_set_mpz(mp, m);
+  }
+  inline fmpz_wrapper(const fmpz_t m) {
+    fmpz_init(mp);
+    fmpz_set(mp, m);
+  }
+  inline fmpz_wrapper(const std::string &s, unsigned base = 10) {
+    fmpz_init(mp);
+    fmpz_set_str(mp, s.c_str(), base);
+  }
+  inline fmpz_wrapper(const fmpz_wrapper &other) {
+    fmpz_init(mp);
+    fmpz_set(mp, other.get_fmpz_t());
+  }
+  inline fmpz_wrapper(fmpz_wrapper &&other) SYMENGINE_NOEXCEPT {
+    fmpz_init(mp);
+    fmpz_swap(mp, other.get_fmpz_t());
+  }
+  inline fmpz_wrapper &operator=(const fmpz_wrapper &other) {
+    fmpz_set(mp, other.get_fmpz_t());
+    return *this;
+  }
+  inline fmpz_wrapper &operator=(fmpz_wrapper &&other) SYMENGINE_NOEXCEPT {
+    fmpz_swap(mp, other.get_fmpz_t());
+    return *this;
+  }
+  inline ~fmpz_wrapper() SYMENGINE_NOEXCEPT { fmpz_clear(mp); }
+  inline fmpz *get_fmpz_t() { return mp; }
+  inline const fmpz *get_fmpz_t() const { return mp; }
+  inline friend fmpz_wrapper operator+(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res;
+    fmpz_add(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator+=(const fmpz_wrapper &a) {
+    fmpz_add(mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline friend fmpz_wrapper operator-(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res;
+    fmpz_sub(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator-=(const fmpz_wrapper &a) {
+    fmpz_sub(mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline fmpz_wrapper operator-() const {
+    fmpz_wrapper res;
+    fmpz_neg(res.get_fmpz_t(), mp);
+    return res;
+  }
+  inline friend fmpz_wrapper operator*(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res;
+    fmpz_mul(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator*=(const fmpz_wrapper &a) {
+    fmpz_mul(mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline friend fmpz_wrapper operator/(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res;
+    fmpz_tdiv_q(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator/=(const fmpz_wrapper &a) {
+    fmpz_tdiv_q(mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline friend fmpz_wrapper operator%(const fmpz_wrapper &a,
+                                       const fmpz_wrapper &b) {
+    fmpz_wrapper res, tmp;
+    fmpz_tdiv_qr(tmp.get_fmpz_t(), res.get_fmpz_t(), a.get_fmpz_t(),
+                 b.get_fmpz_t());
+    return res;
+  }
+  inline fmpz_wrapper operator%=(const fmpz_wrapper &a) {
+    fmpz_wrapper tmp;
+    fmpz_tdiv_qr(tmp.get_fmpz_t(), mp, mp, a.get_fmpz_t());
+    return *this;
+  }
+  inline fmpz_wrapper operator++() {
+    fmpz_add_ui(mp, mp, 1);
+    return *this;
+  }
+  inline fmpz_wrapper operator++(int) {
+    fmpz_wrapper orig = *this;
+    ++(*this);
+    return orig;
+  }
+  inline fmpz_wrapper operator--() {
+    fmpz_sub_ui(mp, mp, 1);
+    return *this;
+  }
+  inline fmpz_wrapper operator--(int) {
+    fmpz_wrapper orig = *this;
+    --(*this);
+    return orig;
+  }
+  inline friend bool operator==(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) == 1;
+  }
+  inline friend bool operator!=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_equal(a.get_fmpz_t(), b.get_fmpz_t()) != 1;
+  }
+  inline friend bool operator<(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) < 0;
+  }
+  inline friend bool operator<=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) <= 0;
+  }
+  inline friend bool operator>(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) > 0;
+  }
+  inline friend bool operator>=(const fmpz_wrapper &a, const fmpz_wrapper &b) {
+    return fmpz_cmp(a.get_fmpz_t(), b.get_fmpz_t()) >= 0;
+  }
+  inline fmpz_wrapper operator<<=(unsigned long u) {
+    fmpz_mul_2exp(mp, mp, u);
+    return *this;
+  }
+  inline fmpz_wrapper operator<<(unsigned long u) const {
+    fmpz_wrapper res;
+    fmpz_mul_2exp(res.get_fmpz_t(), mp, u);
+    return res;
+  }
+  inline fmpz_wrapper operator>>=(unsigned long u) {
+    fmpz_tdiv_q_2exp(mp, mp, u);
+    return *this;
+  }
+  inline fmpz_wrapper operator>>(unsigned long u) const {
+    fmpz_wrapper res;
+    fmpz_tdiv_q_2exp(res.get_fmpz_t(), mp, u);
+    return res;
+  }
+  inline fmpz_wrapper root(unsigned int n) const {
+    fmpz_wrapper res;
+    fmpz_root(res.get_fmpz_t(), mp, n);
+    return res;
+  }
 };
 
-class mpz_view_flint
-{
+class mpz_view_flint {
 
 public:
-    mpz_view_flint(const fmpz_wrapper &i)
-    {
-        if (!COEFF_IS_MPZ(*i.get_fmpz_t())) {
-            mpz_init_set_si(m, *i.get_fmpz_t());
-        } else {
-            ptr = COEFF_TO_PTR(*i.get_fmpz_t());
-        }
+  mpz_view_flint(const fmpz_wrapper &i) {
+    if (!COEFF_IS_MPZ(*i.get_fmpz_t())) {
+      mpz_init_set_si(m, *i.get_fmpz_t());
+    } else {
+      ptr = COEFF_TO_PTR(*i.get_fmpz_t());
     }
-    operator mpz_srcptr() const
-    {
-        if (ptr == nullptr)
-            return m;
-        return ptr;
-    }
-    ~mpz_view_flint()
-    {
-        if (ptr == nullptr)
-            mpz_clear(m);
-    }
+  }
+  operator mpz_srcptr() const {
+    if (ptr == nullptr)
+      return m;
+    return ptr;
+  }
+  ~mpz_view_flint() {
+    if (ptr == nullptr)
+      mpz_clear(m);
+  }
 
 private:
-    mpz_srcptr ptr = nullptr;
-    mpz_t m;
+  mpz_srcptr ptr = nullptr;
+  mpz_t m;
 };
 
-class fmpq_wrapper
-{
+class fmpq_wrapper {
 private:
-    fmpq_t mp;
+  fmpq_t mp;
 
 public:
-    fmpq *get_fmpq_t()
-    {
-        return mp;
-    }
-    const fmpq *get_fmpq_t() const
-    {
-        return mp;
-    }
-    fmpq_wrapper()
-    {
-        fmpq_init(mp);
-    }
-    fmpq_wrapper(const mpz_t m)
-    {
-        fmpq_init(mp);
-        fmpz_set_mpz(fmpq_numref(mp), m);
-    }
-    fmpq_wrapper(const fmpz_t m)
-    {
-        fmpq_init(mp);
-        fmpz_set(fmpq_numref(mp), m);
-    }
-    fmpq_wrapper(const mpq_t m)
-    {
-        fmpq_init(mp);
-        fmpq_set_mpq(mp, m);
-    }
-    fmpq_wrapper(const fmpq_t m)
-    {
-        fmpq_init(mp);
-        fmpq_set(mp, m);
-    }
-    template <typename T,
-              typename std::enable_if<std::is_integral<T>::value
-                                          && std::is_unsigned<T>::value,
-                                      int>::type
-              = 0>
-    fmpq_wrapper(const T i)
-    {
-        fmpq_init(mp);
-        fmpz_set_ui(fmpq_numref(mp), i);
-    }
-    template <typename T,
-              typename std::enable_if<std::is_integral<T>::value
-                                          && std::is_signed<T>::value,
-                                      int>::type
-              = 0>
-    fmpq_wrapper(const T i)
-    {
-        fmpq_init(mp);
-        fmpz_set_si(fmpq_numref(mp), i);
-    }
-    fmpq_wrapper(const fmpz_wrapper &n, const fmpz_wrapper &d = 1)
-    {
-        fmpq_init(mp);
-        fmpz_set(fmpq_numref(mp), n.get_fmpz_t());
-        fmpz_set(fmpq_denref(mp), d.get_fmpz_t());
-    }
-    fmpq_wrapper(const fmpq_wrapper &other)
-    {
-        fmpq_init(mp);
-        fmpq_set(mp, other.get_fmpq_t());
-    }
-    fmpq_wrapper(fmpq_wrapper &&other)
-    {
-        fmpq_init(mp);
-        fmpq_swap(mp, other.get_fmpq_t());
-    }
-    fmpq_wrapper &operator=(const fmpq_wrapper &other)
-    {
-        fmpq_set(mp, other.get_fmpq_t());
-        return *this;
-    }
-    fmpq_wrapper &operator=(fmpq_wrapper &&other)
-    {
-        fmpq_swap(mp, other.get_fmpq_t());
-        return *this;
-    }
-    ~fmpq_wrapper()
-    {
-        fmpq_clear(mp);
-    }
-    void canonicalise()
-    {
-        fmpq_canonicalise(mp);
-    }
-    const fmpz_wrapper &get_den() const
-    {
-        return reinterpret_cast<const fmpz_wrapper &>(*fmpq_denref(mp));
-    }
-    const fmpz_wrapper &get_num() const
-    {
-        return reinterpret_cast<const fmpz_wrapper &>(*fmpq_numref(mp));
-    }
-    fmpz_wrapper &get_den()
-    {
-        return reinterpret_cast<fmpz_wrapper &>(*fmpq_denref(mp));
-    }
-    fmpz_wrapper &get_num()
-    {
-        return reinterpret_cast<fmpz_wrapper &>(*fmpq_numref(mp));
-    }
-    friend fmpq_wrapper operator+(const fmpq_wrapper &a, const fmpq_wrapper &b)
-    {
-        fmpq_wrapper res;
-        fmpq_add(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-        return res;
-    }
-    fmpq_wrapper operator+=(const fmpq_wrapper &a)
-    {
-        fmpq_add(mp, mp, a.get_fmpq_t());
-        return *this;
-    }
-    friend fmpq_wrapper operator-(const fmpq_wrapper &a, const fmpq_wrapper &b)
-    {
-        fmpq_wrapper res;
-        fmpq_sub(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-        return res;
-    }
-    fmpq_wrapper operator-=(const fmpq_wrapper &a)
-    {
-        fmpq_sub(mp, mp, a.get_fmpq_t());
-        return *this;
-    }
-    fmpq_wrapper operator-() const
-    {
-        fmpq_wrapper res;
-        fmpq_neg(res.get_fmpq_t(), mp);
-        return res;
-    }
-    friend fmpq_wrapper operator*(const fmpq_wrapper &a, const fmpq_wrapper &b)
-    {
-        fmpq_wrapper res;
-        fmpq_mul(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-        return res;
-    }
-    fmpq_wrapper operator*=(const fmpq_wrapper &a)
-    {
-        fmpq_mul(mp, mp, a.get_fmpq_t());
-        return *this;
-    }
-    friend fmpq_wrapper operator/(const fmpq_wrapper &a, const fmpq_wrapper &b)
-    {
-        fmpq_wrapper res;
-        fmpq_div(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
-        return res;
-    }
-    fmpq_wrapper operator/=(const fmpq_wrapper &a)
-    {
-        fmpq_div(mp, mp, a.get_fmpq_t());
-        return *this;
-    }
-    bool operator==(const fmpq_wrapper &other) const
-    {
-        return fmpq_equal(mp, other.get_fmpq_t());
-    }
-    bool operator!=(const fmpq_wrapper &other) const
-    {
-        return not(*this == other);
-    }
-    bool operator<(const fmpq_wrapper &other) const
-    {
-        return fmpq_cmp(mp, other.get_fmpq_t()) < 0;
-    }
-    bool operator<=(const fmpq_wrapper &other) const
-    {
-        return fmpq_cmp(mp, other.get_fmpq_t()) <= 0;
-    }
-    bool operator>(const fmpq_wrapper &other) const
-    {
-        return fmpq_cmp(mp, other.get_fmpq_t()) > 0;
-    }
-    bool operator>=(const fmpq_wrapper &other) const
-    {
-        return fmpq_cmp(mp, other.get_fmpq_t()) >= 0;
-    }
-    bool is_zero() const
-    {
-        return fmpq_is_zero(mp);
-    }
-    bool is_one() const
-    {
-        return fmpq_is_one(mp);
-    }
+  fmpq *get_fmpq_t() { return mp; }
+  const fmpq *get_fmpq_t() const { return mp; }
+  fmpq_wrapper() { fmpq_init(mp); }
+  fmpq_wrapper(const mpz_t m) {
+    fmpq_init(mp);
+    fmpz_set_mpz(fmpq_numref(mp), m);
+  }
+  fmpq_wrapper(const fmpz_t m) {
+    fmpq_init(mp);
+    fmpz_set(fmpq_numref(mp), m);
+  }
+  fmpq_wrapper(const mpq_t m) {
+    fmpq_init(mp);
+    fmpq_set_mpq(mp, m);
+  }
+  fmpq_wrapper(const fmpq_t m) {
+    fmpq_init(mp);
+    fmpq_set(mp, m);
+  }
+  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
+                                                    std::is_unsigned<T>::value,
+                                                int>::type = 0>
+  fmpq_wrapper(const T i) {
+    fmpq_init(mp);
+    fmpz_set_ui(fmpq_numref(mp), i);
+  }
+  template <typename T, typename std::enable_if<std::is_integral<T>::value &&
+                                                    std::is_signed<T>::value,
+                                                int>::type = 0>
+  fmpq_wrapper(const T i) {
+    fmpq_init(mp);
+    fmpz_set_si(fmpq_numref(mp), i);
+  }
+  fmpq_wrapper(const fmpz_wrapper &n, const fmpz_wrapper &d = 1) {
+    fmpq_init(mp);
+    fmpz_set(fmpq_numref(mp), n.get_fmpz_t());
+    fmpz_set(fmpq_denref(mp), d.get_fmpz_t());
+  }
+  fmpq_wrapper(const fmpq_wrapper &other) {
+    fmpq_init(mp);
+    fmpq_set(mp, other.get_fmpq_t());
+  }
+  fmpq_wrapper(fmpq_wrapper &&other) {
+    fmpq_init(mp);
+    fmpq_swap(mp, other.get_fmpq_t());
+  }
+  fmpq_wrapper &operator=(const fmpq_wrapper &other) {
+    fmpq_set(mp, other.get_fmpq_t());
+    return *this;
+  }
+  fmpq_wrapper &operator=(fmpq_wrapper &&other) {
+    fmpq_swap(mp, other.get_fmpq_t());
+    return *this;
+  }
+  ~fmpq_wrapper() { fmpq_clear(mp); }
+  void canonicalise() { fmpq_canonicalise(mp); }
+  const fmpz_wrapper &get_den() const {
+    return reinterpret_cast<const fmpz_wrapper &>(*fmpq_denref(mp));
+  }
+  const fmpz_wrapper &get_num() const {
+    return reinterpret_cast<const fmpz_wrapper &>(*fmpq_numref(mp));
+  }
+  fmpz_wrapper &get_den() {
+    return reinterpret_cast<fmpz_wrapper &>(*fmpq_denref(mp));
+  }
+  fmpz_wrapper &get_num() {
+    return reinterpret_cast<fmpz_wrapper &>(*fmpq_numref(mp));
+  }
+  friend fmpq_wrapper operator+(const fmpq_wrapper &a, const fmpq_wrapper &b) {
+    fmpq_wrapper res;
+    fmpq_add(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+    return res;
+  }
+  fmpq_wrapper operator+=(const fmpq_wrapper &a) {
+    fmpq_add(mp, mp, a.get_fmpq_t());
+    return *this;
+  }
+  friend fmpq_wrapper operator-(const fmpq_wrapper &a, const fmpq_wrapper &b) {
+    fmpq_wrapper res;
+    fmpq_sub(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+    return res;
+  }
+  fmpq_wrapper operator-=(const fmpq_wrapper &a) {
+    fmpq_sub(mp, mp, a.get_fmpq_t());
+    return *this;
+  }
+  fmpq_wrapper operator-() const {
+    fmpq_wrapper res;
+    fmpq_neg(res.get_fmpq_t(), mp);
+    return res;
+  }
+  friend fmpq_wrapper operator*(const fmpq_wrapper &a, const fmpq_wrapper &b) {
+    fmpq_wrapper res;
+    fmpq_mul(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+    return res;
+  }
+  fmpq_wrapper operator*=(const fmpq_wrapper &a) {
+    fmpq_mul(mp, mp, a.get_fmpq_t());
+    return *this;
+  }
+  friend fmpq_wrapper operator/(const fmpq_wrapper &a, const fmpq_wrapper &b) {
+    fmpq_wrapper res;
+    fmpq_div(res.get_fmpq_t(), a.get_fmpq_t(), b.get_fmpq_t());
+    return res;
+  }
+  fmpq_wrapper operator/=(const fmpq_wrapper &a) {
+    fmpq_div(mp, mp, a.get_fmpq_t());
+    return *this;
+  }
+  bool operator==(const fmpq_wrapper &other) const {
+    return fmpq_equal(mp, other.get_fmpq_t());
+  }
+  bool operator!=(const fmpq_wrapper &other) const {
+    return not(*this == other);
+  }
+  bool operator<(const fmpq_wrapper &other) const {
+    return fmpq_cmp(mp, other.get_fmpq_t()) < 0;
+  }
+  bool operator<=(const fmpq_wrapper &other) const {
+    return fmpq_cmp(mp, other.get_fmpq_t()) <= 0;
+  }
+  bool operator>(const fmpq_wrapper &other) const {
+    return fmpq_cmp(mp, other.get_fmpq_t()) > 0;
+  }
+  bool operator>=(const fmpq_wrapper &other) const {
+    return fmpq_cmp(mp, other.get_fmpq_t()) >= 0;
+  }
+  bool is_zero() const { return fmpq_is_zero(mp); }
+  bool is_one() const { return fmpq_is_one(mp); }
 };
 
-class mpq_view_flint
-{
+class mpq_view_flint {
 
 public:
-    mpq_view_flint(const fmpq_wrapper &i)
-    {
-        mpq_init(m);
-        fmpq_get_mpq(m, i.get_fmpq_t());
-    }
-    operator mpq_srcptr() const
-    {
-        return m;
-    }
-    ~mpq_view_flint()
-    {
-        mpq_clear(m);
-    }
+  mpq_view_flint(const fmpq_wrapper &i) {
+    mpq_init(m);
+    fmpq_get_mpq(m, i.get_fmpq_t());
+  }
+  operator mpq_srcptr() const { return m; }
+  ~mpq_view_flint() { mpq_clear(m); }
 
 private:
-    mpq_t m;
+  mpq_t m;
 };
 
-class fmpq_poly_wrapper
-{
+class fmpq_poly_wrapper {
 private:
-    fmpq_poly_t poly;
+  fmpq_poly_t poly;
 
 public:
-    fmpq_poly_wrapper()
-    {
-        fmpq_poly_init(poly);
-    }
-    fmpq_poly_wrapper(int i)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_set_si(poly, i);
-    }
-    fmpq_poly_wrapper(const char* cp)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_set_str(poly, cp);
-    }
-    fmpq_poly_wrapper(const fmpq_wrapper& q)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
-    }
-    fmpq_poly_wrapper(const fmpq_poly_wrapper &other)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_set(poly, *other.get_fmpq_poly_t());
-    }
-    fmpq_poly_wrapper(fmpq_poly_wrapper &&other)
-    {
-        fmpq_poly_init(poly);
-        fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
-    }
-    fmpq_poly_wrapper &operator=(const fmpq_poly_wrapper &other)
-    {
-        fmpq_poly_set(poly, *other.get_fmpq_poly_t());
-        return *this;
-    }
-    fmpq_poly_wrapper &operator=(fmpq_poly_wrapper &&other)
-    {
-        fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
-        return *this;
-    }
-    ~fmpq_poly_wrapper()
-    {
-        fmpq_poly_clear(poly);
-    }
+  fmpq_poly_wrapper() { fmpq_poly_init(poly); }
+  fmpq_poly_wrapper(int i) {
+    fmpq_poly_init(poly);
+    fmpq_poly_set_si(poly, i);
+  }
+  fmpq_poly_wrapper(const char *cp) {
+    fmpq_poly_init(poly);
+    fmpq_poly_set_str(poly, cp);
+  }
+  fmpq_poly_wrapper(const fmpq_wrapper &q) {
+    fmpq_poly_init(poly);
+    fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
+  }
+  fmpq_poly_wrapper(const fmpq_poly_wrapper &other) {
+    fmpq_poly_init(poly);
+    fmpq_poly_set(poly, *other.get_fmpq_poly_t());
+  }
+  fmpq_poly_wrapper(fmpq_poly_wrapper &&other) {
+    fmpq_poly_init(poly);
+    fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
+  }
+  fmpq_poly_wrapper &operator=(const fmpq_poly_wrapper &other) {
+    fmpq_poly_set(poly, *other.get_fmpq_poly_t());
+    return *this;
+  }
+  fmpq_poly_wrapper &operator=(fmpq_poly_wrapper &&other) {
+    fmpq_poly_swap(poly, *other.get_fmpq_poly_t());
+    return *this;
+  }
+  ~fmpq_poly_wrapper() { fmpq_poly_clear(poly); }
 
-    const fmpq_poly_t *get_fmpq_poly_t() const
-    {
-        return &poly;
-    }
-    fmpq_poly_t *get_fmpq_poly_t()
-    {
-        return &poly;
-    }
-    std::string to_string() const
-    {
-        return fmpq_poly_get_str(poly);
-    }
-    long degree() const
-    {
-        return fmpq_poly_degree(poly);
-    }
-    fmpq_wrapper get_coeff(unsigned int deg) const
-    {
-        fmpq_wrapper q;
-        fmpq_poly_get_coeff_fmpq(q.get_fmpq_t(), poly, deg);
-        return q;
-    }
+  const fmpq_poly_t *get_fmpq_poly_t() const { return &poly; }
+  fmpq_poly_t *get_fmpq_poly_t() { return &poly; }
+  std::string to_string() const { return fmpq_poly_get_str(poly); }
+  long degree() const { return fmpq_poly_degree(poly); }
+  fmpq_wrapper get_coeff(unsigned int deg) const {
+    fmpq_wrapper q;
+    fmpq_poly_get_coeff_fmpq(q.get_fmpq_t(), poly, deg);
+    return q;
+  }
 
-    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper& o, unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly,
-                *o.get_fmpq_poly_t(), prec);
-        return r;
-    }
-    fmpq_poly_wrapper pow(unsigned int n) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_pow(*r.get_fmpq_poly_t(), poly, n);
-        return r;
-    }
-    fmpq_poly_wrapper derivative() const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_derivative(*r.get_fmpq_poly_t(), poly);
-        return r;
-    }
-    fmpq_poly_wrapper integral() const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_integral(*r.get_fmpq_poly_t(), poly);
-        return r;
-    }
+  fmpq_poly_wrapper mullow(const fmpq_poly_wrapper &o,
+                           unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(), prec);
+    return r;
+  }
+  fmpq_poly_wrapper pow(unsigned int n) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_pow(*r.get_fmpq_poly_t(), poly, n);
+    return r;
+  }
+  fmpq_poly_wrapper derivative() const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_derivative(*r.get_fmpq_poly_t(), poly);
+    return r;
+  }
+  fmpq_poly_wrapper integral() const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_integral(*r.get_fmpq_poly_t(), poly);
+    return r;
+  }
 
-    fmpq_poly_wrapper inv_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_inv_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper revert_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_revert_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper log_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_log_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper exp_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_exp_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper sin_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_sin_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper cos_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_cos_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper tan_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_tan_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper asin_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_asin_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper atan_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_atan_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper sinh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_sinh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper cosh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_cosh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper tanh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_tanh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper asinh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_asinh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper atanh_series(unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
-        return r;
-    }
-    fmpq_poly_wrapper subs(const fmpq_poly_wrapper& o, unsigned int prec) const
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly,
-                *o.get_fmpq_poly_t(), prec);
-        return r;
-    }
-    void set_zero()
-    {
-        fmpq_poly_zero(poly);
-    }
-    void set_one()
-    {
-        fmpq_poly_one(poly);
-    }
+  fmpq_poly_wrapper inv_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_inv_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper revert_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_revert_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper log_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_log_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper exp_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_exp_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper sin_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_sin_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper cos_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_cos_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper tan_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_tan_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper asin_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_asin_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper atan_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_atan_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper sinh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_sinh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper cosh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_cosh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper tanh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_tanh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper asinh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_asinh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper atanh_series(unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
+    return r;
+  }
+  fmpq_poly_wrapper subs(const fmpq_poly_wrapper &o, unsigned int prec) const {
+    fmpq_poly_wrapper r;
+    fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(),
+                             prec);
+    return r;
+  }
+  void set_zero() { fmpq_poly_zero(poly); }
+  void set_one() { fmpq_poly_one(poly); }
 
-    bool operator==(const fmpq_poly_wrapper& o) const
-    {
-        return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
-    }
-    bool operator<(const fmpq_poly_wrapper& o) const
-    {
-        return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
-    }
+  bool operator==(const fmpq_poly_wrapper &o) const {
+    return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
+  }
+  bool operator<(const fmpq_poly_wrapper &o) const {
+    return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
+  }
 
-    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
-        return r;
-    }
-    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
-        return r;
-    }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a, const fmpq_wrapper& q)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), q.get_fmpq_t());
-        return r;
-    }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
-        return r;
-    }
-    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper& a, const fmpq_wrapper& q)
-    {
-        fmpq_poly_wrapper r;
-        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), q.get_fmpq_t());
-        return r;
-    }
+  friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper &a,
+                                     const fmpq_poly_wrapper &o) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                  *o.get_fmpq_poly_t());
+    return r;
+  }
+  friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper &a,
+                                     const fmpq_poly_wrapper &o) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                  *o.get_fmpq_poly_t());
+    return r;
+  }
+  friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
+                                     const fmpq_wrapper &q) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                              q.get_fmpq_t());
+    return r;
+  }
+  friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
+                                     const fmpq_poly_wrapper &o) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                  *o.get_fmpq_poly_t());
+    return r;
+  }
+  friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper &a,
+                                     const fmpq_wrapper &q) {
+    fmpq_poly_wrapper r;
+    fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                              q.get_fmpq_t());
+    return r;
+  }
 
-    void operator+=(const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
-    }
-    void operator-=(const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
-    }
-    void operator*=(const fmpq_poly_wrapper& o)
-    {
-        fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
-    }
+  void operator+=(const fmpq_poly_wrapper &o) {
+    fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
+  }
+  void operator-=(const fmpq_poly_wrapper &o) {
+    fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
+  }
+  void operator*=(const fmpq_poly_wrapper &o) {
+    fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
+  }
 };
 
 } // SymEngine

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -1,207 +1,184 @@
 #ifndef SYMENGINE_SERIES_FLINT_H
 #define SYMENGINE_SERIES_FLINT_H
 
-#include <symengine/series.h>
 #include <symengine/expression.h>
+#include <symengine/series.h>
 
 #ifdef HAVE_SYMENGINE_FLINT
 #include <symengine/flint_wrapper.h>
 
-namespace SymEngine
-{
+namespace SymEngine {
 
 using fp_t = fmpq_poly_wrapper;
 // Univariate Rational Coefficient Power SeriesBase using Flint
 class URatPSeriesFlint
-    : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint>
-{
+    : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint> {
 public:
-    URatPSeriesFlint(const fp_t p, const std::string varname,
-                     const unsigned degree);
-    IMPLEMENT_TYPEID(URATPSERIESFLINT)
-    virtual int compare(const Basic &o) const;
-    virtual std::size_t __hash__() const;
-    virtual RCP<const Basic> as_basic() const;
-    virtual umap_int_basic as_dict() const;
-    virtual RCP<const Basic> get_coeff(int) const;
+  URatPSeriesFlint(const fp_t p, const std::string varname,
+                   const unsigned degree);
+  IMPLEMENT_TYPEID(URATPSERIESFLINT)
+  virtual int compare(const Basic &o) const;
+  virtual std::size_t __hash__() const;
+  virtual RCP<const Basic> as_basic() const;
+  virtual umap_int_basic as_dict() const;
+  virtual RCP<const Basic> get_coeff(int) const;
 
-    static RCP<const URatPSeriesFlint>
-    series(const RCP<const Basic> &t, const std::string &x, unsigned int prec);
-    static fp_t var(const std::string &s);
-    static fp_t convert(const rational_class &x);
-    static fp_t convert(const Rational &x);
-    static fp_t convert(const Integer &x);
-    static fp_t convert(const Basic &x);
-    static inline fp_t mul(const fp_t &s, const fp_t &r, unsigned prec)
-    {
-        return s.mullow(r, prec);
-    }
-    static fp_t pow(const fp_t &s, int n, unsigned prec);
-    static unsigned ldegree(const fp_t &s);
-    static inline fmpq_wrapper find_cf(const fp_t &s, const fp_t &var,
-                                        unsigned deg)
-    {
-        return s.get_coeff(deg);
-    }
-    static fmpq_wrapper root(fmpq_wrapper &c, unsigned n);
-    static fp_t diff(const fp_t &s, const fp_t &var);
-    static fp_t integrate(const fp_t &s, const fp_t &var);
-    static fp_t subs(const fp_t &s, const fp_t &var, const fp_t &r,
-                     unsigned prec);
+  static RCP<const URatPSeriesFlint>
+  series(const RCP<const Basic> &t, const std::string &x, unsigned int prec);
+  static fp_t var(const std::string &s);
+  static fp_t convert(const rational_class &x);
+  static fp_t convert(const Rational &x);
+  static fp_t convert(const Integer &x);
+  static fp_t convert(const Basic &x);
+  static inline fp_t mul(const fp_t &s, const fp_t &r, unsigned prec) {
+    return s.mullow(r, prec);
+  }
+  static fp_t pow(const fp_t &s, int n, unsigned prec);
+  static unsigned ldegree(const fp_t &s);
+  static inline fmpq_wrapper find_cf(const fp_t &s, const fp_t &var,
+                                     unsigned deg) {
+    return s.get_coeff(deg);
+  }
+  static fmpq_wrapper root(fmpq_wrapper &c, unsigned n);
+  static fp_t diff(const fp_t &s, const fp_t &var);
+  static fp_t integrate(const fp_t &s, const fp_t &var);
+  static fp_t subs(const fp_t &s, const fp_t &var, const fp_t &r,
+                   unsigned prec);
 
-    static inline fp_t series_invert(const fp_t &s, const fp_t &var,
-                                     unsigned int prec)
-    {
-        SYMENGINE_ASSERT(not s.get_coeff(0).is_zero());
-        return s.inv_series(prec);
+  static inline fp_t series_invert(const fp_t &s, const fp_t &var,
+                                   unsigned int prec) {
+    SYMENGINE_ASSERT(not s.get_coeff(0).is_zero());
+    return s.inv_series(prec);
+  }
+  static inline fp_t series_reverse(const fp_t &s, const fp_t &var,
+                                    unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero() and not s.get_coeff(1).is_zero());
+    return s.revert_series(prec);
+  }
+  static inline fp_t series_log(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_one());
+    return s.log_series(prec);
+  }
+  static inline fp_t series_exp(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.exp_series(prec);
+  }
+  static inline fp_t series_sin(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.sin_series(prec);
+  }
+
+  static inline fp_t series_cos(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.cos_series(prec);
+  }
+
+  static inline fp_t series_tan(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.tan_series(prec);
+  }
+  static inline fp_t series_atan(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.atan_series(prec);
+  }
+  static inline fp_t series_atanh(const fp_t &s, const fp_t &var,
+                                  unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.atanh_series(prec);
+  }
+  static inline fp_t series_asin(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.asin_series(prec);
+  }
+  static inline fp_t series_asinh(const fp_t &s, const fp_t &var,
+                                  unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.asinh_series(prec);
+  }
+  static inline fp_t series_acos(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    throw std::runtime_error("acos() not implemented");
+  }
+  static inline fp_t series_sinh(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.sinh_series(prec);
+  }
+  static inline fp_t series_cosh(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.cosh_series(prec);
+  }
+  static inline fp_t series_tanh(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.tanh_series(prec);
+  }
+  static inline fp_t series_lambertw(const fp_t &s, const fp_t &var,
+                                     unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+
+    fp_t p1;
+    p1.set_zero();
+
+    auto steps = step_list(prec);
+    for (const auto step : steps) {
+      const fp_t e(series_exp(p1, var, step));
+      const fp_t p2(mul(e, p1, step) - s);
+      const fp_t p3(series_invert(mul(e, fp_t(p1 + fp_t(1)), step), var, step));
+      p1 -= mul(p2, p3, step);
     }
-    static inline fp_t series_reverse(const fp_t &s, const fp_t &var,
-                                      unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero()
-                         and not s.get_coeff(1).is_zero());
-        return s.revert_series(prec);
+    return p1;
+  }
+
+  static inline fp_t series_nthroot(const fp_t &s, int n, const fp_t &var,
+                                    unsigned int prec) {
+    fp_t one;
+    one.set_one();
+    if (n == 0)
+      return one;
+    if (n == 1)
+      return s;
+    if (n == -1)
+      return series_invert(s, var, prec);
+
+    const short ldeg = ldegree(s);
+    if (ldeg % n != 0) {
+      throw std::runtime_error("Puiseux series not implemented.");
     }
-    static inline fp_t series_log(const fp_t &s, const fp_t &var,
-                                  unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_one());
-        return s.log_series(prec);
+    fp_t ss = s;
+    if (ldeg != 0) {
+      ss = s * pow(var, -ldeg, prec);
     }
-    static inline fp_t series_exp(const fp_t &s, const fp_t &var,
-                                  unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.exp_series(prec);
-    }
-    static inline fp_t series_sin(const fp_t &s, const fp_t &var,
-                                  unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.sin_series(prec);
+    fmpq_wrapper ct = find_cf(ss, var, 0);
+    bool do_inv = false;
+    if (n < 0) {
+      n = -n;
+      do_inv = true;
     }
 
-    static inline fp_t series_cos(const fp_t &s, const fp_t &var,
-                                  unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.cos_series(prec);
+    fmpq_wrapper ctroot = root(ct, n);
+    fp_t res_p = one, sn = fp_t(ss / ct);
+    auto steps = step_list(prec);
+    for (const auto step : steps) {
+      fp_t t = mul(pow(res_p, n + 1, step), sn, step);
+      res_p += (res_p - t) / n;
     }
-
-    static inline fp_t series_tan(const fp_t &s, const fp_t &var,
-                                  unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.tan_series(prec);
+    if (ldeg != 0) {
+      res_p *= pow(var, ldeg / n, prec);
     }
-    static inline fp_t series_atan(const fp_t &s, const fp_t &var,
-                                   unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.atan_series(prec);
-    }
-    static inline fp_t series_atanh(const fp_t &s, const fp_t &var,
-                                    unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.atanh_series(prec);
-    }
-    static inline fp_t series_asin(const fp_t &s, const fp_t &var,
-                                   unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.asin_series(prec);
-    }
-    static inline fp_t series_asinh(const fp_t &s, const fp_t &var,
-                                    unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.asinh_series(prec);
-    }
-    static inline fp_t series_acos(const fp_t &s, const fp_t &var,
-                                   unsigned int prec)
-    {
-        throw std::runtime_error("acos() not implemented");
-    }
-    static inline fp_t series_sinh(const fp_t &s, const fp_t &var,
-                                   unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.sinh_series(prec);
-    }
-    static inline fp_t series_cosh(const fp_t &s, const fp_t &var,
-                                   unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.cosh_series(prec);
-    }
-    static inline fp_t series_tanh(const fp_t &s, const fp_t &var,
-                                   unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.tanh_series(prec);
-    }
-    static inline fp_t series_lambertw(const fp_t &s, const fp_t &var,
-                                       unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-
-        fp_t p1;
-        p1.set_zero();
-
-        auto steps = step_list(prec);
-        for (const auto step : steps) {
-            const fp_t e(series_exp(p1, var, step));
-            const fp_t p2(mul(e, p1, step) - s);
-            const fp_t p3(
-                series_invert(mul(e, fp_t(p1 + fp_t(1)), step), var, step));
-            p1 -= mul(p2, p3, step);
-        }
-        return p1;
-    }
-
-    static inline fp_t series_nthroot(const fp_t &s, int n, const fp_t &var,
-                                      unsigned int prec)
-    {
-        fp_t one;
-        one.set_one();
-        if (n == 0)
-            return one;
-        if (n == 1)
-            return s;
-        if (n == -1)
-            return series_invert(s, var, prec);
-
-        const short ldeg = ldegree(s);
-        if (ldeg % n != 0) {
-            throw std::runtime_error("Puiseux series not implemented.");
-        }
-        fp_t ss = s;
-        if (ldeg != 0) {
-            ss = s * pow(var, -ldeg, prec);
-        }
-        fmpq_wrapper ct = find_cf(ss, var, 0);
-        bool do_inv = false;
-        if (n < 0) {
-            n = -n;
-            do_inv = true;
-        }
-
-        fmpq_wrapper ctroot = root(ct, n);
-        fp_t res_p = one, sn = fp_t(ss / ct);
-        auto steps = step_list(prec);
-        for (const auto step : steps) {
-            fp_t t = mul(pow(res_p, n + 1, step), sn, step);
-            res_p += (res_p - t) / n;
-        }
-        if (ldeg != 0) {
-            res_p *= pow(var, ldeg / n, prec);
-        }
-        if (do_inv)
-            return fp_t(res_p * ctroot);
-        else
-            return fp_t(series_invert(res_p, var, prec) * ctroot);
-    }
+    if (do_inv)
+      return fp_t(res_p * ctroot);
+    else
+      return fp_t(series_invert(res_p, var, prec) * ctroot);
+  }
 };
 } // SymEngine
 

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -12,8 +12,7 @@ namespace SymEngine
 
 using fp_t = fmpq_poly_wrapper;
 // Univariate Rational Coefficient Power SeriesBase using Flint
-class URatPSeriesFlint
-    : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint>
+class URatPSeriesFlint : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint>
 {
 public:
     URatPSeriesFlint(const fp_t p, const std::string varname,
@@ -39,7 +38,7 @@ public:
     static fp_t pow(const fp_t &s, int n, unsigned prec);
     static unsigned ldegree(const fp_t &s);
     static inline fmpq_wrapper find_cf(const fp_t &s, const fp_t &var,
-                                        unsigned deg)
+                                       unsigned deg)
     {
         return s.get_coeff(deg);
     }

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -14,171 +14,190 @@ using fp_t = fmpq_poly_wrapper;
 class URatPSeriesFlint
     : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint> {
 public:
-  URatPSeriesFlint(const fp_t p, const std::string varname,
-                   const unsigned degree);
-  IMPLEMENT_TYPEID(URATPSERIESFLINT)
-  virtual int compare(const Basic &o) const;
-  virtual std::size_t __hash__() const;
-  virtual RCP<const Basic> as_basic() const;
-  virtual umap_int_basic as_dict() const;
-  virtual RCP<const Basic> get_coeff(int) const;
+    URatPSeriesFlint(const fp_t p, const std::string varname,
+        const unsigned degree);
+    IMPLEMENT_TYPEID(URATPSERIESFLINT)
+    virtual int compare(const Basic& o) const;
+    virtual std::size_t __hash__() const;
+    virtual RCP<const Basic> as_basic() const;
+    virtual umap_int_basic as_dict() const;
+    virtual RCP<const Basic> get_coeff(int) const;
 
-  static RCP<const URatPSeriesFlint>
-  series(const RCP<const Basic> &t, const std::string &x, unsigned int prec);
-  static fp_t var(const std::string &s);
-  static fp_t convert(const rational_class &x);
-  static fp_t convert(const Rational &x);
-  static fp_t convert(const Integer &x);
-  static fp_t convert(const Basic &x);
-  static inline fp_t mul(const fp_t &s, const fp_t &r, unsigned prec) {
-    return s.mullow(r, prec);
-  }
-  static fp_t pow(const fp_t &s, int n, unsigned prec);
-  static unsigned ldegree(const fp_t &s);
-  static inline fmpq_wrapper find_cf(const fp_t &s, const fp_t &var,
-                                     unsigned deg) {
-    return s.get_coeff(deg);
-  }
-  static fmpq_wrapper root(fmpq_wrapper &c, unsigned n);
-  static fp_t diff(const fp_t &s, const fp_t &var);
-  static fp_t integrate(const fp_t &s, const fp_t &var);
-  static fp_t subs(const fp_t &s, const fp_t &var, const fp_t &r,
-                   unsigned prec);
-
-  static inline fp_t series_invert(const fp_t &s, const fp_t &var,
-                                   unsigned int prec) {
-    SYMENGINE_ASSERT(not s.get_coeff(0).is_zero());
-    return s.inv_series(prec);
-  }
-  static inline fp_t series_reverse(const fp_t &s, const fp_t &var,
-                                    unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero() and not s.get_coeff(1).is_zero());
-    return s.revert_series(prec);
-  }
-  static inline fp_t series_log(const fp_t &s, const fp_t &var,
-                                unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_one());
-    return s.log_series(prec);
-  }
-  static inline fp_t series_exp(const fp_t &s, const fp_t &var,
-                                unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.exp_series(prec);
-  }
-  static inline fp_t series_sin(const fp_t &s, const fp_t &var,
-                                unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.sin_series(prec);
-  }
-
-  static inline fp_t series_cos(const fp_t &s, const fp_t &var,
-                                unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.cos_series(prec);
-  }
-
-  static inline fp_t series_tan(const fp_t &s, const fp_t &var,
-                                unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.tan_series(prec);
-  }
-  static inline fp_t series_atan(const fp_t &s, const fp_t &var,
-                                 unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.atan_series(prec);
-  }
-  static inline fp_t series_atanh(const fp_t &s, const fp_t &var,
-                                  unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.atanh_series(prec);
-  }
-  static inline fp_t series_asin(const fp_t &s, const fp_t &var,
-                                 unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.asin_series(prec);
-  }
-  static inline fp_t series_asinh(const fp_t &s, const fp_t &var,
-                                  unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.asinh_series(prec);
-  }
-  static inline fp_t series_acos(const fp_t &s, const fp_t &var,
-                                 unsigned int prec) {
-    throw std::runtime_error("acos() not implemented");
-  }
-  static inline fp_t series_sinh(const fp_t &s, const fp_t &var,
-                                 unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.sinh_series(prec);
-  }
-  static inline fp_t series_cosh(const fp_t &s, const fp_t &var,
-                                 unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.cosh_series(prec);
-  }
-  static inline fp_t series_tanh(const fp_t &s, const fp_t &var,
-                                 unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-    return s.tanh_series(prec);
-  }
-  static inline fp_t series_lambertw(const fp_t &s, const fp_t &var,
-                                     unsigned int prec) {
-    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-
-    fp_t p1;
-    p1.set_zero();
-
-    auto steps = step_list(prec);
-    for (const auto step : steps) {
-      const fp_t e(series_exp(p1, var, step));
-      const fp_t p2(mul(e, p1, step) - s);
-      const fp_t p3(series_invert(mul(e, fp_t(p1 + fp_t(1)), step), var, step));
-      p1 -= mul(p2, p3, step);
+    static RCP<const URatPSeriesFlint>
+    series(const RCP<const Basic>& t, const std::string& x, unsigned int prec);
+    static fp_t var(const std::string& s);
+    static fp_t convert(const rational_class& x);
+    static fp_t convert(const Rational& x);
+    static fp_t convert(const Integer& x);
+    static fp_t convert(const Basic& x);
+    static inline fp_t mul(const fp_t& s, const fp_t& r, unsigned prec)
+    {
+        return s.mullow(r, prec);
     }
-    return p1;
-  }
-
-  static inline fp_t series_nthroot(const fp_t &s, int n, const fp_t &var,
-                                    unsigned int prec) {
-    fp_t one;
-    one.set_one();
-    if (n == 0)
-      return one;
-    if (n == 1)
-      return s;
-    if (n == -1)
-      return series_invert(s, var, prec);
-
-    const short ldeg = ldegree(s);
-    if (ldeg % n != 0) {
-      throw std::runtime_error("Puiseux series not implemented.");
+    static fp_t pow(const fp_t& s, int n, unsigned prec);
+    static unsigned ldegree(const fp_t& s);
+    static inline fmpq_wrapper find_cf(const fp_t& s, const fp_t& var,
+        unsigned deg)
+    {
+        return s.get_coeff(deg);
     }
-    fp_t ss = s;
-    if (ldeg != 0) {
-      ss = s * pow(var, -ldeg, prec);
+    static fmpq_wrapper root(fmpq_wrapper& c, unsigned n);
+    static fp_t diff(const fp_t& s, const fp_t& var);
+    static fp_t integrate(const fp_t& s, const fp_t& var);
+    static fp_t subs(const fp_t& s, const fp_t& var, const fp_t& r,
+        unsigned prec);
+
+    static inline fp_t series_invert(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(not s.get_coeff(0).is_zero());
+        return s.inv_series(prec);
     }
-    fmpq_wrapper ct = find_cf(ss, var, 0);
-    bool do_inv = false;
-    if (n < 0) {
-      n = -n;
-      do_inv = true;
+    static inline fp_t series_reverse(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero() and not s.get_coeff(1).is_zero());
+        return s.revert_series(prec);
+    }
+    static inline fp_t series_log(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_one());
+        return s.log_series(prec);
+    }
+    static inline fp_t series_exp(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.exp_series(prec);
+    }
+    static inline fp_t series_sin(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.sin_series(prec);
     }
 
-    fmpq_wrapper ctroot = root(ct, n);
-    fp_t res_p = one, sn = fp_t(ss / ct);
-    auto steps = step_list(prec);
-    for (const auto step : steps) {
-      fp_t t = mul(pow(res_p, n + 1, step), sn, step);
-      res_p += (res_p - t) / n;
+    static inline fp_t series_cos(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.cos_series(prec);
     }
-    if (ldeg != 0) {
-      res_p *= pow(var, ldeg / n, prec);
+
+    static inline fp_t series_tan(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.tan_series(prec);
     }
-    if (do_inv)
-      return fp_t(res_p * ctroot);
-    else
-      return fp_t(series_invert(res_p, var, prec) * ctroot);
-  }
+    static inline fp_t series_atan(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.atan_series(prec);
+    }
+    static inline fp_t series_atanh(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.atanh_series(prec);
+    }
+    static inline fp_t series_asin(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.asin_series(prec);
+    }
+    static inline fp_t series_asinh(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.asinh_series(prec);
+    }
+    static inline fp_t series_acos(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        throw std::runtime_error("acos() not implemented");
+    }
+    static inline fp_t series_sinh(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.sinh_series(prec);
+    }
+    static inline fp_t series_cosh(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.cosh_series(prec);
+    }
+    static inline fp_t series_tanh(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+        return s.tanh_series(prec);
+    }
+    static inline fp_t series_lambertw(const fp_t& s, const fp_t& var,
+        unsigned int prec)
+    {
+        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+
+        fp_t p1;
+        p1.set_zero();
+
+        auto steps = step_list(prec);
+        for (const auto step : steps) {
+            const fp_t e(series_exp(p1, var, step));
+            const fp_t p2(mul(e, p1, step) - s);
+            const fp_t p3(series_invert(mul(e, fp_t(p1 + fp_t(1)), step), var, step));
+            p1 -= mul(p2, p3, step);
+        }
+        return p1;
+    }
+
+    static inline fp_t series_nthroot(const fp_t& s, int n, const fp_t& var,
+        unsigned int prec)
+    {
+        fp_t one;
+        one.set_one();
+        if (n == 0)
+            return one;
+        if (n == 1)
+            return s;
+        if (n == -1)
+            return series_invert(s, var, prec);
+
+        const short ldeg = ldegree(s);
+        if (ldeg % n != 0) {
+            throw std::runtime_error("Puiseux series not implemented.");
+        }
+        fp_t ss = s;
+        if (ldeg != 0) {
+            ss = s * pow(var, -ldeg, prec);
+        }
+        fmpq_wrapper ct = find_cf(ss, var, 0);
+        bool do_inv = false;
+        if (n < 0) {
+            n = -n;
+            do_inv = true;
+        }
+
+        fmpq_wrapper ctroot = root(ct, n);
+        fp_t res_p = one, sn = fp_t(ss / ct);
+        auto steps = step_list(prec);
+        for (const auto step : steps) {
+            fp_t t = mul(pow(res_p, n + 1, step), sn, step);
+            res_p += (res_p - t) / n;
+        }
+        if (ldeg != 0) {
+            res_p *= pow(var, ldeg / n, prec);
+        }
+        if (do_inv)
+            return fp_t(res_p * ctroot);
+        else
+            return fp_t(series_invert(res_p, var, prec) * ctroot);
+    }
 };
 } // SymEngine
 

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -14,190 +14,171 @@ using fp_t = fmpq_poly_wrapper;
 class URatPSeriesFlint
     : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint> {
 public:
-    URatPSeriesFlint(const fp_t p, const std::string varname,
-        const unsigned degree);
-    IMPLEMENT_TYPEID(URATPSERIESFLINT)
-    virtual int compare(const Basic& o) const;
-    virtual std::size_t __hash__() const;
-    virtual RCP<const Basic> as_basic() const;
-    virtual umap_int_basic as_dict() const;
-    virtual RCP<const Basic> get_coeff(int) const;
+  URatPSeriesFlint(const fp_t p, const std::string varname,
+                   const unsigned degree);
+  IMPLEMENT_TYPEID(URATPSERIESFLINT)
+  virtual int compare(const Basic &o) const;
+  virtual std::size_t __hash__() const;
+  virtual RCP<const Basic> as_basic() const;
+  virtual umap_int_basic as_dict() const;
+  virtual RCP<const Basic> get_coeff(int) const;
 
-    static RCP<const URatPSeriesFlint>
-    series(const RCP<const Basic>& t, const std::string& x, unsigned int prec);
-    static fp_t var(const std::string& s);
-    static fp_t convert(const rational_class& x);
-    static fp_t convert(const Rational& x);
-    static fp_t convert(const Integer& x);
-    static fp_t convert(const Basic& x);
-    static inline fp_t mul(const fp_t& s, const fp_t& r, unsigned prec)
-    {
-        return s.mullow(r, prec);
-    }
-    static fp_t pow(const fp_t& s, int n, unsigned prec);
-    static unsigned ldegree(const fp_t& s);
-    static inline fmpq_wrapper find_cf(const fp_t& s, const fp_t& var,
-        unsigned deg)
-    {
-        return s.get_coeff(deg);
-    }
-    static fmpq_wrapper root(fmpq_wrapper& c, unsigned n);
-    static fp_t diff(const fp_t& s, const fp_t& var);
-    static fp_t integrate(const fp_t& s, const fp_t& var);
-    static fp_t subs(const fp_t& s, const fp_t& var, const fp_t& r,
-        unsigned prec);
+  static RCP<const URatPSeriesFlint>
+  series(const RCP<const Basic> &t, const std::string &x, unsigned int prec);
+  static fp_t var(const std::string &s);
+  static fp_t convert(const rational_class &x);
+  static fp_t convert(const Rational &x);
+  static fp_t convert(const Integer &x);
+  static fp_t convert(const Basic &x);
+  static inline fp_t mul(const fp_t &s, const fp_t &r, unsigned prec) {
+    return s.mullow(r, prec);
+  }
+  static fp_t pow(const fp_t &s, int n, unsigned prec);
+  static unsigned ldegree(const fp_t &s);
+  static inline fmpq_wrapper find_cf(const fp_t &s, const fp_t &var,
+                                     unsigned deg) {
+    return s.get_coeff(deg);
+  }
+  static fmpq_wrapper root(fmpq_wrapper &c, unsigned n);
+  static fp_t diff(const fp_t &s, const fp_t &var);
+  static fp_t integrate(const fp_t &s, const fp_t &var);
+  static fp_t subs(const fp_t &s, const fp_t &var, const fp_t &r,
+                   unsigned prec);
 
-    static inline fp_t series_invert(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(not s.get_coeff(0).is_zero());
-        return s.inv_series(prec);
+  static inline fp_t series_invert(const fp_t &s, const fp_t &var,
+                                   unsigned int prec) {
+    SYMENGINE_ASSERT(not s.get_coeff(0).is_zero());
+    return s.inv_series(prec);
+  }
+  static inline fp_t series_reverse(const fp_t &s, const fp_t &var,
+                                    unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero() and not s.get_coeff(1).is_zero());
+    return s.revert_series(prec);
+  }
+  static inline fp_t series_log(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_one());
+    return s.log_series(prec);
+  }
+  static inline fp_t series_exp(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.exp_series(prec);
+  }
+  static inline fp_t series_sin(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.sin_series(prec);
+  }
+
+  static inline fp_t series_cos(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.cos_series(prec);
+  }
+
+  static inline fp_t series_tan(const fp_t &s, const fp_t &var,
+                                unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.tan_series(prec);
+  }
+  static inline fp_t series_atan(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.atan_series(prec);
+  }
+  static inline fp_t series_atanh(const fp_t &s, const fp_t &var,
+                                  unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.atanh_series(prec);
+  }
+  static inline fp_t series_asin(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.asin_series(prec);
+  }
+  static inline fp_t series_asinh(const fp_t &s, const fp_t &var,
+                                  unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.asinh_series(prec);
+  }
+  static inline fp_t series_acos(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    throw std::runtime_error("acos() not implemented");
+  }
+  static inline fp_t series_sinh(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.sinh_series(prec);
+  }
+  static inline fp_t series_cosh(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.cosh_series(prec);
+  }
+  static inline fp_t series_tanh(const fp_t &s, const fp_t &var,
+                                 unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+    return s.tanh_series(prec);
+  }
+  static inline fp_t series_lambertw(const fp_t &s, const fp_t &var,
+                                     unsigned int prec) {
+    SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
+
+    fp_t p1;
+    p1.set_zero();
+
+    auto steps = step_list(prec);
+    for (const auto step : steps) {
+      const fp_t e(series_exp(p1, var, step));
+      const fp_t p2(mul(e, p1, step) - s);
+      const fp_t p3(series_invert(mul(e, fp_t(p1 + fp_t(1)), step), var, step));
+      p1 -= mul(p2, p3, step);
     }
-    static inline fp_t series_reverse(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero() and not s.get_coeff(1).is_zero());
-        return s.revert_series(prec);
+    return p1;
+  }
+
+  static inline fp_t series_nthroot(const fp_t &s, int n, const fp_t &var,
+                                    unsigned int prec) {
+    fp_t one;
+    one.set_one();
+    if (n == 0)
+      return one;
+    if (n == 1)
+      return s;
+    if (n == -1)
+      return series_invert(s, var, prec);
+
+    const short ldeg = ldegree(s);
+    if (ldeg % n != 0) {
+      throw std::runtime_error("Puiseux series not implemented.");
     }
-    static inline fp_t series_log(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_one());
-        return s.log_series(prec);
+    fp_t ss = s;
+    if (ldeg != 0) {
+      ss = s * pow(var, -ldeg, prec);
     }
-    static inline fp_t series_exp(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.exp_series(prec);
-    }
-    static inline fp_t series_sin(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.sin_series(prec);
+    fmpq_wrapper ct = find_cf(ss, var, 0);
+    bool do_inv = false;
+    if (n < 0) {
+      n = -n;
+      do_inv = true;
     }
 
-    static inline fp_t series_cos(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.cos_series(prec);
+    fmpq_wrapper ctroot = root(ct, n);
+    fp_t res_p = one, sn = fp_t(ss / ct);
+    auto steps = step_list(prec);
+    for (const auto step : steps) {
+      fp_t t = mul(pow(res_p, n + 1, step), sn, step);
+      res_p += (res_p - t) / n;
     }
-
-    static inline fp_t series_tan(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.tan_series(prec);
+    if (ldeg != 0) {
+      res_p *= pow(var, ldeg / n, prec);
     }
-    static inline fp_t series_atan(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.atan_series(prec);
-    }
-    static inline fp_t series_atanh(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.atanh_series(prec);
-    }
-    static inline fp_t series_asin(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.asin_series(prec);
-    }
-    static inline fp_t series_asinh(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.asinh_series(prec);
-    }
-    static inline fp_t series_acos(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        throw std::runtime_error("acos() not implemented");
-    }
-    static inline fp_t series_sinh(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.sinh_series(prec);
-    }
-    static inline fp_t series_cosh(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.cosh_series(prec);
-    }
-    static inline fp_t series_tanh(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-        return s.tanh_series(prec);
-    }
-    static inline fp_t series_lambertw(const fp_t& s, const fp_t& var,
-        unsigned int prec)
-    {
-        SYMENGINE_ASSERT(s.get_coeff(0).is_zero());
-
-        fp_t p1;
-        p1.set_zero();
-
-        auto steps = step_list(prec);
-        for (const auto step : steps) {
-            const fp_t e(series_exp(p1, var, step));
-            const fp_t p2(mul(e, p1, step) - s);
-            const fp_t p3(series_invert(mul(e, fp_t(p1 + fp_t(1)), step), var, step));
-            p1 -= mul(p2, p3, step);
-        }
-        return p1;
-    }
-
-    static inline fp_t series_nthroot(const fp_t& s, int n, const fp_t& var,
-        unsigned int prec)
-    {
-        fp_t one;
-        one.set_one();
-        if (n == 0)
-            return one;
-        if (n == 1)
-            return s;
-        if (n == -1)
-            return series_invert(s, var, prec);
-
-        const short ldeg = ldegree(s);
-        if (ldeg % n != 0) {
-            throw std::runtime_error("Puiseux series not implemented.");
-        }
-        fp_t ss = s;
-        if (ldeg != 0) {
-            ss = s * pow(var, -ldeg, prec);
-        }
-        fmpq_wrapper ct = find_cf(ss, var, 0);
-        bool do_inv = false;
-        if (n < 0) {
-            n = -n;
-            do_inv = true;
-        }
-
-        fmpq_wrapper ctroot = root(ct, n);
-        fp_t res_p = one, sn = fp_t(ss / ct);
-        auto steps = step_list(prec);
-        for (const auto step : steps) {
-            fp_t t = mul(pow(res_p, n + 1, step), sn, step);
-            res_p += (res_p - t) / n;
-        }
-        if (ldeg != 0) {
-            res_p *= pow(var, ldeg / n, prec);
-        }
-        if (do_inv)
-            return fp_t(res_p * ctroot);
-        else
-            return fp_t(series_invert(res_p, var, prec) * ctroot);
-    }
+    if (do_inv)
+      return fp_t(res_p * ctroot);
+    else
+      return fp_t(series_invert(res_p, var, prec) * ctroot);
+  }
 };
 } // SymEngine
 

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -12,7 +12,8 @@ namespace SymEngine
 
 using fp_t = fmpq_poly_wrapper;
 // Univariate Rational Coefficient Power SeriesBase using Flint
-class URatPSeriesFlint : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint>
+class URatPSeriesFlint
+    : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint>
 {
 public:
     URatPSeriesFlint(const fp_t p, const std::string varname,
@@ -38,7 +39,7 @@ public:
     static fp_t pow(const fp_t &s, int n, unsigned prec);
     static unsigned ldegree(const fp_t &s);
     static inline fmpq_wrapper find_cf(const fp_t &s, const fp_t &var,
-                                       unsigned deg)
+                                        unsigned deg)
     {
         return s.get_coeff(deg);
     }

--- a/symengine/tests/basic/test_series_expansion_URatF.cpp
+++ b/symengine/tests/basic/test_series_expansion_URatF.cpp
@@ -27,7 +27,7 @@ using SymEngine::fmpq_wrapper;
     SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC)             \
         ->get_coeff(COEFF)
 
-static RCP<const Number> fmpqxx2sym(const fmpq_wrapper& fc)
+static RCP<const Number> fmpqxx2sym(const fmpq_wrapper &fc)
 {
     mpq_t gc;
     mpq_init(gc);

--- a/symengine/tests/basic/test_series_expansion_URatF.cpp
+++ b/symengine/tests/basic/test_series_expansion_URatF.cpp
@@ -27,7 +27,7 @@ using SymEngine::fmpq_wrapper;
     SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC)             \
         ->get_coeff(COEFF)
 
-static RCP<const Number> fmpqxx2sym(const fmpq_wrapper &fc)
+static RCP<const Number> fmpqxx2sym(const fmpq_wrapper& fc)
 {
     mpq_t gc;
     mpq_init(gc);

--- a/symengine/tests/basic/test_series_expansion_URatF.cpp
+++ b/symengine/tests/basic/test_series_expansion_URatF.cpp
@@ -23,223 +23,233 @@ using SymEngine::umap_short_basic;
 using SymEngine::URatPSeriesFlint;
 using SymEngine::fp_t;
 using SymEngine::fmpq_wrapper;
-#define series_coeff(EX, SYM, PREC, COEFF)                                     \
-  SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC)               \
-      ->get_coeff(COEFF)
+#define series_coeff(EX, SYM, PREC, COEFF)                         \
+    SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC) \
+        ->get_coeff(COEFF)
 
-static RCP<const Number> fmpqxx2sym(const fmpq_wrapper &fc) {
-  mpq_t gc;
-  mpq_init(gc);
-  fmpq_get_mpq(gc, fc.get_fmpq_t());
-  rational_class r(gc);
-  mpq_clear(gc);
-  return Rational::from_mpq(std::move(r));
+static RCP<const Number> fmpqxx2sym(const fmpq_wrapper& fc)
+{
+    mpq_t gc;
+    mpq_init(gc);
+    fmpq_get_mpq(gc, fc.get_fmpq_t());
+    rational_class r(gc);
+    mpq_clear(gc);
+    return Rational::from_mpq(std::move(r));
 }
 
-static RCP<const Number> invseries_coeff(const RCP<const Basic> &ex,
-                                         const RCP<const Symbol> &sym,
-                                         unsigned int prec, int n) {
-  auto ser = URatPSeriesFlint::series(ex, sym->get_name(), prec);
-  auto serrev = URatPSeriesFlint::series_reverse(
-      ser->get_poly(), fp_t(sym->get_name().c_str()), prec);
-  return fmpqxx2sym(serrev.get_coeff(n));
+static RCP<const Number> invseries_coeff(const RCP<const Basic>& ex,
+    const RCP<const Symbol>& sym,
+    unsigned int prec, int n)
+{
+    auto ser = URatPSeriesFlint::series(ex, sym->get_name(), prec);
+    auto serrev = URatPSeriesFlint::series_reverse(
+        ser->get_poly(), fp_t(sym->get_name().c_str()), prec);
+    return fmpqxx2sym(serrev.get_coeff(n));
 }
 
-static bool expand_check_pairs(const RCP<const Basic> &ex,
-                               const RCP<const Symbol> &x, int prec,
-                               const umap_short_basic &pairs) {
-  auto ser = SymEngine::URatPSeriesFlint::series(ex, x->get_name(), prec);
-  for (auto it : pairs) {
-    // std::cerr << it.first << ", " << *(it.second) << "::" <<
-    // *(v1.at(it.first)) << std::endl;
-    if (not it.second->__eq__(*(ser->get_coeff(it.first))))
-      return false;
-  }
-  return true;
+static bool expand_check_pairs(const RCP<const Basic>& ex,
+    const RCP<const Symbol>& x, int prec,
+    const umap_short_basic& pairs)
+{
+    auto ser = SymEngine::URatPSeriesFlint::series(ex, x->get_name(), prec);
+    for (auto it : pairs) {
+        // std::cerr << it.first << ", " << *(it.second) << "::" <<
+        // *(v1.at(it.first)) << std::endl;
+        if (not it.second->__eq__(*(ser->get_coeff(it.first))))
+            return false;
+    }
+    return true;
 }
 
-TEST_CASE("Expression series expansion: Add ", "[Expansion of Add]") {
-  RCP<const Symbol> x = symbol("x"), y = symbol("y");
-  auto z = add(integer(1), x);
-  z = sub(z, pow(x, integer(2)));
-  z = add(z, pow(x, integer(4)));
-  auto z1 = pow(add(integer(1), x), integer(0));
+TEST_CASE("Expression series expansion: Add ", "[Expansion of Add]")
+{
+    RCP<const Symbol> x = symbol("x"), y = symbol("y");
+    auto z = add(integer(1), x);
+    z = sub(z, pow(x, integer(2)));
+    z = add(z, pow(x, integer(4)));
+    auto z1 = pow(add(integer(1), x), integer(0));
 
-  auto vb = umap_short_basic{
-      {0, integer(1)}, {1, integer(1)}, {2, integer(-1)}, {4, integer(1)}};
-  REQUIRE(expand_check_pairs(z, x, 5, vb));
-  auto vb1 =
-      umap_short_basic{{0, integer(1)}, {1, integer(1)}, {2, integer(-1)}};
-  REQUIRE(expand_check_pairs(z, x, 3, vb1));
-  REQUIRE(series_coeff(z1, x, 9, 0)->__eq__(*integer(1)));
-  REQUIRE(series_coeff(z1, x, 9, 1)->__eq__(*integer(0)));
+    auto vb = umap_short_basic{
+        { 0, integer(1) }, { 1, integer(1) }, { 2, integer(-1) }, { 4, integer(1) }
+    };
+    REQUIRE(expand_check_pairs(z, x, 5, vb));
+    auto vb1 = umap_short_basic{ { 0, integer(1) }, { 1, integer(1) }, { 2, integer(-1) } };
+    REQUIRE(expand_check_pairs(z, x, 3, vb1));
+    REQUIRE(series_coeff(z1, x, 9, 0)->__eq__(*integer(1)));
+    REQUIRE(series_coeff(z1, x, 9, 1)->__eq__(*integer(0)));
 }
 
-TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]") {
-  RCP<const Symbol> x = symbol("x");
-  RCP<const Integer> one = integer(1);
-  auto z1 = sin(x);
-  auto z2 = cos(x);
-  auto z3 = add(sin(x), cos(x));
-  auto z4 = mul(sin(x), cos(x));
-  auto z5 = sin(atan(x));
-  auto z6 = cos(div(x, sub(one, x)));
+TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    auto z1 = sin(x);
+    auto z2 = cos(x);
+    auto z3 = add(sin(x), cos(x));
+    auto z4 = mul(sin(x), cos(x));
+    auto z5 = sin(atan(x));
+    auto z6 = cos(div(x, sub(one, x)));
 
-  REQUIRE(series_coeff(z1, x, 10, 9)->__eq__(*rational(1, 362880)));
-  auto res = umap_short_basic{{0, integer(1)}, {2, rational(-1, 2)}};
-  REQUIRE(expand_check_pairs(z2, x, 3, res));
-  REQUIRE(series_coeff(z3, x, 9, 8)->__eq__(*rational(1, 40320)));
-  REQUIRE(series_coeff(z4, x, 12, 11)->__eq__(*rational(-4, 155925)));
-  REQUIRE(series_coeff(z5, x, 30, 27)->__eq__(*rational(-1300075, 8388608)));
-  REQUIRE(series_coeff(z6, x, 15, 11)->__eq__(*rational(-125929, 362880)));
+    REQUIRE(series_coeff(z1, x, 10, 9)->__eq__(*rational(1, 362880)));
+    auto res = umap_short_basic{ { 0, integer(1) }, { 2, rational(-1, 2) } };
+    REQUIRE(expand_check_pairs(z2, x, 3, res));
+    REQUIRE(series_coeff(z3, x, 9, 8)->__eq__(*rational(1, 40320)));
+    REQUIRE(series_coeff(z4, x, 12, 11)->__eq__(*rational(-4, 155925)));
+    REQUIRE(series_coeff(z5, x, 30, 27)->__eq__(*rational(-1300075, 8388608)));
+    REQUIRE(series_coeff(z6, x, 15, 11)->__eq__(*rational(-125929, 362880)));
 }
 
 TEST_CASE("Expression series expansion: division, inversion ",
-          "[Expansion of 1/ex]") {
-  RCP<const Symbol> x = symbol("x");
-  RCP<const Integer> one = integer(1);
-  RCP<const Integer> two = integer(2);
-  RCP<const Integer> three = integer(3);
-  auto ex1 = div(one, sub(one, x));                 // 1/(1-x)
-  auto ex2 = div(x, sub(sub(one, x), pow(x, two))); // x/(1-x-x^2)
-  auto ex3 =
-      div(pow(x, three), sub(one, mul(pow(x, two), two))); // x^3/(1-2x^2)
-  auto ex4 = div(one, sub(one, sin(x)));                   // 1/(1-sin(x))
-  auto ex5 = div(one, x);
-  auto ex6 = div(one, mul(x, sub(one, x)));
-  auto res1 = umap_short_basic{{-1, integer(1)}};
-  auto res2 = umap_short_basic{{-1, integer(1)}, {0, integer(1)}};
+    "[Expansion of 1/ex]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    RCP<const Integer> two = integer(2);
+    RCP<const Integer> three = integer(3);
+    auto ex1 = div(one, sub(one, x)); // 1/(1-x)
+    auto ex2 = div(x, sub(sub(one, x), pow(x, two))); // x/(1-x-x^2)
+    auto ex3 = div(pow(x, three), sub(one, mul(pow(x, two), two))); // x^3/(1-2x^2)
+    auto ex4 = div(one, sub(one, sin(x))); // 1/(1-sin(x))
+    auto ex5 = div(one, x);
+    auto ex6 = div(one, mul(x, sub(one, x)));
+    auto res1 = umap_short_basic{ { -1, integer(1) } };
+    auto res2 = umap_short_basic{ { -1, integer(1) }, { 0, integer(1) } };
 
-  REQUIRE(series_coeff(ex1, x, 100, 99)->__eq__(*integer(1)));
-  REQUIRE(series_coeff(ex2, x, 100, 35)->__eq__(*integer(9227465)));
-  REQUIRE(series_coeff(ex3, x, 100, 49)->__eq__(*integer(8388608)));
-  REQUIRE(series_coeff(ex4, x, 20, 10)->__eq__(*rational(1382, 14175)));
-  //! TODO: REQUIRE(expand_check_pairs(ex5, x, 8, res1));
-  //! TODO: REQUIRE(expand_check_pairs(ex6, x, 8, res2));
+    REQUIRE(series_coeff(ex1, x, 100, 99)->__eq__(*integer(1)));
+    REQUIRE(series_coeff(ex2, x, 100, 35)->__eq__(*integer(9227465)));
+    REQUIRE(series_coeff(ex3, x, 100, 49)->__eq__(*integer(8388608)));
+    REQUIRE(series_coeff(ex4, x, 20, 10)->__eq__(*rational(1382, 14175)));
+    //! TODO: REQUIRE(expand_check_pairs(ex5, x, 8, res1));
+    //! TODO: REQUIRE(expand_check_pairs(ex6, x, 8, res2));
 }
 
-TEST_CASE("Expression series expansion: roots", "[Expansion of root(ex)]") {
-  RCP<const Symbol> x = symbol("x");
-  RCP<const Number> q12 = rational(1, 2);
-  RCP<const Number> qm23 = rational(-2, 3);
-  RCP<const Integer> one = integer(1);
-  RCP<const Integer> four = integer(4);
-  auto ex1 = pow(sub(four, x), q12);
-  auto ex2 = pow(sub(one, x), qm23);
-  auto ex3 = sqrt(sub(one, x));
-  auto ex4 = pow(cos(x), q12);
-  auto ex5 = pow(cos(x), qm23);
-  auto ex6 = sqrt(cos(x));
+TEST_CASE("Expression series expansion: roots", "[Expansion of root(ex)]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Number> q12 = rational(1, 2);
+    RCP<const Number> qm23 = rational(-2, 3);
+    RCP<const Integer> one = integer(1);
+    RCP<const Integer> four = integer(4);
+    auto ex1 = pow(sub(four, x), q12);
+    auto ex2 = pow(sub(one, x), qm23);
+    auto ex3 = sqrt(sub(one, x));
+    auto ex4 = pow(cos(x), q12);
+    auto ex5 = pow(cos(x), qm23);
+    auto ex6 = sqrt(cos(x));
 
-  REQUIRE(series_coeff(ex1, x, 8, 6)->__eq__(*rational(-21, 2097152)));
-  REQUIRE(series_coeff(ex2, x, 12, 10)->__eq__(*rational(1621477, 4782969)));
-  REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(-2431, 262144)));
-  REQUIRE(series_coeff(ex4, x, 100, 8)->__eq__(*rational(-559, 645120)));
-  REQUIRE(series_coeff(ex5, x, 20, 10)->__eq__(*rational(701, 127575)));
-  REQUIRE(series_coeff(ex6, x, 10, 8)->__eq__(*rational(-559, 645120)));
+    REQUIRE(series_coeff(ex1, x, 8, 6)->__eq__(*rational(-21, 2097152)));
+    REQUIRE(series_coeff(ex2, x, 12, 10)->__eq__(*rational(1621477, 4782969)));
+    REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(-2431, 262144)));
+    REQUIRE(series_coeff(ex4, x, 100, 8)->__eq__(*rational(-559, 645120)));
+    REQUIRE(series_coeff(ex5, x, 20, 10)->__eq__(*rational(701, 127575)));
+    REQUIRE(series_coeff(ex6, x, 10, 8)->__eq__(*rational(-559, 645120)));
 }
 
-TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]") {
-  RCP<const Symbol> x = symbol("x");
-  RCP<const Integer> one = integer(1);
-  RCP<const Integer> two = integer(2);
-  RCP<const Integer> three = integer(3);
-  auto ex1 = log(add(one, x));
-  auto ex2 = log(cos(x));
-  auto ex3 = log(div(one, sub(one, x)));
-  auto ex4 = exp(x);
-  auto ex5 = exp(log(add(x, one)));
-  auto ex6 = log(exp(x));
-  auto ex7 = exp(sin(x));
-  auto ex8 = pow(cos(x), sin(x));
+TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    RCP<const Integer> two = integer(2);
+    RCP<const Integer> three = integer(3);
+    auto ex1 = log(add(one, x));
+    auto ex2 = log(cos(x));
+    auto ex3 = log(div(one, sub(one, x)));
+    auto ex4 = exp(x);
+    auto ex5 = exp(log(add(x, one)));
+    auto ex6 = log(exp(x));
+    auto ex7 = exp(sin(x));
+    auto ex8 = pow(cos(x), sin(x));
 
-  REQUIRE(series_coeff(ex1, x, 100, 98)->__eq__(*rational(-1, 98)));
-  REQUIRE(series_coeff(ex2, x, 20, 12)->__eq__(*rational(-691, 935550)));
-  REQUIRE(series_coeff(ex3, x, 100, 48)->__eq__(*rational(1, 48)));
-  REQUIRE(series_coeff(ex4, x, 20, 9)->__eq__(*rational(1, 362880)));
-  auto res1 = umap_short_basic{{0, integer(1)}, {1, integer(1)}};
-  auto res2 = umap_short_basic{{1, integer(1)}};
-  REQUIRE(expand_check_pairs(ex5, x, 20, res1));
-  REQUIRE(expand_check_pairs(ex6, x, 20, res2));
-  REQUIRE(series_coeff(ex7, x, 20, 10)->__eq__(*rational(-2951, 3628800)));
-  REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*rational(1381, 2661120)));
+    REQUIRE(series_coeff(ex1, x, 100, 98)->__eq__(*rational(-1, 98)));
+    REQUIRE(series_coeff(ex2, x, 20, 12)->__eq__(*rational(-691, 935550)));
+    REQUIRE(series_coeff(ex3, x, 100, 48)->__eq__(*rational(1, 48)));
+    REQUIRE(series_coeff(ex4, x, 20, 9)->__eq__(*rational(1, 362880)));
+    auto res1 = umap_short_basic{ { 0, integer(1) }, { 1, integer(1) } };
+    auto res2 = umap_short_basic{ { 1, integer(1) } };
+    REQUIRE(expand_check_pairs(ex5, x, 20, res1));
+    REQUIRE(expand_check_pairs(ex6, x, 20, res2));
+    REQUIRE(series_coeff(ex7, x, 20, 10)->__eq__(*rational(-2951, 3628800)));
+    REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*rational(1381, 2661120)));
 }
 
-TEST_CASE("Expression series expansion: reversion ", "[Expansion of f^-1]") {
-  RCP<const Symbol> x = symbol("x");
-  RCP<const Integer> two = integer(2);
-  RCP<const Integer> three = integer(3);
-  auto ex1 = sub(x, pow(x, two));
-  auto ex2 = sub(x, pow(x, three));
-  auto ex3 = sin(x);
-  auto ex4 = mul(x, exp(x));
+TEST_CASE("Expression series expansion: reversion ", "[Expansion of f^-1]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> two = integer(2);
+    RCP<const Integer> three = integer(3);
+    auto ex1 = sub(x, pow(x, two));
+    auto ex2 = sub(x, pow(x, three));
+    auto ex3 = sin(x);
+    auto ex4 = mul(x, exp(x));
 
-  REQUIRE(invseries_coeff(ex1, x, 20, 15)->__eq__(*integer(2674440)));
-  REQUIRE(invseries_coeff(ex2, x, 20, 15)->__eq__(*integer(7752)));
-  REQUIRE(invseries_coeff(ex3, x, 20, 15)->__eq__(*rational(143, 10240)));
-  REQUIRE(invseries_coeff(ex4, x, 20, 10)->__eq__(*rational(-156250, 567)));
+    REQUIRE(invseries_coeff(ex1, x, 20, 15)->__eq__(*integer(2674440)));
+    REQUIRE(invseries_coeff(ex2, x, 20, 15)->__eq__(*integer(7752)));
+    REQUIRE(invseries_coeff(ex3, x, 20, 15)->__eq__(*rational(143, 10240)));
+    REQUIRE(invseries_coeff(ex4, x, 20, 10)->__eq__(*rational(-156250, 567)));
 }
 
 TEST_CASE("Expression series expansion: atan, tan, asin, cot, sec, csc",
-          "[Expansion of tan, atan, asin, cot, sec, csc]") {
-  RCP<const Symbol> x = symbol("x");
-  RCP<const Integer> one = integer(1);
-  auto ex1 = atan(x);
-  auto ex2 = atan(div(x, sub(one, x)));
-  auto ex3 = tan(x);
-  auto ex4 = tan(div(x, sub(one, x)));
-  auto ex5 = asin(x);
-  auto ex6 = asin(div(x, sub(one, x)));
-  auto res1 = umap_short_basic{{-1, integer(1)}, {1, rational(-1, 3)}};
-  auto res2 = umap_short_basic{{-1, integer(1)}, {7, rational(-1051, 1814400)}};
-  auto ex9 = sec(x);
+    "[Expansion of tan, atan, asin, cot, sec, csc]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    auto ex1 = atan(x);
+    auto ex2 = atan(div(x, sub(one, x)));
+    auto ex3 = tan(x);
+    auto ex4 = tan(div(x, sub(one, x)));
+    auto ex5 = asin(x);
+    auto ex6 = asin(div(x, sub(one, x)));
+    auto res1 = umap_short_basic{ { -1, integer(1) }, { 1, rational(-1, 3) } };
+    auto res2 = umap_short_basic{ { -1, integer(1) }, { 7, rational(-1051, 1814400) } };
+    auto ex9 = sec(x);
 
-  REQUIRE(series_coeff(ex1, x, 20, 19)->__eq__(*rational(-1, 19)));
-  REQUIRE(series_coeff(ex2, x, 40, 33)->__eq__(*rational(65536, 33)));
-  REQUIRE(series_coeff(ex3, x, 20, 13)->__eq__(*rational(21844, 6081075)));
-  REQUIRE(series_coeff(ex4, x, 20, 12)->__eq__(*rational(1303712, 14175)));
-  REQUIRE(series_coeff(ex5, x, 20, 15)->__eq__(*rational(143, 10240)));
-  REQUIRE(series_coeff(ex6, x, 20, 16)->__eq__(*rational(1259743, 2048)));
-  REQUIRE(series_coeff(ex9, x, 20, 8)->__eq__(*rational(277, 8064)));
+    REQUIRE(series_coeff(ex1, x, 20, 19)->__eq__(*rational(-1, 19)));
+    REQUIRE(series_coeff(ex2, x, 40, 33)->__eq__(*rational(65536, 33)));
+    REQUIRE(series_coeff(ex3, x, 20, 13)->__eq__(*rational(21844, 6081075)));
+    REQUIRE(series_coeff(ex4, x, 20, 12)->__eq__(*rational(1303712, 14175)));
+    REQUIRE(series_coeff(ex5, x, 20, 15)->__eq__(*rational(143, 10240)));
+    REQUIRE(series_coeff(ex6, x, 20, 16)->__eq__(*rational(1259743, 2048)));
+    REQUIRE(series_coeff(ex9, x, 20, 8)->__eq__(*rational(277, 8064)));
 
-  // These cannot be checked using catch.hpp
-  // See https://github.com/philsquared/Catch/issues/553
-  //    auto ex7 = cot(x);
-  //    auto ex8 = cot(sin(x));
-  //    auto ex10 = csc(x);
-  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex7, "x", 10),
-  //    std::runtime_error);
-  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex8, "x", 10),
-  //    std::runtime_error);
-  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex10, "x", 10),
-  //    std::runtime_error);
+    // These cannot be checked using catch.hpp
+    // See https://github.com/philsquared/Catch/issues/553
+    //    auto ex7 = cot(x);
+    //    auto ex8 = cot(sin(x));
+    //    auto ex10 = csc(x);
+    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex7, "x", 10),
+    //    std::runtime_error);
+    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex8, "x", 10),
+    //    std::runtime_error);
+    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex10, "x", 10),
+    //    std::runtime_error);
 }
 
 TEST_CASE("Expression series expansion: sinh, cosh, tanh, asinh, atanh",
-          "[Expansion of sinh, cosh, tanh, asinh, atanh]") {
-  RCP<const Symbol> x = symbol("x");
-  RCP<const Integer> one = integer(1);
-  auto ex1 = sinh(x);
-  auto ex2 = sinh(div(x, sub(one, x)));
-  auto ex3 = cosh(x);
-  auto ex4 = cosh(div(x, sub(one, x)));
-  auto ex5 = tanh(x);
-  auto ex6 = tanh(div(x, sub(one, x)));
-  auto ex7 = atanh(x);
-  auto ex8 = atanh(div(x, sub(one, x)));
-  auto ex9 = asinh(x);
-  auto ex10 = asinh(div(x, sub(one, x)));
+    "[Expansion of sinh, cosh, tanh, asinh, atanh]")
+{
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Integer> one = integer(1);
+    auto ex1 = sinh(x);
+    auto ex2 = sinh(div(x, sub(one, x)));
+    auto ex3 = cosh(x);
+    auto ex4 = cosh(div(x, sub(one, x)));
+    auto ex5 = tanh(x);
+    auto ex6 = tanh(div(x, sub(one, x)));
+    auto ex7 = atanh(x);
+    auto ex8 = atanh(div(x, sub(one, x)));
+    auto ex9 = asinh(x);
+    auto ex10 = asinh(div(x, sub(one, x)));
 
-  REQUIRE(series_coeff(ex1, x, 10, 9)->__eq__(*rational(1, 362880)));
-  REQUIRE(series_coeff(ex2, x, 20, 10)->__eq__(*rational(325249, 40320)));
-  REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(1, 3628800)));
-  REQUIRE(series_coeff(ex4, x, 20, 11)->__eq__(*rational(3756889, 362880)));
-  REQUIRE(series_coeff(ex5, x, 20, 13)->__eq__(*rational(21844, 6081075)));
-  REQUIRE(series_coeff(ex6, x, 20, 14)->__eq__(*rational(225979, 66825)));
-  REQUIRE(series_coeff(ex7, x, 100, 99)->__eq__(*rational(1, 99)));
-  REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*integer(2048)));
-  REQUIRE(series_coeff(ex9, x, 20, 15)->__eq__(*rational(-143, 10240)));
-  REQUIRE(series_coeff(ex10, x, 20, 16)->__eq__(*rational(-3179, 2048)));
+    REQUIRE(series_coeff(ex1, x, 10, 9)->__eq__(*rational(1, 362880)));
+    REQUIRE(series_coeff(ex2, x, 20, 10)->__eq__(*rational(325249, 40320)));
+    REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(1, 3628800)));
+    REQUIRE(series_coeff(ex4, x, 20, 11)->__eq__(*rational(3756889, 362880)));
+    REQUIRE(series_coeff(ex5, x, 20, 13)->__eq__(*rational(21844, 6081075)));
+    REQUIRE(series_coeff(ex6, x, 20, 14)->__eq__(*rational(225979, 66825)));
+    REQUIRE(series_coeff(ex7, x, 100, 99)->__eq__(*rational(1, 99)));
+    REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*integer(2048)));
+    REQUIRE(series_coeff(ex9, x, 20, 15)->__eq__(*rational(-143, 10240)));
+    REQUIRE(series_coeff(ex10, x, 20, 16)->__eq__(*rational(-3179, 2048)));
 }
 
 #if 0
@@ -256,9 +266,10 @@ TEST_CASE("Expression series expansion: lambertw ", "[Expansion of lambertw]")
 
 #else
 TEST_CASE("Check error when expansion called without Flint ",
-          "[Expansion without Piranha]") {
-  RCP<const Symbol> x = symbol("x");
-  auto ex1 = lambertw(x);
-  REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex1, "x", 10), std::runtime_error);
+    "[Expansion without Piranha]")
+{
+    RCP<const Symbol> x = symbol("x");
+    auto ex1 = lambertw(x);
+    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex1, "x", 10), std::runtime_error);
 }
 #endif

--- a/symengine/tests/basic/test_series_expansion_URatF.cpp
+++ b/symengine/tests/basic/test_series_expansion_URatF.cpp
@@ -23,233 +23,223 @@ using SymEngine::umap_short_basic;
 using SymEngine::URatPSeriesFlint;
 using SymEngine::fp_t;
 using SymEngine::fmpq_wrapper;
-#define series_coeff(EX, SYM, PREC, COEFF)                         \
-    SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC) \
-        ->get_coeff(COEFF)
+#define series_coeff(EX, SYM, PREC, COEFF)                                     \
+  SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC)               \
+      ->get_coeff(COEFF)
 
-static RCP<const Number> fmpqxx2sym(const fmpq_wrapper& fc)
-{
-    mpq_t gc;
-    mpq_init(gc);
-    fmpq_get_mpq(gc, fc.get_fmpq_t());
-    rational_class r(gc);
-    mpq_clear(gc);
-    return Rational::from_mpq(std::move(r));
+static RCP<const Number> fmpqxx2sym(const fmpq_wrapper &fc) {
+  mpq_t gc;
+  mpq_init(gc);
+  fmpq_get_mpq(gc, fc.get_fmpq_t());
+  rational_class r(gc);
+  mpq_clear(gc);
+  return Rational::from_mpq(std::move(r));
 }
 
-static RCP<const Number> invseries_coeff(const RCP<const Basic>& ex,
-    const RCP<const Symbol>& sym,
-    unsigned int prec, int n)
-{
-    auto ser = URatPSeriesFlint::series(ex, sym->get_name(), prec);
-    auto serrev = URatPSeriesFlint::series_reverse(
-        ser->get_poly(), fp_t(sym->get_name().c_str()), prec);
-    return fmpqxx2sym(serrev.get_coeff(n));
+static RCP<const Number> invseries_coeff(const RCP<const Basic> &ex,
+                                         const RCP<const Symbol> &sym,
+                                         unsigned int prec, int n) {
+  auto ser = URatPSeriesFlint::series(ex, sym->get_name(), prec);
+  auto serrev = URatPSeriesFlint::series_reverse(
+      ser->get_poly(), fp_t(sym->get_name().c_str()), prec);
+  return fmpqxx2sym(serrev.get_coeff(n));
 }
 
-static bool expand_check_pairs(const RCP<const Basic>& ex,
-    const RCP<const Symbol>& x, int prec,
-    const umap_short_basic& pairs)
-{
-    auto ser = SymEngine::URatPSeriesFlint::series(ex, x->get_name(), prec);
-    for (auto it : pairs) {
-        // std::cerr << it.first << ", " << *(it.second) << "::" <<
-        // *(v1.at(it.first)) << std::endl;
-        if (not it.second->__eq__(*(ser->get_coeff(it.first))))
-            return false;
-    }
-    return true;
+static bool expand_check_pairs(const RCP<const Basic> &ex,
+                               const RCP<const Symbol> &x, int prec,
+                               const umap_short_basic &pairs) {
+  auto ser = SymEngine::URatPSeriesFlint::series(ex, x->get_name(), prec);
+  for (auto it : pairs) {
+    // std::cerr << it.first << ", " << *(it.second) << "::" <<
+    // *(v1.at(it.first)) << std::endl;
+    if (not it.second->__eq__(*(ser->get_coeff(it.first))))
+      return false;
+  }
+  return true;
 }
 
-TEST_CASE("Expression series expansion: Add ", "[Expansion of Add]")
-{
-    RCP<const Symbol> x = symbol("x"), y = symbol("y");
-    auto z = add(integer(1), x);
-    z = sub(z, pow(x, integer(2)));
-    z = add(z, pow(x, integer(4)));
-    auto z1 = pow(add(integer(1), x), integer(0));
+TEST_CASE("Expression series expansion: Add ", "[Expansion of Add]") {
+  RCP<const Symbol> x = symbol("x"), y = symbol("y");
+  auto z = add(integer(1), x);
+  z = sub(z, pow(x, integer(2)));
+  z = add(z, pow(x, integer(4)));
+  auto z1 = pow(add(integer(1), x), integer(0));
 
-    auto vb = umap_short_basic{
-        { 0, integer(1) }, { 1, integer(1) }, { 2, integer(-1) }, { 4, integer(1) }
-    };
-    REQUIRE(expand_check_pairs(z, x, 5, vb));
-    auto vb1 = umap_short_basic{ { 0, integer(1) }, { 1, integer(1) }, { 2, integer(-1) } };
-    REQUIRE(expand_check_pairs(z, x, 3, vb1));
-    REQUIRE(series_coeff(z1, x, 9, 0)->__eq__(*integer(1)));
-    REQUIRE(series_coeff(z1, x, 9, 1)->__eq__(*integer(0)));
+  auto vb = umap_short_basic{
+      {0, integer(1)}, {1, integer(1)}, {2, integer(-1)}, {4, integer(1)}};
+  REQUIRE(expand_check_pairs(z, x, 5, vb));
+  auto vb1 =
+      umap_short_basic{{0, integer(1)}, {1, integer(1)}, {2, integer(-1)}};
+  REQUIRE(expand_check_pairs(z, x, 3, vb1));
+  REQUIRE(series_coeff(z1, x, 9, 0)->__eq__(*integer(1)));
+  REQUIRE(series_coeff(z1, x, 9, 1)->__eq__(*integer(0)));
 }
 
-TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    auto z1 = sin(x);
-    auto z2 = cos(x);
-    auto z3 = add(sin(x), cos(x));
-    auto z4 = mul(sin(x), cos(x));
-    auto z5 = sin(atan(x));
-    auto z6 = cos(div(x, sub(one, x)));
+TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  auto z1 = sin(x);
+  auto z2 = cos(x);
+  auto z3 = add(sin(x), cos(x));
+  auto z4 = mul(sin(x), cos(x));
+  auto z5 = sin(atan(x));
+  auto z6 = cos(div(x, sub(one, x)));
 
-    REQUIRE(series_coeff(z1, x, 10, 9)->__eq__(*rational(1, 362880)));
-    auto res = umap_short_basic{ { 0, integer(1) }, { 2, rational(-1, 2) } };
-    REQUIRE(expand_check_pairs(z2, x, 3, res));
-    REQUIRE(series_coeff(z3, x, 9, 8)->__eq__(*rational(1, 40320)));
-    REQUIRE(series_coeff(z4, x, 12, 11)->__eq__(*rational(-4, 155925)));
-    REQUIRE(series_coeff(z5, x, 30, 27)->__eq__(*rational(-1300075, 8388608)));
-    REQUIRE(series_coeff(z6, x, 15, 11)->__eq__(*rational(-125929, 362880)));
+  REQUIRE(series_coeff(z1, x, 10, 9)->__eq__(*rational(1, 362880)));
+  auto res = umap_short_basic{{0, integer(1)}, {2, rational(-1, 2)}};
+  REQUIRE(expand_check_pairs(z2, x, 3, res));
+  REQUIRE(series_coeff(z3, x, 9, 8)->__eq__(*rational(1, 40320)));
+  REQUIRE(series_coeff(z4, x, 12, 11)->__eq__(*rational(-4, 155925)));
+  REQUIRE(series_coeff(z5, x, 30, 27)->__eq__(*rational(-1300075, 8388608)));
+  REQUIRE(series_coeff(z6, x, 15, 11)->__eq__(*rational(-125929, 362880)));
 }
 
 TEST_CASE("Expression series expansion: division, inversion ",
-    "[Expansion of 1/ex]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    RCP<const Integer> two = integer(2);
-    RCP<const Integer> three = integer(3);
-    auto ex1 = div(one, sub(one, x)); // 1/(1-x)
-    auto ex2 = div(x, sub(sub(one, x), pow(x, two))); // x/(1-x-x^2)
-    auto ex3 = div(pow(x, three), sub(one, mul(pow(x, two), two))); // x^3/(1-2x^2)
-    auto ex4 = div(one, sub(one, sin(x))); // 1/(1-sin(x))
-    auto ex5 = div(one, x);
-    auto ex6 = div(one, mul(x, sub(one, x)));
-    auto res1 = umap_short_basic{ { -1, integer(1) } };
-    auto res2 = umap_short_basic{ { -1, integer(1) }, { 0, integer(1) } };
+          "[Expansion of 1/ex]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  RCP<const Integer> two = integer(2);
+  RCP<const Integer> three = integer(3);
+  auto ex1 = div(one, sub(one, x));                 // 1/(1-x)
+  auto ex2 = div(x, sub(sub(one, x), pow(x, two))); // x/(1-x-x^2)
+  auto ex3 =
+      div(pow(x, three), sub(one, mul(pow(x, two), two))); // x^3/(1-2x^2)
+  auto ex4 = div(one, sub(one, sin(x)));                   // 1/(1-sin(x))
+  auto ex5 = div(one, x);
+  auto ex6 = div(one, mul(x, sub(one, x)));
+  auto res1 = umap_short_basic{{-1, integer(1)}};
+  auto res2 = umap_short_basic{{-1, integer(1)}, {0, integer(1)}};
 
-    REQUIRE(series_coeff(ex1, x, 100, 99)->__eq__(*integer(1)));
-    REQUIRE(series_coeff(ex2, x, 100, 35)->__eq__(*integer(9227465)));
-    REQUIRE(series_coeff(ex3, x, 100, 49)->__eq__(*integer(8388608)));
-    REQUIRE(series_coeff(ex4, x, 20, 10)->__eq__(*rational(1382, 14175)));
-    //! TODO: REQUIRE(expand_check_pairs(ex5, x, 8, res1));
-    //! TODO: REQUIRE(expand_check_pairs(ex6, x, 8, res2));
+  REQUIRE(series_coeff(ex1, x, 100, 99)->__eq__(*integer(1)));
+  REQUIRE(series_coeff(ex2, x, 100, 35)->__eq__(*integer(9227465)));
+  REQUIRE(series_coeff(ex3, x, 100, 49)->__eq__(*integer(8388608)));
+  REQUIRE(series_coeff(ex4, x, 20, 10)->__eq__(*rational(1382, 14175)));
+  //! TODO: REQUIRE(expand_check_pairs(ex5, x, 8, res1));
+  //! TODO: REQUIRE(expand_check_pairs(ex6, x, 8, res2));
 }
 
-TEST_CASE("Expression series expansion: roots", "[Expansion of root(ex)]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Number> q12 = rational(1, 2);
-    RCP<const Number> qm23 = rational(-2, 3);
-    RCP<const Integer> one = integer(1);
-    RCP<const Integer> four = integer(4);
-    auto ex1 = pow(sub(four, x), q12);
-    auto ex2 = pow(sub(one, x), qm23);
-    auto ex3 = sqrt(sub(one, x));
-    auto ex4 = pow(cos(x), q12);
-    auto ex5 = pow(cos(x), qm23);
-    auto ex6 = sqrt(cos(x));
+TEST_CASE("Expression series expansion: roots", "[Expansion of root(ex)]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Number> q12 = rational(1, 2);
+  RCP<const Number> qm23 = rational(-2, 3);
+  RCP<const Integer> one = integer(1);
+  RCP<const Integer> four = integer(4);
+  auto ex1 = pow(sub(four, x), q12);
+  auto ex2 = pow(sub(one, x), qm23);
+  auto ex3 = sqrt(sub(one, x));
+  auto ex4 = pow(cos(x), q12);
+  auto ex5 = pow(cos(x), qm23);
+  auto ex6 = sqrt(cos(x));
 
-    REQUIRE(series_coeff(ex1, x, 8, 6)->__eq__(*rational(-21, 2097152)));
-    REQUIRE(series_coeff(ex2, x, 12, 10)->__eq__(*rational(1621477, 4782969)));
-    REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(-2431, 262144)));
-    REQUIRE(series_coeff(ex4, x, 100, 8)->__eq__(*rational(-559, 645120)));
-    REQUIRE(series_coeff(ex5, x, 20, 10)->__eq__(*rational(701, 127575)));
-    REQUIRE(series_coeff(ex6, x, 10, 8)->__eq__(*rational(-559, 645120)));
+  REQUIRE(series_coeff(ex1, x, 8, 6)->__eq__(*rational(-21, 2097152)));
+  REQUIRE(series_coeff(ex2, x, 12, 10)->__eq__(*rational(1621477, 4782969)));
+  REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(-2431, 262144)));
+  REQUIRE(series_coeff(ex4, x, 100, 8)->__eq__(*rational(-559, 645120)));
+  REQUIRE(series_coeff(ex5, x, 20, 10)->__eq__(*rational(701, 127575)));
+  REQUIRE(series_coeff(ex6, x, 10, 8)->__eq__(*rational(-559, 645120)));
 }
 
-TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    RCP<const Integer> two = integer(2);
-    RCP<const Integer> three = integer(3);
-    auto ex1 = log(add(one, x));
-    auto ex2 = log(cos(x));
-    auto ex3 = log(div(one, sub(one, x)));
-    auto ex4 = exp(x);
-    auto ex5 = exp(log(add(x, one)));
-    auto ex6 = log(exp(x));
-    auto ex7 = exp(sin(x));
-    auto ex8 = pow(cos(x), sin(x));
+TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  RCP<const Integer> two = integer(2);
+  RCP<const Integer> three = integer(3);
+  auto ex1 = log(add(one, x));
+  auto ex2 = log(cos(x));
+  auto ex3 = log(div(one, sub(one, x)));
+  auto ex4 = exp(x);
+  auto ex5 = exp(log(add(x, one)));
+  auto ex6 = log(exp(x));
+  auto ex7 = exp(sin(x));
+  auto ex8 = pow(cos(x), sin(x));
 
-    REQUIRE(series_coeff(ex1, x, 100, 98)->__eq__(*rational(-1, 98)));
-    REQUIRE(series_coeff(ex2, x, 20, 12)->__eq__(*rational(-691, 935550)));
-    REQUIRE(series_coeff(ex3, x, 100, 48)->__eq__(*rational(1, 48)));
-    REQUIRE(series_coeff(ex4, x, 20, 9)->__eq__(*rational(1, 362880)));
-    auto res1 = umap_short_basic{ { 0, integer(1) }, { 1, integer(1) } };
-    auto res2 = umap_short_basic{ { 1, integer(1) } };
-    REQUIRE(expand_check_pairs(ex5, x, 20, res1));
-    REQUIRE(expand_check_pairs(ex6, x, 20, res2));
-    REQUIRE(series_coeff(ex7, x, 20, 10)->__eq__(*rational(-2951, 3628800)));
-    REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*rational(1381, 2661120)));
+  REQUIRE(series_coeff(ex1, x, 100, 98)->__eq__(*rational(-1, 98)));
+  REQUIRE(series_coeff(ex2, x, 20, 12)->__eq__(*rational(-691, 935550)));
+  REQUIRE(series_coeff(ex3, x, 100, 48)->__eq__(*rational(1, 48)));
+  REQUIRE(series_coeff(ex4, x, 20, 9)->__eq__(*rational(1, 362880)));
+  auto res1 = umap_short_basic{{0, integer(1)}, {1, integer(1)}};
+  auto res2 = umap_short_basic{{1, integer(1)}};
+  REQUIRE(expand_check_pairs(ex5, x, 20, res1));
+  REQUIRE(expand_check_pairs(ex6, x, 20, res2));
+  REQUIRE(series_coeff(ex7, x, 20, 10)->__eq__(*rational(-2951, 3628800)));
+  REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*rational(1381, 2661120)));
 }
 
-TEST_CASE("Expression series expansion: reversion ", "[Expansion of f^-1]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> two = integer(2);
-    RCP<const Integer> three = integer(3);
-    auto ex1 = sub(x, pow(x, two));
-    auto ex2 = sub(x, pow(x, three));
-    auto ex3 = sin(x);
-    auto ex4 = mul(x, exp(x));
+TEST_CASE("Expression series expansion: reversion ", "[Expansion of f^-1]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> two = integer(2);
+  RCP<const Integer> three = integer(3);
+  auto ex1 = sub(x, pow(x, two));
+  auto ex2 = sub(x, pow(x, three));
+  auto ex3 = sin(x);
+  auto ex4 = mul(x, exp(x));
 
-    REQUIRE(invseries_coeff(ex1, x, 20, 15)->__eq__(*integer(2674440)));
-    REQUIRE(invseries_coeff(ex2, x, 20, 15)->__eq__(*integer(7752)));
-    REQUIRE(invseries_coeff(ex3, x, 20, 15)->__eq__(*rational(143, 10240)));
-    REQUIRE(invseries_coeff(ex4, x, 20, 10)->__eq__(*rational(-156250, 567)));
+  REQUIRE(invseries_coeff(ex1, x, 20, 15)->__eq__(*integer(2674440)));
+  REQUIRE(invseries_coeff(ex2, x, 20, 15)->__eq__(*integer(7752)));
+  REQUIRE(invseries_coeff(ex3, x, 20, 15)->__eq__(*rational(143, 10240)));
+  REQUIRE(invseries_coeff(ex4, x, 20, 10)->__eq__(*rational(-156250, 567)));
 }
 
 TEST_CASE("Expression series expansion: atan, tan, asin, cot, sec, csc",
-    "[Expansion of tan, atan, asin, cot, sec, csc]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    auto ex1 = atan(x);
-    auto ex2 = atan(div(x, sub(one, x)));
-    auto ex3 = tan(x);
-    auto ex4 = tan(div(x, sub(one, x)));
-    auto ex5 = asin(x);
-    auto ex6 = asin(div(x, sub(one, x)));
-    auto res1 = umap_short_basic{ { -1, integer(1) }, { 1, rational(-1, 3) } };
-    auto res2 = umap_short_basic{ { -1, integer(1) }, { 7, rational(-1051, 1814400) } };
-    auto ex9 = sec(x);
+          "[Expansion of tan, atan, asin, cot, sec, csc]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  auto ex1 = atan(x);
+  auto ex2 = atan(div(x, sub(one, x)));
+  auto ex3 = tan(x);
+  auto ex4 = tan(div(x, sub(one, x)));
+  auto ex5 = asin(x);
+  auto ex6 = asin(div(x, sub(one, x)));
+  auto res1 = umap_short_basic{{-1, integer(1)}, {1, rational(-1, 3)}};
+  auto res2 = umap_short_basic{{-1, integer(1)}, {7, rational(-1051, 1814400)}};
+  auto ex9 = sec(x);
 
-    REQUIRE(series_coeff(ex1, x, 20, 19)->__eq__(*rational(-1, 19)));
-    REQUIRE(series_coeff(ex2, x, 40, 33)->__eq__(*rational(65536, 33)));
-    REQUIRE(series_coeff(ex3, x, 20, 13)->__eq__(*rational(21844, 6081075)));
-    REQUIRE(series_coeff(ex4, x, 20, 12)->__eq__(*rational(1303712, 14175)));
-    REQUIRE(series_coeff(ex5, x, 20, 15)->__eq__(*rational(143, 10240)));
-    REQUIRE(series_coeff(ex6, x, 20, 16)->__eq__(*rational(1259743, 2048)));
-    REQUIRE(series_coeff(ex9, x, 20, 8)->__eq__(*rational(277, 8064)));
+  REQUIRE(series_coeff(ex1, x, 20, 19)->__eq__(*rational(-1, 19)));
+  REQUIRE(series_coeff(ex2, x, 40, 33)->__eq__(*rational(65536, 33)));
+  REQUIRE(series_coeff(ex3, x, 20, 13)->__eq__(*rational(21844, 6081075)));
+  REQUIRE(series_coeff(ex4, x, 20, 12)->__eq__(*rational(1303712, 14175)));
+  REQUIRE(series_coeff(ex5, x, 20, 15)->__eq__(*rational(143, 10240)));
+  REQUIRE(series_coeff(ex6, x, 20, 16)->__eq__(*rational(1259743, 2048)));
+  REQUIRE(series_coeff(ex9, x, 20, 8)->__eq__(*rational(277, 8064)));
 
-    // These cannot be checked using catch.hpp
-    // See https://github.com/philsquared/Catch/issues/553
-    //    auto ex7 = cot(x);
-    //    auto ex8 = cot(sin(x));
-    //    auto ex10 = csc(x);
-    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex7, "x", 10),
-    //    std::runtime_error);
-    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex8, "x", 10),
-    //    std::runtime_error);
-    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex10, "x", 10),
-    //    std::runtime_error);
+  // These cannot be checked using catch.hpp
+  // See https://github.com/philsquared/Catch/issues/553
+  //    auto ex7 = cot(x);
+  //    auto ex8 = cot(sin(x));
+  //    auto ex10 = csc(x);
+  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex7, "x", 10),
+  //    std::runtime_error);
+  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex8, "x", 10),
+  //    std::runtime_error);
+  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex10, "x", 10),
+  //    std::runtime_error);
 }
 
 TEST_CASE("Expression series expansion: sinh, cosh, tanh, asinh, atanh",
-    "[Expansion of sinh, cosh, tanh, asinh, atanh]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    auto ex1 = sinh(x);
-    auto ex2 = sinh(div(x, sub(one, x)));
-    auto ex3 = cosh(x);
-    auto ex4 = cosh(div(x, sub(one, x)));
-    auto ex5 = tanh(x);
-    auto ex6 = tanh(div(x, sub(one, x)));
-    auto ex7 = atanh(x);
-    auto ex8 = atanh(div(x, sub(one, x)));
-    auto ex9 = asinh(x);
-    auto ex10 = asinh(div(x, sub(one, x)));
+          "[Expansion of sinh, cosh, tanh, asinh, atanh]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  auto ex1 = sinh(x);
+  auto ex2 = sinh(div(x, sub(one, x)));
+  auto ex3 = cosh(x);
+  auto ex4 = cosh(div(x, sub(one, x)));
+  auto ex5 = tanh(x);
+  auto ex6 = tanh(div(x, sub(one, x)));
+  auto ex7 = atanh(x);
+  auto ex8 = atanh(div(x, sub(one, x)));
+  auto ex9 = asinh(x);
+  auto ex10 = asinh(div(x, sub(one, x)));
 
-    REQUIRE(series_coeff(ex1, x, 10, 9)->__eq__(*rational(1, 362880)));
-    REQUIRE(series_coeff(ex2, x, 20, 10)->__eq__(*rational(325249, 40320)));
-    REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(1, 3628800)));
-    REQUIRE(series_coeff(ex4, x, 20, 11)->__eq__(*rational(3756889, 362880)));
-    REQUIRE(series_coeff(ex5, x, 20, 13)->__eq__(*rational(21844, 6081075)));
-    REQUIRE(series_coeff(ex6, x, 20, 14)->__eq__(*rational(225979, 66825)));
-    REQUIRE(series_coeff(ex7, x, 100, 99)->__eq__(*rational(1, 99)));
-    REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*integer(2048)));
-    REQUIRE(series_coeff(ex9, x, 20, 15)->__eq__(*rational(-143, 10240)));
-    REQUIRE(series_coeff(ex10, x, 20, 16)->__eq__(*rational(-3179, 2048)));
+  REQUIRE(series_coeff(ex1, x, 10, 9)->__eq__(*rational(1, 362880)));
+  REQUIRE(series_coeff(ex2, x, 20, 10)->__eq__(*rational(325249, 40320)));
+  REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(1, 3628800)));
+  REQUIRE(series_coeff(ex4, x, 20, 11)->__eq__(*rational(3756889, 362880)));
+  REQUIRE(series_coeff(ex5, x, 20, 13)->__eq__(*rational(21844, 6081075)));
+  REQUIRE(series_coeff(ex6, x, 20, 14)->__eq__(*rational(225979, 66825)));
+  REQUIRE(series_coeff(ex7, x, 100, 99)->__eq__(*rational(1, 99)));
+  REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*integer(2048)));
+  REQUIRE(series_coeff(ex9, x, 20, 15)->__eq__(*rational(-143, 10240)));
+  REQUIRE(series_coeff(ex10, x, 20, 16)->__eq__(*rational(-3179, 2048)));
 }
 
 #if 0
@@ -266,10 +256,9 @@ TEST_CASE("Expression series expansion: lambertw ", "[Expansion of lambertw]")
 
 #else
 TEST_CASE("Check error when expansion called without Flint ",
-    "[Expansion without Piranha]")
-{
-    RCP<const Symbol> x = symbol("x");
-    auto ex1 = lambertw(x);
-    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex1, "x", 10), std::runtime_error);
+          "[Expansion without Piranha]") {
+  RCP<const Symbol> x = symbol("x");
+  auto ex1 = lambertw(x);
+  REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex1, "x", 10), std::runtime_error);
 }
 #endif

--- a/symengine/tests/basic/test_series_expansion_URatF.cpp
+++ b/symengine/tests/basic/test_series_expansion_URatF.cpp
@@ -1,6 +1,6 @@
-#include <symengine/series_flint.h>
 #include "catch.hpp"
 #include <chrono>
+#include <symengine/series_flint.h>
 
 using SymEngine::Basic;
 using SymEngine::Integer;
@@ -24,234 +24,222 @@ using SymEngine::URatPSeriesFlint;
 using SymEngine::fp_t;
 using SymEngine::fmpq_wrapper;
 #define series_coeff(EX, SYM, PREC, COEFF)                                     \
-    SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC)             \
-        ->get_coeff(COEFF)
+  SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC)               \
+      ->get_coeff(COEFF)
 
-static RCP<const Number> fmpqxx2sym(const fmpq_wrapper& fc)
-{
-    mpq_t gc;
-    mpq_init(gc);
-    fmpq_get_mpq(gc, fc.get_fmpq_t());
-    rational_class r(gc);
-    mpq_clear(gc);
-    return Rational::from_mpq(std::move(r));
+static RCP<const Number> fmpqxx2sym(const fmpq_wrapper &fc) {
+  mpq_t gc;
+  mpq_init(gc);
+  fmpq_get_mpq(gc, fc.get_fmpq_t());
+  rational_class r(gc);
+  mpq_clear(gc);
+  return Rational::from_mpq(std::move(r));
 }
 
 static RCP<const Number> invseries_coeff(const RCP<const Basic> &ex,
                                          const RCP<const Symbol> &sym,
-                                         unsigned int prec, int n)
-{
-    auto ser = URatPSeriesFlint::series(ex, sym->get_name(), prec);
-    auto serrev = URatPSeriesFlint::series_reverse(
-        ser->get_poly(), fp_t(sym->get_name().c_str()), prec);
-    return fmpqxx2sym(serrev.get_coeff(n));
+                                         unsigned int prec, int n) {
+  auto ser = URatPSeriesFlint::series(ex, sym->get_name(), prec);
+  auto serrev = URatPSeriesFlint::series_reverse(
+      ser->get_poly(), fp_t(sym->get_name().c_str()), prec);
+  return fmpqxx2sym(serrev.get_coeff(n));
 }
 
 static bool expand_check_pairs(const RCP<const Basic> &ex,
                                const RCP<const Symbol> &x, int prec,
-                               const umap_short_basic &pairs)
-{
-    auto ser = SymEngine::URatPSeriesFlint::series(ex, x->get_name(), prec);
-    for (auto it : pairs) {
-        // std::cerr << it.first << ", " << *(it.second) << "::" <<
-        // *(v1.at(it.first)) << std::endl;
-        if (not it.second->__eq__(*(ser->get_coeff(it.first))))
-            return false;
-    }
-    return true;
+                               const umap_short_basic &pairs) {
+  auto ser = SymEngine::URatPSeriesFlint::series(ex, x->get_name(), prec);
+  for (auto it : pairs) {
+    // std::cerr << it.first << ", " << *(it.second) << "::" <<
+    // *(v1.at(it.first)) << std::endl;
+    if (not it.second->__eq__(*(ser->get_coeff(it.first))))
+      return false;
+  }
+  return true;
 }
 
-TEST_CASE("Expression series expansion: Add ", "[Expansion of Add]")
-{
-    RCP<const Symbol> x = symbol("x"), y = symbol("y");
-    auto z = add(integer(1), x);
-    z = sub(z, pow(x, integer(2)));
-    z = add(z, pow(x, integer(4)));
-    auto z1 = pow(add(integer(1), x), integer(0));
+TEST_CASE("Expression series expansion: Add ", "[Expansion of Add]") {
+  RCP<const Symbol> x = symbol("x"), y = symbol("y");
+  auto z = add(integer(1), x);
+  z = sub(z, pow(x, integer(2)));
+  z = add(z, pow(x, integer(4)));
+  auto z1 = pow(add(integer(1), x), integer(0));
 
-    auto vb = umap_short_basic{
-        {0, integer(1)}, {1, integer(1)}, {2, integer(-1)}, {4, integer(1)}};
-    REQUIRE(expand_check_pairs(z, x, 5, vb));
-    auto vb1
-        = umap_short_basic{{0, integer(1)}, {1, integer(1)}, {2, integer(-1)}};
-    REQUIRE(expand_check_pairs(z, x, 3, vb1));
-    REQUIRE(series_coeff(z1, x, 9, 0)->__eq__(*integer(1)));
-    REQUIRE(series_coeff(z1, x, 9, 1)->__eq__(*integer(0)));
+  auto vb = umap_short_basic{
+      {0, integer(1)}, {1, integer(1)}, {2, integer(-1)}, {4, integer(1)}};
+  REQUIRE(expand_check_pairs(z, x, 5, vb));
+  auto vb1 =
+      umap_short_basic{{0, integer(1)}, {1, integer(1)}, {2, integer(-1)}};
+  REQUIRE(expand_check_pairs(z, x, 3, vb1));
+  REQUIRE(series_coeff(z1, x, 9, 0)->__eq__(*integer(1)));
+  REQUIRE(series_coeff(z1, x, 9, 1)->__eq__(*integer(0)));
 }
 
-TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    auto z1 = sin(x);
-    auto z2 = cos(x);
-    auto z3 = add(sin(x), cos(x));
-    auto z4 = mul(sin(x), cos(x));
-    auto z5 = sin(atan(x));
-    auto z6 = cos(div(x, sub(one, x)));
+TEST_CASE("Expression series expansion: sin, cos", "[Expansion of sin, cos]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  auto z1 = sin(x);
+  auto z2 = cos(x);
+  auto z3 = add(sin(x), cos(x));
+  auto z4 = mul(sin(x), cos(x));
+  auto z5 = sin(atan(x));
+  auto z6 = cos(div(x, sub(one, x)));
 
-    REQUIRE(series_coeff(z1, x, 10, 9)->__eq__(*rational(1, 362880)));
-    auto res = umap_short_basic{{0, integer(1)}, {2, rational(-1, 2)}};
-    REQUIRE(expand_check_pairs(z2, x, 3, res));
-    REQUIRE(series_coeff(z3, x, 9, 8)->__eq__(*rational(1, 40320)));
-    REQUIRE(series_coeff(z4, x, 12, 11)->__eq__(*rational(-4, 155925)));
-    REQUIRE(series_coeff(z5, x, 30, 27)->__eq__(*rational(-1300075, 8388608)));
-    REQUIRE(series_coeff(z6, x, 15, 11)->__eq__(*rational(-125929, 362880)));
+  REQUIRE(series_coeff(z1, x, 10, 9)->__eq__(*rational(1, 362880)));
+  auto res = umap_short_basic{{0, integer(1)}, {2, rational(-1, 2)}};
+  REQUIRE(expand_check_pairs(z2, x, 3, res));
+  REQUIRE(series_coeff(z3, x, 9, 8)->__eq__(*rational(1, 40320)));
+  REQUIRE(series_coeff(z4, x, 12, 11)->__eq__(*rational(-4, 155925)));
+  REQUIRE(series_coeff(z5, x, 30, 27)->__eq__(*rational(-1300075, 8388608)));
+  REQUIRE(series_coeff(z6, x, 15, 11)->__eq__(*rational(-125929, 362880)));
 }
 
 TEST_CASE("Expression series expansion: division, inversion ",
-          "[Expansion of 1/ex]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    RCP<const Integer> two = integer(2);
-    RCP<const Integer> three = integer(3);
-    auto ex1 = div(one, sub(one, x));                 // 1/(1-x)
-    auto ex2 = div(x, sub(sub(one, x), pow(x, two))); // x/(1-x-x^2)
-    auto ex3
-        = div(pow(x, three), sub(one, mul(pow(x, two), two))); // x^3/(1-2x^2)
-    auto ex4 = div(one, sub(one, sin(x)));                     // 1/(1-sin(x))
-    auto ex5 = div(one, x);
-    auto ex6 = div(one, mul(x, sub(one, x)));
-    auto res1 = umap_short_basic{{-1, integer(1)}};
-    auto res2 = umap_short_basic{{-1, integer(1)}, {0, integer(1)}};
+          "[Expansion of 1/ex]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  RCP<const Integer> two = integer(2);
+  RCP<const Integer> three = integer(3);
+  auto ex1 = div(one, sub(one, x));                 // 1/(1-x)
+  auto ex2 = div(x, sub(sub(one, x), pow(x, two))); // x/(1-x-x^2)
+  auto ex3 =
+      div(pow(x, three), sub(one, mul(pow(x, two), two))); // x^3/(1-2x^2)
+  auto ex4 = div(one, sub(one, sin(x)));                   // 1/(1-sin(x))
+  auto ex5 = div(one, x);
+  auto ex6 = div(one, mul(x, sub(one, x)));
+  auto res1 = umap_short_basic{{-1, integer(1)}};
+  auto res2 = umap_short_basic{{-1, integer(1)}, {0, integer(1)}};
 
-    REQUIRE(series_coeff(ex1, x, 100, 99)->__eq__(*integer(1)));
-    REQUIRE(series_coeff(ex2, x, 100, 35)->__eq__(*integer(9227465)));
-    REQUIRE(series_coeff(ex3, x, 100, 49)->__eq__(*integer(8388608)));
-    REQUIRE(series_coeff(ex4, x, 20, 10)->__eq__(*rational(1382, 14175)));
-    //! TODO: REQUIRE(expand_check_pairs(ex5, x, 8, res1));
-    //! TODO: REQUIRE(expand_check_pairs(ex6, x, 8, res2));
+  REQUIRE(series_coeff(ex1, x, 100, 99)->__eq__(*integer(1)));
+  REQUIRE(series_coeff(ex2, x, 100, 35)->__eq__(*integer(9227465)));
+  REQUIRE(series_coeff(ex3, x, 100, 49)->__eq__(*integer(8388608)));
+  REQUIRE(series_coeff(ex4, x, 20, 10)->__eq__(*rational(1382, 14175)));
+  //! TODO: REQUIRE(expand_check_pairs(ex5, x, 8, res1));
+  //! TODO: REQUIRE(expand_check_pairs(ex6, x, 8, res2));
 }
 
-TEST_CASE("Expression series expansion: roots", "[Expansion of root(ex)]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Number> q12 = rational(1, 2);
-    RCP<const Number> qm23 = rational(-2, 3);
-    RCP<const Integer> one = integer(1);
-    RCP<const Integer> four = integer(4);
-    auto ex1 = pow(sub(four, x), q12);
-    auto ex2 = pow(sub(one, x), qm23);
-    auto ex3 = sqrt(sub(one, x));
-    auto ex4 = pow(cos(x), q12);
-    auto ex5 = pow(cos(x), qm23);
-    auto ex6 = sqrt(cos(x));
+TEST_CASE("Expression series expansion: roots", "[Expansion of root(ex)]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Number> q12 = rational(1, 2);
+  RCP<const Number> qm23 = rational(-2, 3);
+  RCP<const Integer> one = integer(1);
+  RCP<const Integer> four = integer(4);
+  auto ex1 = pow(sub(four, x), q12);
+  auto ex2 = pow(sub(one, x), qm23);
+  auto ex3 = sqrt(sub(one, x));
+  auto ex4 = pow(cos(x), q12);
+  auto ex5 = pow(cos(x), qm23);
+  auto ex6 = sqrt(cos(x));
 
-    REQUIRE(series_coeff(ex1, x, 8, 6)->__eq__(*rational(-21, 2097152)));
-    REQUIRE(series_coeff(ex2, x, 12, 10)->__eq__(*rational(1621477, 4782969)));
-    REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(-2431, 262144)));
-    REQUIRE(series_coeff(ex4, x, 100, 8)->__eq__(*rational(-559, 645120)));
-    REQUIRE(series_coeff(ex5, x, 20, 10)->__eq__(*rational(701, 127575)));
-    REQUIRE(series_coeff(ex6, x, 10, 8)->__eq__(*rational(-559, 645120)));
+  REQUIRE(series_coeff(ex1, x, 8, 6)->__eq__(*rational(-21, 2097152)));
+  REQUIRE(series_coeff(ex2, x, 12, 10)->__eq__(*rational(1621477, 4782969)));
+  REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(-2431, 262144)));
+  REQUIRE(series_coeff(ex4, x, 100, 8)->__eq__(*rational(-559, 645120)));
+  REQUIRE(series_coeff(ex5, x, 20, 10)->__eq__(*rational(701, 127575)));
+  REQUIRE(series_coeff(ex6, x, 10, 8)->__eq__(*rational(-559, 645120)));
 }
 
-TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    RCP<const Integer> two = integer(2);
-    RCP<const Integer> three = integer(3);
-    auto ex1 = log(add(one, x));
-    auto ex2 = log(cos(x));
-    auto ex3 = log(div(one, sub(one, x)));
-    auto ex4 = exp(x);
-    auto ex5 = exp(log(add(x, one)));
-    auto ex6 = log(exp(x));
-    auto ex7 = exp(sin(x));
-    auto ex8 = pow(cos(x), sin(x));
+TEST_CASE("Expression series expansion: log, exp ", "[Expansion of log, exp]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  RCP<const Integer> two = integer(2);
+  RCP<const Integer> three = integer(3);
+  auto ex1 = log(add(one, x));
+  auto ex2 = log(cos(x));
+  auto ex3 = log(div(one, sub(one, x)));
+  auto ex4 = exp(x);
+  auto ex5 = exp(log(add(x, one)));
+  auto ex6 = log(exp(x));
+  auto ex7 = exp(sin(x));
+  auto ex8 = pow(cos(x), sin(x));
 
-    REQUIRE(series_coeff(ex1, x, 100, 98)->__eq__(*rational(-1, 98)));
-    REQUIRE(series_coeff(ex2, x, 20, 12)->__eq__(*rational(-691, 935550)));
-    REQUIRE(series_coeff(ex3, x, 100, 48)->__eq__(*rational(1, 48)));
-    REQUIRE(series_coeff(ex4, x, 20, 9)->__eq__(*rational(1, 362880)));
-    auto res1 = umap_short_basic{{0, integer(1)}, {1, integer(1)}};
-    auto res2 = umap_short_basic{{1, integer(1)}};
-    REQUIRE(expand_check_pairs(ex5, x, 20, res1));
-    REQUIRE(expand_check_pairs(ex6, x, 20, res2));
-    REQUIRE(series_coeff(ex7, x, 20, 10)->__eq__(*rational(-2951, 3628800)));
-    REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*rational(1381, 2661120)));
+  REQUIRE(series_coeff(ex1, x, 100, 98)->__eq__(*rational(-1, 98)));
+  REQUIRE(series_coeff(ex2, x, 20, 12)->__eq__(*rational(-691, 935550)));
+  REQUIRE(series_coeff(ex3, x, 100, 48)->__eq__(*rational(1, 48)));
+  REQUIRE(series_coeff(ex4, x, 20, 9)->__eq__(*rational(1, 362880)));
+  auto res1 = umap_short_basic{{0, integer(1)}, {1, integer(1)}};
+  auto res2 = umap_short_basic{{1, integer(1)}};
+  REQUIRE(expand_check_pairs(ex5, x, 20, res1));
+  REQUIRE(expand_check_pairs(ex6, x, 20, res2));
+  REQUIRE(series_coeff(ex7, x, 20, 10)->__eq__(*rational(-2951, 3628800)));
+  REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*rational(1381, 2661120)));
 }
 
-TEST_CASE("Expression series expansion: reversion ", "[Expansion of f^-1]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> two = integer(2);
-    RCP<const Integer> three = integer(3);
-    auto ex1 = sub(x, pow(x, two));
-    auto ex2 = sub(x, pow(x, three));
-    auto ex3 = sin(x);
-    auto ex4 = mul(x, exp(x));
+TEST_CASE("Expression series expansion: reversion ", "[Expansion of f^-1]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> two = integer(2);
+  RCP<const Integer> three = integer(3);
+  auto ex1 = sub(x, pow(x, two));
+  auto ex2 = sub(x, pow(x, three));
+  auto ex3 = sin(x);
+  auto ex4 = mul(x, exp(x));
 
-    REQUIRE(invseries_coeff(ex1, x, 20, 15)->__eq__(*integer(2674440)));
-    REQUIRE(invseries_coeff(ex2, x, 20, 15)->__eq__(*integer(7752)));
-    REQUIRE(invseries_coeff(ex3, x, 20, 15)->__eq__(*rational(143, 10240)));
-    REQUIRE(invseries_coeff(ex4, x, 20, 10)->__eq__(*rational(-156250, 567)));
+  REQUIRE(invseries_coeff(ex1, x, 20, 15)->__eq__(*integer(2674440)));
+  REQUIRE(invseries_coeff(ex2, x, 20, 15)->__eq__(*integer(7752)));
+  REQUIRE(invseries_coeff(ex3, x, 20, 15)->__eq__(*rational(143, 10240)));
+  REQUIRE(invseries_coeff(ex4, x, 20, 10)->__eq__(*rational(-156250, 567)));
 }
 
 TEST_CASE("Expression series expansion: atan, tan, asin, cot, sec, csc",
-          "[Expansion of tan, atan, asin, cot, sec, csc]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    auto ex1 = atan(x);
-    auto ex2 = atan(div(x, sub(one, x)));
-    auto ex3 = tan(x);
-    auto ex4 = tan(div(x, sub(one, x)));
-    auto ex5 = asin(x);
-    auto ex6 = asin(div(x, sub(one, x)));
-    auto res1 = umap_short_basic{{-1, integer(1)}, {1, rational(-1, 3)}};
-    auto res2
-        = umap_short_basic{{-1, integer(1)}, {7, rational(-1051, 1814400)}};
-    auto ex9 = sec(x);
+          "[Expansion of tan, atan, asin, cot, sec, csc]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  auto ex1 = atan(x);
+  auto ex2 = atan(div(x, sub(one, x)));
+  auto ex3 = tan(x);
+  auto ex4 = tan(div(x, sub(one, x)));
+  auto ex5 = asin(x);
+  auto ex6 = asin(div(x, sub(one, x)));
+  auto res1 = umap_short_basic{{-1, integer(1)}, {1, rational(-1, 3)}};
+  auto res2 = umap_short_basic{{-1, integer(1)}, {7, rational(-1051, 1814400)}};
+  auto ex9 = sec(x);
 
-    REQUIRE(series_coeff(ex1, x, 20, 19)->__eq__(*rational(-1, 19)));
-    REQUIRE(series_coeff(ex2, x, 40, 33)->__eq__(*rational(65536, 33)));
-    REQUIRE(series_coeff(ex3, x, 20, 13)->__eq__(*rational(21844, 6081075)));
-    REQUIRE(series_coeff(ex4, x, 20, 12)->__eq__(*rational(1303712, 14175)));
-    REQUIRE(series_coeff(ex5, x, 20, 15)->__eq__(*rational(143, 10240)));
-    REQUIRE(series_coeff(ex6, x, 20, 16)->__eq__(*rational(1259743, 2048)));
-    REQUIRE(series_coeff(ex9, x, 20, 8)->__eq__(*rational(277, 8064)));
+  REQUIRE(series_coeff(ex1, x, 20, 19)->__eq__(*rational(-1, 19)));
+  REQUIRE(series_coeff(ex2, x, 40, 33)->__eq__(*rational(65536, 33)));
+  REQUIRE(series_coeff(ex3, x, 20, 13)->__eq__(*rational(21844, 6081075)));
+  REQUIRE(series_coeff(ex4, x, 20, 12)->__eq__(*rational(1303712, 14175)));
+  REQUIRE(series_coeff(ex5, x, 20, 15)->__eq__(*rational(143, 10240)));
+  REQUIRE(series_coeff(ex6, x, 20, 16)->__eq__(*rational(1259743, 2048)));
+  REQUIRE(series_coeff(ex9, x, 20, 8)->__eq__(*rational(277, 8064)));
 
-    // These cannot be checked using catch.hpp
-    // See https://github.com/philsquared/Catch/issues/553
-    //    auto ex7 = cot(x);
-    //    auto ex8 = cot(sin(x));
-    //    auto ex10 = csc(x);
-    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex7, "x", 10),
-    //    std::runtime_error);
-    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex8, "x", 10),
-    //    std::runtime_error);
-    //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex10, "x", 10),
-    //    std::runtime_error);
+  // These cannot be checked using catch.hpp
+  // See https://github.com/philsquared/Catch/issues/553
+  //    auto ex7 = cot(x);
+  //    auto ex8 = cot(sin(x));
+  //    auto ex10 = csc(x);
+  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex7, "x", 10),
+  //    std::runtime_error);
+  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex8, "x", 10),
+  //    std::runtime_error);
+  //    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex10, "x", 10),
+  //    std::runtime_error);
 }
 
 TEST_CASE("Expression series expansion: sinh, cosh, tanh, asinh, atanh",
-          "[Expansion of sinh, cosh, tanh, asinh, atanh]")
-{
-    RCP<const Symbol> x = symbol("x");
-    RCP<const Integer> one = integer(1);
-    auto ex1 = sinh(x);
-    auto ex2 = sinh(div(x, sub(one, x)));
-    auto ex3 = cosh(x);
-    auto ex4 = cosh(div(x, sub(one, x)));
-    auto ex5 = tanh(x);
-    auto ex6 = tanh(div(x, sub(one, x)));
-    auto ex7 = atanh(x);
-    auto ex8 = atanh(div(x, sub(one, x)));
-    auto ex9 = asinh(x);
-    auto ex10 = asinh(div(x, sub(one, x)));
+          "[Expansion of sinh, cosh, tanh, asinh, atanh]") {
+  RCP<const Symbol> x = symbol("x");
+  RCP<const Integer> one = integer(1);
+  auto ex1 = sinh(x);
+  auto ex2 = sinh(div(x, sub(one, x)));
+  auto ex3 = cosh(x);
+  auto ex4 = cosh(div(x, sub(one, x)));
+  auto ex5 = tanh(x);
+  auto ex6 = tanh(div(x, sub(one, x)));
+  auto ex7 = atanh(x);
+  auto ex8 = atanh(div(x, sub(one, x)));
+  auto ex9 = asinh(x);
+  auto ex10 = asinh(div(x, sub(one, x)));
 
-    REQUIRE(series_coeff(ex1, x, 10, 9)->__eq__(*rational(1, 362880)));
-    REQUIRE(series_coeff(ex2, x, 20, 10)->__eq__(*rational(325249, 40320)));
-    REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(1, 3628800)));
-    REQUIRE(series_coeff(ex4, x, 20, 11)->__eq__(*rational(3756889, 362880)));
-    REQUIRE(series_coeff(ex5, x, 20, 13)->__eq__(*rational(21844, 6081075)));
-    REQUIRE(series_coeff(ex6, x, 20, 14)->__eq__(*rational(225979, 66825)));
-    REQUIRE(series_coeff(ex7, x, 100, 99)->__eq__(*rational(1, 99)));
-    REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*integer(2048)));
-    REQUIRE(series_coeff(ex9, x, 20, 15)->__eq__(*rational(-143, 10240)));
-    REQUIRE(series_coeff(ex10, x, 20, 16)->__eq__(*rational(-3179, 2048)));
+  REQUIRE(series_coeff(ex1, x, 10, 9)->__eq__(*rational(1, 362880)));
+  REQUIRE(series_coeff(ex2, x, 20, 10)->__eq__(*rational(325249, 40320)));
+  REQUIRE(series_coeff(ex3, x, 12, 10)->__eq__(*rational(1, 3628800)));
+  REQUIRE(series_coeff(ex4, x, 20, 11)->__eq__(*rational(3756889, 362880)));
+  REQUIRE(series_coeff(ex5, x, 20, 13)->__eq__(*rational(21844, 6081075)));
+  REQUIRE(series_coeff(ex6, x, 20, 14)->__eq__(*rational(225979, 66825)));
+  REQUIRE(series_coeff(ex7, x, 100, 99)->__eq__(*rational(1, 99)));
+  REQUIRE(series_coeff(ex8, x, 20, 16)->__eq__(*integer(2048)));
+  REQUIRE(series_coeff(ex9, x, 20, 15)->__eq__(*rational(-143, 10240)));
+  REQUIRE(series_coeff(ex10, x, 20, 16)->__eq__(*rational(-3179, 2048)));
 }
 
 #if 0
@@ -268,11 +256,9 @@ TEST_CASE("Expression series expansion: lambertw ", "[Expansion of lambertw]")
 
 #else
 TEST_CASE("Check error when expansion called without Flint ",
-          "[Expansion without Piranha]")
-{
-    RCP<const Symbol> x = symbol("x");
-    auto ex1 = lambertw(x);
-    REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex1, "x", 10),
-                      std::runtime_error);
+          "[Expansion without Piranha]") {
+  RCP<const Symbol> x = symbol("x");
+  auto ex1 = lambertw(x);
+  REQUIRE_THROWS_AS(URatPSeriesFlint::series(ex1, "x", 10), std::runtime_error);
 }
 #endif


### PR DESCRIPTION
* Since `LLVM apt repository` is back up, the allowed failures are removed.