### PR TITLE
Improved sec(x) and csc(x) functions for x = 0 case

### DIFF
--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -113,6 +113,10 @@ bool get_pi_shift(const RCP<const Basic> &arg, const Ptr<RCP<const Integer>> &n,
         *n = integer(12);
         *x = zero;
         return true;
+    } else if (eq(*arg, *zero)) {
+        *n = integer(0);
+        *x = zero;
+        return true;
     } else {
         return false;
     }

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -649,6 +649,7 @@ TEST_CASE("Csc: functions", "[functions]")
     REQUIRE(eq(*r1, *r2));
 
     CHECK_THROWS_AS(csc(mul(integer(7), pi)), std::runtime_error);
+    CHECK_THROWS_AS(csc(integer(0)), std::runtime_error);
 }
 
 TEST_CASE("Sec: functions", "[functions]")
@@ -689,6 +690,10 @@ TEST_CASE("Sec: functions", "[functions]")
     std::cout << *r1 << std::endl;
     std::cout << *r2 << std::endl;
     REQUIRE(eq(*r1, *r2));
+
+    // sec(0) = zero
+    r1 = sec(zero);
+    REQUIRE(eq(*r1, *i1));
 
     // sec(-y) = sec(y)
     r1 = sec(mul(im1, y));


### PR DESCRIPTION
Fix for #921. Enabled function `get_pi_shift()` to account for `arg == 0` case

#### Output before this PR:
```python
sec(0) = 2*2**(1/2)/(1 + 3**(1/2))

csc(0) = -4/(-1 + 5**(1/2))
```
#### Output after this PR:
```python
sec(0) = 1

csc(0) # returns " libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: div: Division by zero "
```