### PR TITLE
Fix mp_powm of Flint

### DIFF
--- a/symengine/mp_class.h
+++ b/symengine/mp_class.h
@@ -511,10 +511,12 @@ inline void mp_powm(fmpz_wrapper &res, const fmpz_wrapper &a,
                     const fmpz_wrapper &b, const fmpz_wrapper &m)
 {
     if (b >= 0) {
-        fmpz_powm(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t(), m.get_fmpz_t());
+        fmpz_powm(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t(),
+                  m.get_fmpz_t());
     } else {
         fmpz_neg(res.get_fmpz_t(), b.get_fmpz_t());
-        fmpz_powm(res.get_fmpz_t(), a.get_fmpz_t(), res.get_fmpz_t(), m.get_fmpz_t());
+        fmpz_powm(res.get_fmpz_t(), a.get_fmpz_t(), res.get_fmpz_t(),
+                  m.get_fmpz_t());
         fmpz_invmod(res.get_fmpz_t(), res.get_fmpz_t(), m.get_fmpz_t());
     }
 }

--- a/symengine/mp_class.h
+++ b/symengine/mp_class.h
@@ -510,7 +510,13 @@ inline void mp_pow_ui(fmpz_wrapper &res, const fmpz_wrapper &i, unsigned long n)
 inline void mp_powm(fmpz_wrapper &res, const fmpz_wrapper &a,
                     const fmpz_wrapper &b, const fmpz_wrapper &m)
 {
-    fmpz_powm(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t(), m.get_fmpz_t());
+    if (b >= 0) {
+        fmpz_powm(res.get_fmpz_t(), a.get_fmpz_t(), b.get_fmpz_t(), m.get_fmpz_t());
+    } else {
+        fmpz_neg(res.get_fmpz_t(), b.get_fmpz_t());
+        fmpz_powm(res.get_fmpz_t(), a.get_fmpz_t(), res.get_fmpz_t(), m.get_fmpz_t());
+        fmpz_invmod(res.get_fmpz_t(), res.get_fmpz_t(), m.get_fmpz_t());
+    }
 }
 
 inline bool mp_invert(fmpz_wrapper &res, const fmpz_wrapper &a,

--- a/symengine/tests/ntheory/test_ntheory.cpp
+++ b/symengine/tests/ntheory/test_ntheory.cpp
@@ -627,12 +627,12 @@ TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
     roots.clear();
     nthroot_mod_list(roots, im4, i4, i65);
     REQUIRE(roots.size() == 16);
-    v = {integer(4),  integer(6),  integer(7), integer(9),
-         integer(17),  integer(19),  integer(22), integer(32),
-         integer(33),  integer(43),  integer(46), integer(48),
+    v = {integer(4),  integer(6),  integer(7),  integer(9),
+         integer(17), integer(19), integer(22), integer(32),
+         integer(33), integer(43), integer(46), integer(48),
          integer(56), integer(58), integer(59), integer(61)};
     same = std::equal(v.begin(), v.end(), roots.begin(),
-                           SymEngine::RCPBasicKeyEq());
+                      SymEngine::RCPBasicKeyEq());
     REQUIRE(same == true);
 }
 

--- a/symengine/tests/ntheory/test_ntheory.cpp
+++ b/symengine/tests/ntheory/test_ntheory.cpp
@@ -560,6 +560,7 @@ TEST_CASE("test_legendre_jacobi_kronecker(): ntheory", "[ntheory]")
 TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
 {
     RCP<const Integer> im1 = integer(-1);
+    RCP<const Integer> im4 = integer(-4);
     RCP<const Integer> i1 = integer(1);
     RCP<const Integer> i2 = integer(2);
     RCP<const Integer> i3 = integer(3);
@@ -575,6 +576,7 @@ TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
     RCP<const Integer> i32 = integer(32);
     RCP<const Integer> i41 = integer(41);
     RCP<const Integer> i64 = integer(64);
+    RCP<const Integer> i65 = integer(65);
     RCP<const Integer> i93 = integer(93);
     RCP<const Integer> i100 = integer(100);
     RCP<const Integer> i105 = integer(105);
@@ -621,6 +623,17 @@ TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
     roots.clear();
     nthroot_mod_list(roots, i1, i18, i105);
     REQUIRE(roots.size() == 24);
+
+    roots.clear();
+    nthroot_mod_list(roots, im4, i4, i65);
+    REQUIRE(roots.size() == 16);
+    v = {integer(4),  integer(6),  integer(7), integer(9),
+         integer(17),  integer(19),  integer(22), integer(32),
+         integer(33),  integer(43),  integer(46), integer(48),
+         integer(56), integer(58), integer(59), integer(61)};
+    same = std::equal(v.begin(), v.end(), roots.begin(),
+                           SymEngine::RCPBasicKeyEq());
+    REQUIRE(same == true);
 }
 
 TEST_CASE("test_powermod(): ntheory", "[ntheory]")


### PR DESCRIPTION
Special case negative numbers b for a**b mod m
gmp does the correct thing for `b`, but flint is undefined for `b` < 0.