### PR TITLE
has_symbol(): replace unnecessary RCP function arg

### DIFF
--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -212,7 +212,7 @@ public:
         do {
             name = "_" + name;
             s = symbol(name);
-        } while (has_symbol(b, s));
+        } while (has_symbol(b, *s));
         return s;
     }
 

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1313,7 +1313,7 @@ bool Derivative::is_canonical(const RCP<const Basic> &arg,
         bool found = false;
         auto v = arg->get_args();
         for (auto &p : x) {
-            if (has_symbol(*v[0], rcp_static_cast<const Symbol>(p))) {
+            if (has_symbol(*v[0], *rcp_static_cast<const Symbol>(p))) {
                 found = true;
                 break;
             }
@@ -1323,8 +1323,8 @@ bool Derivative::is_canonical(const RCP<const Basic> &arg,
         bool found = false;
         auto v = arg->get_args();
         for (auto &p : x) {
-            if (has_symbol(*v[0], rcp_static_cast<const Symbol>(p))
-                or has_symbol(*v[1], rcp_static_cast<const Symbol>(p))) {
+            if (has_symbol(*v[0], *rcp_static_cast<const Symbol>(p))
+                or has_symbol(*v[1], *rcp_static_cast<const Symbol>(p))) {
                 found = true;
                 break;
             }

--- a/symengine/series.cpp
+++ b/symengine/series.cpp
@@ -25,7 +25,7 @@ RCP<const SeriesCoeffInterface> series(const RCP<const Basic> &ex,
     if (prec == 0)
         return make_rcp<const UPSeriesPiranha>(p_expr{Expression()},
                                                var->get_name(), prec);
-    if (not has_symbol(*ex, var))
+    if (not has_symbol(*ex, *var))
         return make_rcp<const UPSeriesPiranha>(p_expr{Expression(ex)},
                                                var->get_name(), prec);
     if (is_a<Symbol>(*ex))

--- a/symengine/series_visitor.h
+++ b/symengine/series_visitor.h
@@ -280,7 +280,7 @@ public:
     }
     void bvisit(const Basic &x)
     {
-        if (!has_symbol(x, symbol(varname))) {
+        if (!has_symbol(x, *symbol(varname))) {
             p = Series::convert(x);
         } else {
             throw std::runtime_error("Not Implemented");

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -30,6 +30,7 @@ using SymEngine::make_rcp;
 using SymEngine::print_stack_on_segfault;
 using SymEngine::Complex;
 using SymEngine::has_symbol;
+using SymEngine::coeff;
 using SymEngine::is_a;
 using SymEngine::rcp_static_cast;
 using SymEngine::set_basic;
@@ -789,6 +790,22 @@ TEST_CASE("has_symbol: Basic", "[basic]")
     REQUIRE(has_symbol(*r1, *x));
     REQUIRE(has_symbol(*r1, *y));
     REQUIRE(not has_symbol(*r1, *z));
+}
+
+TEST_CASE("coeff: Basic", "[basic]")
+{
+    RCP<const Basic> r1;
+    RCP<const Symbol> x, y, z;
+    x = symbol("x");
+    y = symbol("y");
+    z = symbol("z");
+    r1 = add(x, pow(y, integer(2)));
+    REQUIRE(eq(*coeff(*r1, x, integer(1)), *integer(1)));
+    REQUIRE(eq(*coeff(*r1, x, integer(1)), *integer(1)));
+    REQUIRE(eq(*coeff(*r1, y, integer(0)), *integer(0)));
+    REQUIRE(eq(*coeff(*r1, y, integer(1)), *integer(0)));
+    REQUIRE(eq(*coeff(*r1, y, integer(2)), *integer(1)));
+    REQUIRE(eq(*coeff(*r1, z, integer(2)), *integer(0)));
 }
 
 TEST_CASE("free_symbols: Basic", "[basic]")

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -781,14 +781,14 @@ TEST_CASE("has_symbol: Basic", "[basic]")
     y = symbol("y");
     z = symbol("z");
     r1 = add(x, pow(y, integer(2)));
-    REQUIRE(has_symbol(*r1, x));
-    REQUIRE(has_symbol(*r1, y));
-    REQUIRE(not has_symbol(*r1, z));
+    REQUIRE(has_symbol(*r1, *x));
+    REQUIRE(has_symbol(*r1, *y));
+    REQUIRE(not has_symbol(*r1, *z));
 
     r1 = sin(add(x, pow(y, integer(2))));
-    REQUIRE(has_symbol(*r1, x));
-    REQUIRE(has_symbol(*r1, y));
-    REQUIRE(not has_symbol(*r1, z));
+    REQUIRE(has_symbol(*r1, *x));
+    REQUIRE(has_symbol(*r1, *y));
+    REQUIRE(not has_symbol(*r1, *z));
 }
 
 TEST_CASE("free_symbols: Basic", "[basic]")

--- a/symengine/tests/basic/test_series_generic.cpp
+++ b/symengine/tests/basic/test_series_generic.cpp
@@ -53,7 +53,8 @@ TEST_CASE("Create UnivariateSeries", "[UnivariateSeries]")
     REQUIRE(R->__str__() == "a*x**2 + b*x + c + O(x**3)");
 
     // check if unknown types are handled by visitor
-    RCP<const UnivariateSeries> S = UnivariateSeries::series(emptyset(), "x", 2);
+    RCP<const UnivariateSeries> S
+        = UnivariateSeries::series(emptyset(), "x", 2);
     REQUIRE(S->__str__() == "EmptySet + O(x**2)");
 }
 

--- a/symengine/tests/basic/test_series_generic.cpp
+++ b/symengine/tests/basic/test_series_generic.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 #include <chrono>
 
+#include <symengine/sets.h>
 #include <symengine/series_generic.h>
 
 using SymEngine::UExprDict;
@@ -20,6 +21,7 @@ using SymEngine::Integer;
 using SymEngine::integer;
 using SymEngine::integer_class;
 using SymEngine::rational;
+using SymEngine::emptyset;
 using SymEngine::vec_basic_eq_perm;
 using SymEngine::Expression;
 using SymEngine::umap_short_basic;
@@ -49,6 +51,10 @@ TEST_CASE("Create UnivariateSeries", "[UnivariateSeries]")
     UExprDict cpoly_(cdict_);
     RCP<const UnivariateSeries> R = UnivariateSeries::create(x, 3, cpoly_);
     REQUIRE(R->__str__() == "a*x**2 + b*x + c + O(x**3)");
+
+    // check if unknown types are handled by visitor
+    RCP<const UnivariateSeries> S = UnivariateSeries::series(emptyset(), "x", 2);
+    REQUIRE(S->__str__() == "EmptySet + O(x**2)");
 }
 
 TEST_CASE("Adding two UnivariateSeries", "[UnivariateSeries]")

--- a/symengine/visitor.cpp
+++ b/symengine/visitor.cpp
@@ -51,8 +51,8 @@ void postorder_traversal_stop(const Basic &b, StopVisitor &v)
 
 bool has_symbol(const Basic &b, const Symbol& x)
 {
-    HasSymbolVisitor v;
-    return v.apply(b, x);
+    HasSymbolVisitor v(x);
+    return v.apply(b);
 }
 
 RCP<const Basic> coeff(const Basic &b, const RCP<const Basic> &x,

--- a/symengine/visitor.cpp
+++ b/symengine/visitor.cpp
@@ -49,7 +49,7 @@ void postorder_traversal_stop(const Basic &b, StopVisitor &v)
     b.accept(v);
 }
 
-bool has_symbol(const Basic &b, const Symbol& x)
+bool has_symbol(const Basic &b, const Symbol &x)
 {
     HasSymbolVisitor v(x);
     return v.apply(b);

--- a/symengine/visitor.cpp
+++ b/symengine/visitor.cpp
@@ -49,7 +49,7 @@ void postorder_traversal_stop(const Basic &b, StopVisitor &v)
     b.accept(v);
 }
 
-bool has_symbol(const Basic &b, const RCP<const Symbol> &x)
+bool has_symbol(const Basic &b, const Symbol& x)
 {
     HasSymbolVisitor v;
     return v.apply(b, x);

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -76,7 +76,10 @@ protected:
     bool has_;
 
 public:
-    HasSymbolVisitor(const Symbol &x) : x_(&x) {}
+    HasSymbolVisitor(const Symbol &x) : x_(&x)
+    {
+    }
+
     void bvisit(const Symbol &x)
     {
         if (x_->__eq__(x)) {
@@ -100,7 +103,7 @@ public:
     }
 };
 
-bool has_symbol(const Basic &b, const Symbol& x);
+bool has_symbol(const Basic &b, const Symbol &x);
 
 class CoeffVisitor : public BaseVisitor<CoeffVisitor, StopVisitor>
 {

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -76,6 +76,7 @@ protected:
     bool has_;
 
 public:
+    HasSymbolVisitor(const Symbol &x) : x_(&x) {}
     void bvisit(const Symbol &x)
     {
         if (x_->__eq__(x)) {
@@ -86,13 +87,12 @@ public:
 
     void bvisit(const Basic &x){};
 
-    bool apply(const Basic &b, const Symbol& x)
+    bool apply(const Basic &b)
     {
         // We are breaking a rule and assigning to a Ptr from a raw pointer
         // directly. But since HasSymbolVisitor is only instantiated inside the
         // has_symbol() function, the `x` can never go out of scope, so this is
         // safe.
-        x_ = Ptr<const Symbol>(&x);
         has_ = false;
         stop_ = false;
         preorder_traversal_stop(b, *this);

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -72,7 +72,7 @@ void postorder_traversal_stop(const Basic &b, StopVisitor &v);
 class HasSymbolVisitor : public BaseVisitor<HasSymbolVisitor, StopVisitor>
 {
 protected:
-    const Symbol* x_;
+    Ptr<const Symbol> x_;
     bool has_;
 
 public:
@@ -88,7 +88,11 @@ public:
 
     bool apply(const Basic &b, const Symbol& x)
     {
-        x_ = &x;
+        // We are breaking a rule and assigning to a Ptr from a raw pointer
+        // directly. But since HasSymbolVisitor is only instantiated inside the
+        // has_symbol() function, the `x` can never go out of scope, so this is
+        // safe.
+        x_ = Ptr<const Symbol>(&x);
         has_ = false;
         stop_ = false;
         preorder_traversal_stop(b, *this);

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -72,7 +72,7 @@ void postorder_traversal_stop(const Basic &b, StopVisitor &v);
 class HasSymbolVisitor : public BaseVisitor<HasSymbolVisitor, StopVisitor>
 {
 protected:
-    RCP<const Symbol> x_;
+    const Symbol* x_;
     bool has_;
 
 public:
@@ -86,9 +86,9 @@ public:
 
     void bvisit(const Basic &x){};
 
-    bool apply(const Basic &b, const RCP<const Symbol> &x)
+    bool apply(const Basic &b, const Symbol& x)
     {
-        x_ = x;
+        x_ = &x;
         has_ = false;
         stop_ = false;
         preorder_traversal_stop(b, *this);
@@ -96,7 +96,7 @@ public:
     }
 };
 
-bool has_symbol(const Basic &b, const RCP<const Symbol> &x);
+bool has_symbol(const Basic &b, const Symbol& x);
 
 class CoeffVisitor : public BaseVisitor<CoeffVisitor, StopVisitor>
 {


### PR DESCRIPTION
Take 3. There is still a coverage fail which led me to the investigation of a hidden bug in series_visitor.h (probably). Later.