### PR TITLE
make duplicate code common, uratpoly

### DIFF
--- a/symengine/fields.h
+++ b/symengine/fields.h
@@ -632,6 +632,12 @@ inline RCP<const GaloisField> gf_poly(RCP<const Basic> i, map_uint_mpz &&dict,
     GaloisFieldDict wrapper(dict, modulo_);
     return GaloisField::from_dict(i, std::move(wrapper));
 }
+
+inline RCP<const GaloisField> pow_upoly(const GaloisField &a, unsigned int p)
+{
+    auto dict = GaloisField::container_type::pow(a.get_poly(), p);
+    return GaloisField::from_container(a.get_var(), std::move(dict));
+}
 }
 
 #endif

--- a/symengine/polys/basic_conversions.h
+++ b/symengine/polys/basic_conversions.h
@@ -212,6 +212,11 @@ public:
     using BasicToUPolyBase<Poly, BasicToURatPoly>::bvisit;
     using BasicToUPolyBase<Poly, BasicToURatPoly>::apply;
 
+    BasicToURatPoly(const RCP<const Basic> &gen)
+        : BasicToUPolyBase<Poly, BasicToURatPoly<Poly>>(gen)
+    {
+    }
+
     void bvisit(const Rational &x)
     {
         this->dict = URatDict(x.as_rational_class());
@@ -221,11 +226,12 @@ public:
     {
         if (is_a<const Integer>(x))
             this->dict = Poly::container_from_dict(
-                this->gen,
-                {{pow, rational_class(static_cast<const Integer &>(x).as_integer_class())}});
+                this->gen, {{pow, rational_class(static_cast<const Integer &>(x)
+                                                     .as_integer_class())}});
         else if (is_a<const Rational>(x))
             this->dict = Poly::container_from_dict(
-                this->gen, {{pow, static_cast<const Rational &>(x).as_rational_class()}});
+                this->gen,
+                {{pow, static_cast<const Rational &>(x).as_rational_class()}});
         else
             throw std::runtime_error("Non-rational found");
     }
@@ -251,8 +257,8 @@ template <typename T, typename P>
 enable_if_t<std::is_base_of<URatPolyBase<T, P>, P>::value, T>
 _basic_to_upoly(const RCP<const Basic> &basic, const RCP<const Basic> &gen)
 {
-    BasicToURatPoly<P> v;
-    return v.apply(*basic, gen);
+    BasicToURatPoly<P> v(gen);
+    return v.apply(*basic);
 }
 
 template <typename P>

--- a/symengine/polys/basic_conversions.h
+++ b/symengine/polys/basic_conversions.h
@@ -129,7 +129,7 @@ public:
     void bvisit(const Integer &x)
     {
         integer_class i = x.as_integer_class();
-        dict = P::container_from_dict(gen, {{0, i}});
+        dict = P::container_from_dict(gen, {{0, typename P::coef_type(i)}});
     }
 
     void bvisit(const Basic &x)
@@ -221,7 +221,8 @@ public:
     {
         if (is_a<const Integer>(x))
             this->dict = Poly::container_from_dict(
-                this->gen, {{pow, rational_class(static_cast<const Integer &>(x).i)}});
+                this->gen,
+                {{pow, rational_class(static_cast<const Integer &>(x).i)}});
         else if (is_a<const Rational>(x))
             this->dict = Poly::container_from_dict(
                 this->gen, {{pow, static_cast<const Rational &>(x).i}});

--- a/symengine/polys/basic_conversions.h
+++ b/symengine/polys/basic_conversions.h
@@ -227,7 +227,7 @@ public:
             this->dict = Poly::container_from_dict(
                 this->gen, {{pow, static_cast<const Rational &>(x).i}});
         else
-            throw std::runtime_error("Non-integer found");
+            throw std::runtime_error("Non-rational found");
     }
 };
 

