### PR TITLE
Moving clang-format back to main tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,19 +55,21 @@ matrix:
     - compiler: clang
     - os: osx
   include:
-    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" WITH_COVERAGE="yes" WITH_MPC="yes"
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" TEST_CLANG_FORMAT="yes" WITH_COVERAGE="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
       addons:
         apt:
           sources:
           - ubuntu-toolchain-r-test
+          - llvm-toolchain-precise-3.7
           packages:
           - libgmp-dev
           - libmpfr-dev
           - libmpc-dev
           - binutils-dev
           - g++-5
+          - clang-format-3.7
     - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_PIRANHA="yes" WITH_BENCHMARKS_NONIUS="yes" WITH_COVERAGE="yes" TEST_IN_TREE="yes" WITH_FLINT="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
@@ -134,31 +136,6 @@ matrix:
     - env: BUILD_TYPE="Release"
       compiler: gcc
       os: osx
-    - env: BUILD_TYPE="Release" TEST_CLANG_FORMAT="yes"
-      compiler: gcc
-      os: linux
-      addons:
-        apt:
-          sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-precise-3.7
-          packages:
-          - g++-4.7
-          - libgmp-dev
-          - clang-format-3.7
-  allow_failures:
-    - env: BUILD_TYPE="Release" TEST_CLANG_FORMAT="yes"
-      compiler: gcc
-      os: linux
-      addons:
-        apt:
-          sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-precise-3.7
-          packages:
-          - g++-4.7
-          - libgmp-dev
-          - clang-format-3.7
 
 install:
   - source bin/install_travis.sh

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -497,7 +497,8 @@ public:
                                  const RCP<const Symbol> &x)
     {
         if (self.get_var()->__eq__(*x)) {
-            return UIntPolyFlint::from_container(self.get_var(), self.get_poly().derivative());
+            return UIntPolyFlint::from_container(self.get_var(),
+                                                 self.get_poly().derivative());
         } else {
             return UIntPolyFlint::from_dict(self.get_var(), {{}});
         }

--- a/symengine/flint_wrapper.h
+++ b/symengine/flint_wrapper.h
@@ -490,12 +490,12 @@ public:
         fmpz_poly_init(poly);
         fmpz_poly_set_si(poly, i);
     }
-    fmpz_poly_wrapper(const char* cp)
+    fmpz_poly_wrapper(const char *cp)
     {
         fmpz_poly_init(poly);
         fmpz_poly_set_str(poly, cp);
     }
-    fmpz_poly_wrapper(const fmpz_wrapper& z)
+    fmpz_poly_wrapper(const fmpz_wrapper &z)
     {
         fmpz_poly_init(poly);
         fmpz_poly_set_fmpz(poly, z.get_fmpz_t());
@@ -533,7 +533,7 @@ public:
     {
         return &poly;
     }
-    bool operator==(const fmpz_poly_wrapper& other) const
+    bool operator==(const fmpz_poly_wrapper &other) const
     {
         return fmpz_poly_equal(poly, *other.get_fmpz_poly_t()) == 1;
     }
@@ -555,17 +555,17 @@ public:
         fmpz_poly_get_coeff_fmpz(z.get_fmpz_t(), poly, n);
         return z;
     }
-    void set_coeff(unsigned int n, const fmpz_wrapper& z)
+    void set_coeff(unsigned int n, const fmpz_wrapper &z)
     {
         fmpz_poly_set_coeff_fmpz(poly, n, z.get_fmpz_t());
     }
-    fmpz_wrapper eval(const fmpz_wrapper& z) const
+    fmpz_wrapper eval(const fmpz_wrapper &z) const
     {
         fmpz_wrapper r;
         fmpz_poly_evaluate_fmpz(r.get_fmpz_t(), poly, z.get_fmpz_t());
         return r;
     }
-    void eval_vec(fmpz* ovec, fmpz *ivec, unsigned int n) const
+    void eval_vec(fmpz *ovec, fmpz *ivec, unsigned int n) const
     {
         fmpz_poly_evaluate_fmpz_vec(ovec, *get_fmpz_poly_t(), ivec, n);
     }
