### PR TITLE
safe accessors to Add::coeff_ and dict_

### DIFF
--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -331,19 +331,4 @@ vec_basic Add::get_args() const
     return args;
 }
 
-RCP<const Number> Add::get_coef() const
-{
-    return coef_;
-}
-
-umap_basic_num::const_iterator Add::cbegin() const
-{
-    return dict_.cbegin();
-}
-
-umap_basic_num::const_iterator Add::cend() const
-{
-    return dict_.cend();
-}
-
 } // SymEngine

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -331,4 +331,19 @@ vec_basic Add::get_args() const
     return args;
 }
 
+RCP<const Number> Add::get_coef() const
+{
+    return coef_;
+}
+
+umap_basic_num::const_iterator Add::cbegin() const
+{
+    return dict_.cbegin();
+}
+
+umap_basic_num::const_iterator Add::cend() const
+{
+    return dict_.cend();
+}
+
 } // SymEngine

--- a/symengine/add.h
+++ b/symengine/add.h
@@ -73,7 +73,7 @@ public:
     {
         return coef_;
     }
-    const umap_basic_num& get_dict() const
+    const umap_basic_num &get_dict() const
     {
         return dict_;
     }

--- a/symengine/add.h
+++ b/symengine/add.h
@@ -68,6 +68,9 @@ public:
                       const umap_basic_num &dict) const;
 
     virtual vec_basic get_args() const;
+    RCP<const Number> get_coef() const;
+    umap_basic_num::const_iterator cbegin() const;
+    umap_basic_num::const_iterator cend() const;
 };
 
 //! \return Add made from `a + b`

--- a/symengine/add.h
+++ b/symengine/add.h
@@ -68,9 +68,15 @@ public:
                       const umap_basic_num &dict) const;
 
     virtual vec_basic get_args() const;
-    RCP<const Number> get_coef() const;
-    umap_basic_num::const_iterator cbegin() const;
-    umap_basic_num::const_iterator cend() const;
+
+    RCP<const Number> get_coef() const
+    {
+        return coef_;
+    }
+    const umap_basic_num& get_dict() const
+    {
+        return dict_;
+    }
 };
 
 //! \return Add made from `a + b`

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -240,6 +240,22 @@ TEST_CASE("Add: basic", "[basic]")
     REQUIRE(vec_basic_eq_perm(r->get_args(), {mul(integer(2), x), y}));
     REQUIRE(not vec_basic_eq_perm(r->get_args(), {mul(integer(3), x), y}));
 
+    RCP<const Add> ar = rcp_static_cast<const Add>(r);
+    REQUIRE(eq(*ar->get_coef(), *zero));
+    umap_basic_num::const_iterator it = ar->cbegin();
+    const Basic &br1 = *(it->first);
+    const Number &nr1 = *(it->second);
+    bool ok = ((eq(br1, *x) and eq(nr1, *integer(2)))
+            or (eq(br1, *y) and eq(nr1, *integer(1))));
+    REQUIRE(ok);
+    ++it;
+    const Basic& br2 = *(it->first);
+    const Number& nr2 = *(it->second);
+    ok = ((eq(br2, *x) and eq(nr2, *integer(2)))
+            or (eq(br2, *y) and eq(nr2, *integer(1))));
+    REQUIRE(ok);
+    REQUIRE(++it == ar->cend());
+
     RCP<const Basic> term1, term2;
     RCP<const Add> a1 = rcp_static_cast<const Add>(add(r, r));
     a1->as_two_terms(outArg(term1), outArg(term2));
@@ -247,6 +263,8 @@ TEST_CASE("Add: basic", "[basic]")
     REQUIRE(eq(*a1, *a2));
 
     r = add(mul(integer(5), x), integer(5));
+    ar = rcp_static_cast<const Add>(r);
+    REQUIRE(eq(*ar->get_coef(), *integer(5)));
     REQUIRE(vec_basic_eq_perm(r->get_args(), {mul(integer(5), x), integer(5)}));
 
     r = add(add(mul(mul(integer(2), x), y), integer(5)), pow(x, integer(2)));

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -242,19 +242,13 @@ TEST_CASE("Add: basic", "[basic]")
 
     RCP<const Add> ar = rcp_static_cast<const Add>(r);
     REQUIRE(eq(*ar->get_coef(), *zero));
-    umap_basic_num::const_iterator it = ar->cbegin();
-    const Basic &br1 = *(it->first);
-    const Number &nr1 = *(it->second);
-    bool ok = ((eq(br1, *x) and eq(nr1, *integer(2)))
-            or (eq(br1, *y) and eq(nr1, *integer(1))));
-    REQUIRE(ok);
-    ++it;
-    const Basic& br2 = *(it->first);
-    const Number& nr2 = *(it->second);
-    ok = ((eq(br2, *x) and eq(nr2, *integer(2)))
-            or (eq(br2, *y) and eq(nr2, *integer(1))));
-    REQUIRE(ok);
-    REQUIRE(++it == ar->cend());
+    const umap_basic_num& addmap = ar->get_dict();
+    auto search = addmap.find(x);
+    REQUIRE(search != addmap.end());
+    REQUIRE(eq(*search->second, *integer(2)));
+    search = addmap.find(y);
+    REQUIRE(search != addmap.end());
+    REQUIRE(eq(*search->second, *integer(1)));
 
     RCP<const Basic> term1, term2;
     RCP<const Add> a1 = rcp_static_cast<const Add>(add(r, r));

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -242,7 +242,7 @@ TEST_CASE("Add: basic", "[basic]")
 
     RCP<const Add> ar = rcp_static_cast<const Add>(r);
     REQUIRE(eq(*ar->get_coef(), *zero));
-    const umap_basic_num& addmap = ar->get_dict();
+    const umap_basic_num &addmap = ar->get_dict();
     auto search = addmap.find(x);
     REQUIRE(search != addmap.end());
     REQUIRE(eq(*search->second, *integer(2)));


### PR DESCRIPTION
Something like this is needed to provide SymPy's `x.as_coefficients_dict`, see https://github.com/symengine/symengine.py/issues/59

If you can think of a better interface, share your thoughts please.