--- a/symengine/polys/basic_conversions.h
+++ b/symengine/polys/basic_conversions.h
@@ -214,7 +214,7 @@ public:
 
     void bvisit(const Rational &x)
     {
-        this->dict = URatDict(x.i);
+        this->dict = URatDict(x.as_rational_class());
     }
 
     void dict_set(unsigned int pow, const Basic &x)
@@ -222,10 +222,10 @@ public:
         if (is_a<const Integer>(x))
             this->dict = Poly::container_from_dict(
                 this->gen,
-                {{pow, rational_class(static_cast<const Integer &>(x).i)}});
+                {{pow, rational_class(static_cast<const Integer &>(x).as_integer_class())}});
         else if (is_a<const Rational>(x))
             this->dict = Poly::container_from_dict(
-                this->gen, {{pow, static_cast<const Rational &>(x).i}});
+                this->gen, {{pow, static_cast<const Rational &>(x).as_rational_class()}});
         else
             throw std::runtime_error("Non-rational found");
     }

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -151,55 +151,47 @@ public:
     hash_t __hash__() const;
 }; // URatPolyFlint
 
-template <typename T>
-enable_if_t<std::is_same<UIntPolyFlint, T>::value
-                or std::is_same<URatPolyFlint, T>::value,
-            RCP<const T>>
-gcd_upoly(const T &a, const T &b)
+template <typename Container, template <typename X, typename Y> class BaseType,
+          typename Poly>
+RCP<const Poly> gcd_upoly(const UFlintPoly<Container, BaseType, Poly> &a,
+                          const Poly &b)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw SymEngineException("Error: variables must agree.");
-    return make_rcp<const T>(a.get_var(), a.get_poly().gcd(b.get_poly()));
+    return make_rcp<const Poly>(a.get_var(), a.get_poly().gcd(b.get_poly()));
 }
 
-template <typename T>
-enable_if_t<std::is_same<UIntPolyFlint, T>::value
-                or std::is_same<URatPolyFlint, T>::value,
-            RCP<const T>>
-lcm_upoly(const T &a, const T &b)
+template <typename Container, template <typename X, typename Y> class BaseType,
+          typename Poly>
+RCP<const Poly> lcm_upoly(const UFlintPoly<Container, BaseType, Poly> &a,
+                          const Poly &b)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw SymEngineException("Error: variables must agree.");
-    return make_rcp<const T>(a.get_var(), a.get_poly().lcm(b.get_poly()));
+    return make_rcp<const Poly>(a.get_var(), a.get_poly().lcm(b.get_poly()));
 }
 
-inline RCP<const UIntPolyFlint> pow_upoly(const UIntPolyFlint &a,
-                                          unsigned int p)
+template <typename Container, template <typename X, typename Y> class BaseType,
+          typename Poly>
+RCP<const Poly> pow_upoly(const UFlintPoly<Container, BaseType, Poly> &a,
+                          unsigned int p)
 {
-    return make_rcp<const UIntPolyFlint>(a.get_var(), a.get_poly().pow(p));
+    return make_rcp<const Poly>(a.get_var(), a.get_poly().pow(p));
 }
 
-// temporary, needs to be common ^
-inline RCP<const URatPolyFlint> pow_upoly(const URatPolyFlint &a,
-                                          unsigned int p)
-{
-    return make_rcp<const URatPolyFlint>(a.get_var(), a.get_poly().pow(p));
-}
-
-template <typename T>
-enable_if_t<std::is_same<UIntPolyFlint, T>::value
-                or std::is_same<URatPolyFlint, T>::value,
-            bool>
-divides_upoly(const T &a, const T &b, const Ptr<RCP<const T>> &res)
+template <typename Container, template <typename X, typename Y> class BaseType,
+          typename Poly>
+bool divides_upoly(const UFlintPoly<Container, BaseType, Poly> &a,
+                   const Poly &b, const Ptr<RCP<const Poly>> &res)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw SymEngineException("Error: variables must agree.");
 