@@ -575,29 +575,29 @@ public:
         fmpz_poly_neg(*r.get_fmpz_poly_t(), *get_fmpz_poly_t());
         return r;
     }
-    void operator+=(const fmpz_poly_wrapper& other)
+    void operator+=(const fmpz_poly_wrapper &other)
     {
         fmpz_poly_add(*get_fmpz_poly_t(), *get_fmpz_poly_t(),
-                *other.get_fmpz_poly_t());
+                      *other.get_fmpz_poly_t());
     }
-    void operator-=(const fmpz_poly_wrapper& other)
+    void operator-=(const fmpz_poly_wrapper &other)
     {
         fmpz_poly_sub(*get_fmpz_poly_t(), *get_fmpz_poly_t(),
-                *other.get_fmpz_poly_t());
+                      *other.get_fmpz_poly_t());
     }
-    void operator*=(const fmpz_poly_wrapper& other)
+    void operator*=(const fmpz_poly_wrapper &other)
     {
         fmpz_poly_mul(*get_fmpz_poly_t(), *get_fmpz_poly_t(),
-                *other.get_fmpz_poly_t());
+                      *other.get_fmpz_poly_t());
     }
 
-    fmpz_poly_wrapper gcd(const fmpz_poly_wrapper& other) const
+    fmpz_poly_wrapper gcd(const fmpz_poly_wrapper &other) const
     {
         fmpz_poly_wrapper r;
         fmpz_poly_gcd(*r.get_fmpz_poly_t(), poly, *other.get_fmpz_poly_t());
         return r;
     }
-    fmpz_poly_wrapper lcm(const fmpz_poly_wrapper& other) const
+    fmpz_poly_wrapper lcm(const fmpz_poly_wrapper &other) const
     {
         fmpz_poly_wrapper r;
         fmpz_poly_lcm(*r.get_fmpz_poly_t(), poly, *other.get_fmpz_poly_t());
@@ -609,9 +609,11 @@ public:
         fmpz_poly_pow(*r.get_fmpz_poly_t(), poly, n);
         return r;
     }
-    bool divides(const fmpz_poly_wrapper& other, fmpz_poly_wrapper& r) const
+    bool divides(const fmpz_poly_wrapper &other, fmpz_poly_wrapper &r) const
     {
-        return fmpz_poly_divides(*r.get_fmpz_poly_t(), *other.get_fmpz_poly_t(), poly) == 1;
+        return fmpz_poly_divides(*r.get_fmpz_poly_t(), *other.get_fmpz_poly_t(),
+                                 poly)
+               == 1;
     }
     fmpz_poly_wrapper derivative() const
     {
@@ -636,7 +638,7 @@ public:
         fmpq_poly_init(poly);
         fmpq_poly_set_si(poly, i);
     }
-    fmpq_poly_wrapper(const char* cp)
+    fmpq_poly_wrapper(const char *cp)
     {
         fmpq_poly_init(poly);
         fmpq_poly_set_str(poly, cp);
@@ -651,7 +653,7 @@ public:
         fmpq_poly_init(poly);
         fmpq_poly_set_mpq(poly, q);
     }
-    fmpq_poly_wrapper(const fmpq_wrapper& q)
+    fmpq_poly_wrapper(const fmpq_wrapper &q)
     {
         fmpq_poly_init(poly);
         fmpq_poly_set_fmpq(poly, q.get_fmpq_t());
@@ -704,11 +706,12 @@ public:
         return q;
     }
 
-    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper& o, unsigned int prec) const
+    fmpq_poly_wrapper mullow(const fmpq_poly_wrapper &o,
+                             unsigned int prec) const
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly,
-                *o.get_fmpq_poly_t(), prec);
+        fmpq_poly_mullow(*r.get_fmpq_poly_t(), poly, *o.get_fmpq_poly_t(),
+                         prec);
         return r;
     }
     fmpq_poly_wrapper pow(unsigned int n) const
@@ -814,11 +817,11 @@ public:
         fmpq_poly_atanh_series(*r.get_fmpq_poly_t(), poly, prec);
         return r;
     }
