### PR TITLE
Trigger Conda build on merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,21 @@ addons:
     - libmpc-dev
     - binutils-dev
     - g++-4.7
+
 env:
+  global:
+    - secure: "Xj8vvg++O4mhcUTQGtHqXHhn8o5LklI/GkGWO6fcRXlJQszvpSMQiYfJ1UAYlmmuvXRNjWWdhEr7inJdHe1ZtNSXVU/jEICUytFBG6T3uuhOsBPkjVTp2en5vwsSPohaHcAnhoDyK9L48SBcTKLTCkTMhOitj9jk2renem0dX84="
+
   ## All these variables are sent into the bin/test_travis.sh script. See this
   ## script to know how they are used. Most of them are just passed to cmake,
   ## so if they are not set, cmake will use a default value. For the rest, the
   ## bin/test_travis.sh script usually checks for either "yes" or "no" in an if
   ## statement, so if the variable is not set, the other if branch will get
   ## executed.
-
+  matrix:
   ## Out of tree builds (default):
   # Debug build (with BFD)
-  - BUILD_TYPE="Debug" WITH_BFD="yes"
+  - BUILD_TYPE="Debug" WITH_BFD="yes" TRIGGER_FEEDSTOCK="yes"
   # Debug build (with BFD and SYMENGINE_THREAD_SAFE)
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_THREAD_SAFE="yes"
   # Debug build (with BFD) with ECM
@@ -140,7 +144,6 @@ matrix:
 install:
   - source bin/install_travis.sh
 script:
-  - bin/travis_clang.sh
-  - bin/test_travis.sh
+  - bin/trigger_feedstock.sh
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,6 +144,8 @@ matrix:
 install:
   - source bin/install_travis.sh
 script:
+  - bin/travis_clang.sh
+  - bin/test_travis.sh
   - bin/trigger_feedstock.sh
 notifications:
   email: false

--- a/bin/trigger_feedstock.sh
+++ b/bin/trigger_feedstock.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -x
+
+if [[ "${TRIGGER_FEEDSTOCK}" != "yes" ]]; then
+    exit 0;
+fi
+if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
+    echo "Testing a pull request, feedstock is not triggered.";
+    exit 0;
+fi
+
+cd $SOURCE_DIR;
+export ver=`git describe --tags`
+export commit=`git rev-parse HEAD`
+
+git config --global user.name "Isuru Fernando"
+git config --global user.email "isuruf@gmail.com"
+
+set +x
+git clone "https://${GH_TOKEN}@github.com/symengine/symengine-feedstock.git" feedstock -q
+set -x
+
+cd feedstock
+if [[ "${TRAVIS_TAG}" != "" ]]; then
+    git checkout tagged
+else
+    git checkout dev
+fi
+
+sed -ie '1,2d' recipe/meta.yaml
+sed -i '1s/^/{% set version = "'${ver}'" %}\n/' recipe/meta.yaml
+sed -i '1s/^/{% set commit = "'${commit}'" %}\n/' recipe/meta.yaml
+git add recipe/meta.yaml
+git commit -m "Update symengine version to ${ver}"
+git push -q
+

--- a/bin/trigger_feedstock.sh
+++ b/bin/trigger_feedstock.sh
@@ -9,6 +9,11 @@ if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
     echo "Testing a pull request, feedstock is not triggered.";
     exit 0;
 fi
+if [[ "${GH_TOKEN}" == "" ]]; then
+    echo "Testing a fork, feedstock is not triggered.";
+    exit 0;
+fi
+
 
 cd $SOURCE_DIR;
 export ver=`git describe --tags`

--- a/bin/trigger_feedstock.sh
+++ b/bin/trigger_feedstock.sh
@@ -30,7 +30,9 @@ cd feedstock
 if [[ "${TRAVIS_TAG}" != "" ]]; then
     git checkout tagged
 else
-    git checkout dev
+    echo "Testing merge. Not triggering feedstock"
+    exit 0
+    # git checkout dev
 fi
 
 sed -ie '1,2d' recipe/meta.yaml


### PR DESCRIPTION
On every merge this would trigger a conda build and upload to `symengine/label/dev` and on tags it will upload to `symengine`. Version is calculated using `git describe --tags` which includes the commit hash in it.