### PR TITLE
Sign check for Numbers

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -408,6 +408,11 @@ int basic_number_sign(const basic s)
     }
 }
 
+int is_a_Number(const basic s)
+{
+    return (int)is_a_Number(*(s->m));
+}
+
 #define IMPLEMENT_ONE_ARG_FUNC(func)                                           \
     void basic_##func(basic s, const basic a)                                  \
     {                                                                          \

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -394,6 +394,17 @@ int basic_neq(const basic a, const basic b)
     return SymEngine::neq(*(a->m), *(b->m)) ? 1 : 0;
 }
 
+int basic_number_sign(const basic s)
+{
+    if ((rcp_static_cast<const Number>(s->m))->is_positive()) {
+        return 1;
+    } else if ((rcp_static_cast<const Number>(s->m))->is_zero()) {
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
 #define IMPLEMENT_ONE_ARG_FUNC(func)                                           \
     void basic_##func(basic s, const basic a)                                  \
     {                                                                          \

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -396,6 +396,9 @@ int basic_neq(const basic a, const basic b)
 
 int basic_number_sign(const basic s)
 {
+
+    SYMENGINE_ASSERT(is_a_Number(*(s->m)));
+
     if ((rcp_static_cast<const Number>(s->m))->is_positive()) {
         return 1;
     } else if ((rcp_static_cast<const Number>(s->m))->is_zero()) {

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -258,6 +258,19 @@ int complex_mpc_is_zero(const basic s)
     SYMENGINE_ASSERT(is_a<ComplexMPC>(*(s->m)));
     return (int)((rcp_static_cast<const ComplexMPC>(s->m))->is_zero());
 }
+
+void complex_mpc_real_part(basic s, const basic com)
+{
+    SYMENGINE_ASSERT(is_a<ComplexMPC>(*(com->m)));
+    s->m = (rcp_static_cast<const ComplexMPC>(com->m))->real_part();
+}
+
+void complex_mpc_imaginary_part(basic s, const basic com)
+{
+    SYMENGINE_ASSERT(is_a<ComplexMPC>(*(com->m)));
+    s->m = (rcp_static_cast<const ComplexMPC>(com->m))->imaginary_part();
+}
+
 #endif // HAVE_SYMENGINE_MPC
 signed long integer_get_si(const basic s)
 {
@@ -408,11 +421,6 @@ int basic_number_sign(const basic s)
     }
 }
 
-int is_a_Number(const basic s)
-{
-    return (int)is_a_Number(*(s->m));
-}
-
 #define IMPLEMENT_ONE_ARG_FUNC(func)                                           \
     void basic_##func(basic s, const basic a)                                  \
     {                                                                          \
@@ -464,6 +472,10 @@ void basic_str_free(char *s)
     delete[] s;
 }
 
+int is_a_Number(const basic s)
+{
+    return (int)is_a_Number(*(s->m));
+}
 int is_a_Integer(const basic c)
 {
     return is_a<Integer>(*(c->m));

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -208,6 +208,8 @@ int basic_eq(const basic a, const basic b);
 int basic_neq(const basic a, const basic b);
 //! Returns +1 if s (Number) is positive, 0 if 0, -1 if negative
 int basic_number_sign(const basic s);
+//! Return 1 if s is a Number, 0 otherwise
+int is_a_Number(const basic s);
 
 //! Expands the expr a and assigns to s.
 void basic_expand(basic s, const basic a);

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -156,6 +156,10 @@ int real_mpfr_is_zero(const basic s);
 #ifdef HAVE_SYMENGINE_MPC
 //! Returns 1 if s has value zero; 0 otherwise
 int complex_mpc_is_zero(const basic s);
+//! Assign to s, the real part of com
+void complex_mpc_real_part(basic s, const basic com);
+//! Assign to s, the imaginary part of com
+void complex_mpc_imaginary_part(basic s, const basic com);
 #endif // HAVE_SYMENGINE_MPC
 
 //! Returns signed long value of s.
@@ -208,8 +212,6 @@ int basic_eq(const basic a, const basic b);
 int basic_neq(const basic a, const basic b);
 //! Returns +1 if s (Number) is positive, 0 if 0, -1 if negative
 int basic_number_sign(const basic s);
-//! Return 1 if s is a Number, 0 otherwise
-int is_a_Number(const basic s);
 
 //! Expands the expr a and assigns to s.
 void basic_expand(basic s, const basic a);
@@ -289,6 +291,8 @@ char *basic_str(const basic s);
 //! Frees the string s
 void basic_str_free(char *s);
 
+//! Return 1 if s is a Number, 0 if not.
+int is_a_Number(const basic s);
 //! Return 1 if s is an Integer, 0 if not.
 int is_a_Integer(const basic s);
 //! Return 1 if s is a Rational, 0 if not.

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -206,6 +206,8 @@ int basic_diff(basic s, const basic expr, const basic sym);
 int basic_eq(const basic a, const basic b);
 //! Returns 1 if both basic are not equal, 0 if they are
 int basic_neq(const basic a, const basic b);
+//! Returns +1 if s is positive, 0 if 0, -1 if negative
+int basic_number_sign(const basic s);
 
 //! Expands the expr a and assigns to s.
 void basic_expand(basic s, const basic a);

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -206,7 +206,7 @@ int basic_diff(basic s, const basic expr, const basic sym);
 int basic_eq(const basic a, const basic b);
 //! Returns 1 if both basic are not equal, 0 if they are
 int basic_neq(const basic a, const basic b);
-//! Returns +1 if s is positive, 0 if 0, -1 if negative
+//! Returns +1 if s (Number) is positive, 0 if 0, -1 if negative
 int basic_number_sign(const basic s);
 
 //! Expands the expr a and assigns to s.

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -66,12 +66,20 @@ void test_cwrapper()
     SYMENGINE_C_ASSERT(!is_a_Symbol(e));
     SYMENGINE_C_ASSERT(is_a_Rational(e));
     SYMENGINE_C_ASSERT(!is_a_Integer(e));
+    
+    
+    integer_set_si(e, 0);
+    SYMENGINE_C_ASSERT(integer_get_si(e) == 0);
+    SYMENGINE_C_ASSERT(basic_number_sign(e) == 0);
 
     integer_set_ui(e, 123);
     SYMENGINE_C_ASSERT(integer_get_ui(e) == 123);
+    SYMENGINE_C_ASSERT(basic_number_sign(e) == 1);
 
     integer_set_si(e, -123);
     SYMENGINE_C_ASSERT(integer_get_si(e) == -123);
+    SYMENGINE_C_ASSERT(basic_number_sign(e) == -1);
+    
 
     mpz_t test;
     mpz_init(test);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -23,7 +23,11 @@ void test_cwrapper()
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
-
+    
+    SYMENGINE_C_ASSERT(is_a_Number(x) == 0);
+    SYMENGINE_C_ASSERT(is_a_Number(y) == 0);
+    SYMENGINE_C_ASSERT(is_a_Number(z) == 0);
+    
     s = basic_str(x);
     SYMENGINE_C_ASSERT(strcmp(s, "x") == 0);
     basic_str_free(s);
@@ -79,6 +83,8 @@ void test_cwrapper()
     integer_set_si(e, -123);
     SYMENGINE_C_ASSERT(integer_get_si(e) == -123);
     SYMENGINE_C_ASSERT(basic_number_sign(e) == -1);
+    
+    SYMENGINE_C_ASSERT(is_a_Number(e) == 1);
     
 
     mpz_t test;

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -71,7 +71,6 @@ void test_cwrapper()
     SYMENGINE_C_ASSERT(is_a_Rational(e));
     SYMENGINE_C_ASSERT(!is_a_Integer(e));
     
-    
     integer_set_si(e, 0);
     SYMENGINE_C_ASSERT(integer_get_si(e) == 0);
     SYMENGINE_C_ASSERT(basic_number_sign(e) == 0);
@@ -83,10 +82,8 @@ void test_cwrapper()
     integer_set_si(e, -123);
     SYMENGINE_C_ASSERT(integer_get_si(e) == -123);
     SYMENGINE_C_ASSERT(basic_number_sign(e) == -1);
-    
     SYMENGINE_C_ASSERT(is_a_Number(e) == 1);
     
-
     mpz_t test;
     mpz_init(test);
 
@@ -270,23 +267,34 @@ void test_real_mpfr()
 #ifdef HAVE_SYMENGINE_MPC
 void test_complex_mpc()
 {
-    basic d, d1, imag;
+    basic d, d1, d2;
     basic_new_stack(d);
     basic_new_stack(d1);
-    basic_new_stack(imag);
+    basic_new_stack(d2);
 
-    basic_const_I(imag);
+    basic_const_I(d2);
 
     real_mpfr_set_d(d, 0.000001, 200);
-    real_mpfr_set_d(d1, 000001, 200);
-    basic_mul(d1, d1, imag);
-    basic_add(d, d, d1);
-    SYMENGINE_C_ASSERT(basic_get_type(d) == SYMENGINE_COMPLEX_MPC);
-    SYMENGINE_C_ASSERT(complex_mpc_is_zero(d) == 0);
+    real_mpfr_set_d(d1, 0.000001, 200);
+    basic_mul(d2, d1, d2);
+    basic_add(d2, d, d2);
+    SYMENGINE_C_ASSERT(basic_get_type(d2) == SYMENGINE_COMPLEX_MPC);
+    SYMENGINE_C_ASSERT(complex_mpc_is_zero(d2) == 0);
+    
+    basic r1;
+    basic_new_stack(r1);
+    
+    complex_mpc_real_part(r1, d2);
+    SYMENGINE_C_ASSERT(basic_eq(r1, d));
+    
+    complex_mpc_imaginary_part(r1, d2);
+    SYMENGINE_C_ASSERT(basic_eq(r1, d1));
+    
 
     basic_free_stack(d);
     basic_free_stack(d1);
-    basic_free_stack(imag);
+    basic_free_stack(d2);
+    basic_free_stack(r1);
 }
 #endif // HAVE_SYMENGINE_MPC
 


### PR DESCRIPTION
In order to implement, <,<=,> and >= for numbers in Ruby Wrappers.
They are required for the tests of evalf function.