-    fmpq_poly_wrapper subs(const fmpq_poly_wrapper& o, unsigned int prec) const
+    fmpq_poly_wrapper subs(const fmpq_poly_wrapper &o, unsigned int prec) const
     {
         fmpq_poly_wrapper r;
         fmpq_poly_compose_series(*r.get_fmpq_poly_t(), poly,
-                *o.get_fmpq_poly_t(), prec);
+                                 *o.get_fmpq_poly_t(), prec);
         return r;
     }
     void set_zero()
@@ -830,55 +833,65 @@ public:
         fmpq_poly_one(poly);
     }
 
-    bool operator==(const fmpq_poly_wrapper& o) const
+    bool operator==(const fmpq_poly_wrapper &o) const
     {
         return fmpq_poly_equal(poly, *o.get_fmpq_poly_t()) != 0;
     }
-    bool operator<(const fmpq_poly_wrapper& o) const
+    bool operator<(const fmpq_poly_wrapper &o) const
     {
         return fmpq_poly_cmp(poly, *o.get_fmpq_poly_t()) == -1;
     }
 
-    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
+    friend fmpq_poly_wrapper operator+(const fmpq_poly_wrapper &a,
+                                       const fmpq_poly_wrapper &o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
+        fmpq_poly_add(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                      *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
+    friend fmpq_poly_wrapper operator-(const fmpq_poly_wrapper &a,
+                                       const fmpq_poly_wrapper &o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
+        fmpq_poly_sub(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                      *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a, const fmpq_wrapper& q)
+    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
+                                       const fmpq_wrapper &q)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), q.get_fmpq_t());
+        fmpq_poly_scalar_mul_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                                  q.get_fmpq_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper& a, const fmpq_poly_wrapper& o)
+    friend fmpq_poly_wrapper operator*(const fmpq_poly_wrapper &a,
+                                       const fmpq_poly_wrapper &o)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), *o.get_fmpq_poly_t());
+        fmpq_poly_mul(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                      *o.get_fmpq_poly_t());
         return r;
     }
-    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper& a, const fmpq_wrapper& q)
+    friend fmpq_poly_wrapper operator/(const fmpq_poly_wrapper &a,
+                                       const fmpq_wrapper &q)
     {
         fmpq_poly_wrapper r;
-        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(), q.get_fmpq_t());
+        fmpq_poly_scalar_div_fmpq(*r.get_fmpq_poly_t(), *a.get_fmpq_poly_t(),
+                                  q.get_fmpq_t());
         return r;
     }
 
-    void operator+=(const fmpq_poly_wrapper& o)
+    void operator+=(const fmpq_poly_wrapper &o)
     {
         fmpq_poly_add(poly, poly, *o.get_fmpq_poly_t());
     }
-    void operator-=(const fmpq_poly_wrapper& o)
+    void operator-=(const fmpq_poly_wrapper &o)
     {
         fmpq_poly_sub(poly, poly, *o.get_fmpq_poly_t());
     }
-    void operator*=(const fmpq_poly_wrapper& o)
+    void operator*=(const fmpq_poly_wrapper &o)
     {
         fmpq_poly_mul(poly, poly, *o.get_fmpq_poly_t());
     }

--- a/symengine/polys/uintpoly_flint.cpp
+++ b/symengine/polys/uintpoly_flint.cpp
@@ -82,12 +82,12 @@ vec_integer_class UIntPolyFlint::multieval(const vec_integer_class &v) const
     const unsigned int n = v.size();
     fmpz *fvp = _fmpz_vec_init(n);
     for (unsigned int i = 0; i < n; ++i)
-        fmpz_set_mpz(fvp+i, get_mpz_t(v[i]));
+        fmpz_set_mpz(fvp + i, get_mpz_t(v[i]));
 
     poly_.eval_vec(fvp, fvp, n);
     vec_integer_class res(n);
     for (unsigned int i = 0; i < n; ++i)
-        res[i] = to_integer_class(fvp+i);
+        res[i] = to_integer_class(fvp + i);
     _fmpz_vec_clear(fvp, n);
     return res;
 }

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -37,8 +37,7 @@ public:
     fz_t get_coeff_ref(unsigned int x) const;
 
     typedef ContainerForIter<UIntPolyFlint, fz_t> iterator;