-    typename T::container_type q, r;
+    typename Poly::container_type q, r;
 
     b.get_poly().divrem(q, r, a.get_poly());
     if (r == 0) {
-        *res = make_rcp<T>(a.get_var(), std::move(q));
+        *res = make_rcp<Poly>(a.get_var(), std::move(q));
         return true;
     } else {
         return false;

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -342,46 +342,27 @@ inline RCP<const URatPolyPiranha> lcm_upoly(const URatPolyPiranha &a,
     return make_rcp<const URatPolyPiranha>(a.get_var(), std::move(lcmx));
 }
 
-inline RCP<const UIntPolyPiranha> pow_upoly(const UIntPolyPiranha &a,
-                                            unsigned int p)
+template <typename Container, template <typename X, typename Y> class BaseType,
+          typename Poly>
+RCP<const Poly> pow_upoly(const UPiranhaPoly<Container, BaseType, Poly> &a,
+                          unsigned int p)
 {
-    return make_rcp<const UIntPolyPiranha>(
-        a.get_var(), std::move(piranha::math::pow(a.get_poly(), p)));
+    return make_rcp<const Poly>(a.get_var(),
+                                std::move(piranha::math::pow(a.get_poly(), p)));
 }
 
-inline RCP<const URatPolyPiranha> pow_upoly(const URatPolyPiranha &a,
-                                            unsigned int p)
-{
-    return make_rcp<const URatPolyPiranha>(
-        a.get_var(), std::move(piranha::math::pow(a.get_poly(), p)));
-}
-
-inline bool divides_upoly(const UIntPolyPiranha &a, const UIntPolyPiranha &b,
-                          const Ptr<RCP<const UIntPolyPiranha>> &res)
+template <typename Container, template <typename X, typename Y> class BaseType,
+          typename Poly>
+bool divides_upoly(const UPiranhaPoly<Container, BaseType, Poly> &a,
+                   const Poly &b, const Ptr<RCP<const Poly>> &res)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))
         throw SymEngineException("Error: variables must agree.");
 
     try {
-        pintpoly z;
+        Container z;
         piranha::math::divexact(z, b.get_poly(), a.get_poly());
-        *res = UIntPolyPiranha::from_container(a.get_var(), std::move(z));
-        return true;
-    } catch (const piranha::math::inexact_division &) {
-        return false;
-    }
-}
-
-inline bool divides_upoly(const URatPolyPiranha &a, const URatPolyPiranha &b,
-                          const Ptr<RCP<const URatPolyPiranha>> &res)
-{
-    if (!(a.get_var()->__eq__(*b.get_var())))
-        throw SymEngineException("Error: variables must agree.");
-
-    try {
-        pratpoly z;
-        piranha::math::divexact(z, b.get_poly(), a.get_poly());
-        *res = URatPolyPiranha::from_container(a.get_var(), std::move(z));
+        *res = Poly::from_container(a.get_var(), std::move(z));
         return true;
     } catch (const piranha::math::inexact_division &) {
         return false;

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -129,6 +129,20 @@ public:
         }
     }
 
+    ODictWrapper(std::map<Key, Value> &&p)
+    {
+        for (auto &iter : p) {
+            if (iter.second != Value(0)) {
+                auto erase = iter;
+                iter++;
+                p.erase(erase);
+            } else {
+                iter++;
+            }
+        }
+        dict_ = p;
+    }
+
     ODictWrapper(const Value &p)
     {
         if (p != Value(0))

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -694,13 +694,6 @@ RCP<const Poly> mul_upoly(const Poly &a, const Poly &b)
 }
 
 template <typename Poly>
-RCP<const Poly> pow_upoly(const Poly &a, unsigned int p)
-{
-    auto dict = Poly::container_type::pow(a.get_poly(), p);
-    return Poly::from_container(a.get_var(), std::move(dict));
-}
-
-template <typename Poly>
 RCP<const Poly> quo_upoly(const Poly &a, const Poly &b)
 {
     if (!(a.get_var()->__eq__(*b.get_var())))

--- a/symengine/polys/usymenginepoly.h
+++ b/symengine/polys/usymenginepoly.h
@@ -116,6 +116,15 @@ public:
         return this->get_degree() + 1;
     }
 };
+
+template <typename Container, template <typename X, typename Y> class BaseType,
+          typename Poly>
+RCP<const Poly> pow_upoly(const USymEnginePoly<Container, BaseType, Poly> &a,
+                          unsigned int p)
+{
+    auto dict = Poly::container_type::pow(a.get_poly(), p);
+    return Poly::from_container(a.get_var(), std::move(dict));
+}
 }
 
 #endif

--- a/symengine/tests/polynomial/test_basic_conversions.cpp
+++ b/symengine/tests/polynomial/test_basic_conversions.cpp
@@ -319,21 +319,21 @@ TEST_CASE("basic_to_poly URat", "[b2poly]")
     basic = xb2;
     gen = x;
     poly1 = from_basic<URatPoly>(basic, gen);
-    poly2 = URatPoly::from_vec(gen, {{0_q, rc(1_z, 2_z)}});
+    poly2 = URatPoly::from_vec(gen, {0_q, rc(1_z, 2_z)});
     REQUIRE(eq(*poly1, *poly2));
 
     // 3x + 2
     basic = add(mul(x, i3), i2);
     gen = x;
     poly1 = from_basic<URatPoly>(basic, gen);
-    poly2 = URatPoly::from_vec(gen, {{2_q, 3_q}});
+    poly2 = URatPoly::from_vec(gen, {2_q, 3_q});
     REQUIRE(eq(*poly1, *poly2));
 
     // 3/2 * (2**x)
     basic = mul(div(i3, i2), pow(i2, x));
     gen = pow(i2, x);
     poly1 = from_basic<URatPoly>(basic, gen);
-    poly2 = URatPoly::from_vec(gen, {{0_q, rc(3_z, 2_z)}});
+    poly2 = URatPoly::from_vec(gen, {0_q, rc(3_z, 2_z)});
     REQUIRE(eq(*poly1, *poly2));
 
     // x + y

--- a/symengine/tests/polynomial/test_basic_conversions.cpp
+++ b/symengine/tests/polynomial/test_basic_conversions.cpp
@@ -338,11 +338,11 @@ TEST_CASE("basic_to_poly URat", "[b2poly]")
 
     // x + y
     basic = add(x, y);
-    CHECK_THROWS_AS(from_basic<URatPoly>(basic), std::runtime_error);
+    CHECK_THROWS_AS(from_basic<URatPoly>(basic), SymEngineException);
 
     // x + 1/x
     basic = add(x, div(one, x));
-    CHECK_THROWS_AS(from_basic<URatPoly>(basic), std::runtime_error);
+    CHECK_THROWS_AS(from_basic<URatPoly>(basic), SymEngineException);
 }
 
 TEST_CASE("basic_to_poly UExpr", "[b2poly]")

--- a/symengine/tests/polynomial/test_basic_conversions.cpp
+++ b/symengine/tests/polynomial/test_basic_conversions.cpp
@@ -333,7 +333,7 @@ TEST_CASE("basic_to_poly URat", "[b2poly]")
     basic = mul(div(i3, i2), pow(i2, x));
     gen = pow(i2, x);
     poly1 = from_basic<URatPoly>(basic, gen);
-    poly2 = URatPoly::from_vec(gen, {{0_z, rc(3_z, 2_z)}});
+    poly2 = URatPoly::from_vec(gen, {{0_q, rc(3_z, 2_z)}});
     REQUIRE(eq(*poly1, *poly2));
 
     // x + y


### PR DESCRIPTION
@isuruf please see
Now I feel what you were saying about code simplicity is correct. This `BaseType` solution feels a little too compliacted. I am still thinking of alternatives.

Basically, most of the function definitions are in base classes like `UIntPolyBase`/`URatPolyBase` while their implementations in `USymEnginePoly`/`UFlintPoly` etc.

Initially, I though multiple inheritance would work, ie, inherit from the base class and then inherit from the implementation class. But the compiler does not treat the implementation with their respective definitions (signature mismatch?). Do you have any alternative suggestions for the overall structure?