-    typedef ContainerRevIter<UIntPolyFlint, fz_t>
-        reverse_iterator;
+    typedef ContainerRevIter<UIntPolyFlint, fz_t> reverse_iterator;
     iterator begin() const
     {
         return iterator(rcp_from_this_cast<UIntPolyFlint>(), 0);
@@ -69,8 +68,8 @@ inline RCP<const UIntPolyFlint> gcd_upoly(const UIntPolyFlint &a,
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
-    return make_rcp<const UIntPolyFlint>(
-        a.get_var(), a.get_poly().gcd(b.get_poly()));
+    return make_rcp<const UIntPolyFlint>(a.get_var(),
+                                         a.get_poly().gcd(b.get_poly()));
 }
 
 inline RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a,
@@ -78,15 +77,14 @@ inline RCP<const UIntPolyFlint> lcm_upoly(const UIntPolyFlint &a,
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw std::runtime_error("Error: variables must agree.");
-    return make_rcp<const UIntPolyFlint>(
-        a.get_var(), a.get_poly().lcm(b.get_poly()));
+    return make_rcp<const UIntPolyFlint>(a.get_var(),
+                                         a.get_poly().lcm(b.get_poly()));
 }
 
 inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a,
                                           unsigned int p)
 {
-    return make_rcp<const UIntPolyFlint>(
-        a.get_var(), a.get_poly().pow(p));
+    return make_rcp<const UIntPolyFlint>(a.get_var(), a.get_poly().pow(p));
 }
 
 inline bool divides_upoly(const UIntPolyFlint &a, const UIntPolyFlint &b,

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -32,7 +32,7 @@ inline integer_class to_integer_class(const integer_class &i)
 #if SYMENGINE_INTEGER_CLASS == SYMENGINE_GMPXX                                 \
     || SYMENGINE_INTEGER_CLASS == SYMENGINE_GMP
 #ifdef HAVE_SYMENGINE_FLINT
-inline integer_class to_integer_class(const fz_t& i)
+inline integer_class to_integer_class(const fz_t &i)
 {
     integer_class x;
     fmpz_get_mpz(x.get_mpz_t(), i.get_fmpz_t());
@@ -51,7 +51,7 @@ inline integer_class to_integer_class(const piranha::integer &i)
 
 #elif SYMENGINE_INTEGER_CLASS == SYMENGINE_PIRANHA
 #ifdef HAVE_SYMENGINE_FLINT
-inline integer_class to_integer_class(const fz_t& i)
+inline integer_class to_integer_class(const fz_t &i)
 {
     integer_class x;
     fmpz_get_mpz(get_mpz_t(x), i.get_fmpz_t());

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -12,8 +12,7 @@ namespace SymEngine
 
 using fp_t = fmpq_poly_wrapper;
 // Univariate Rational Coefficient Power SeriesBase using Flint
-class URatPSeriesFlint
-    : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint>
+class URatPSeriesFlint : public SeriesBase<fp_t, fmpq_wrapper, URatPSeriesFlint>
 {
 public:
     URatPSeriesFlint(const fp_t p, const std::string varname,
@@ -40,7 +39,7 @@ public:
     static fp_t pow(const fp_t &s, int n, unsigned prec);
     static unsigned ldegree(const fp_t &s);
     static inline fmpq_wrapper find_cf(const fp_t &s, const fp_t &var,
-                                        unsigned deg)
+                                       unsigned deg)
     {
         return s.get_coeff(deg);
     }

--- a/symengine/tests/basic/test_series_expansion_URatF.cpp
+++ b/symengine/tests/basic/test_series_expansion_URatF.cpp
@@ -27,7 +27,7 @@ using SymEngine::fmpq_wrapper;
     SymEngine::URatPSeriesFlint::series(EX, SYM->get_name(), PREC)             \
         ->get_coeff(COEFF)
 
-static RCP<const Number> fmpqxx2sym(const fmpq_wrapper& fc)
+static RCP<const Number> fmpqxx2sym(const fmpq_wrapper &fc)
 {
     mpq_t gc;
     mpq_init(gc);


### PR DESCRIPTION
* This is extension of #1001. 

* Since LLVM apt repository is back up, the allowed failures are removed.