### PR TITLE
rename PZERO -> pzero

### DIFF
--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -50,7 +50,6 @@ if [[ "${TRAVIS_OS_NAME}" != "osx" ]]; then
         sudo apt-get install cmake libgmp-dev
     fi
 else
-    brew install cmake
     wget https://raw.githubusercontent.com/symengine/dependencies/6a42d290071921a0a478c6883fc0ddd709d664c9/gmp-6.0.0a.tar.bz2
     tar -xjf gmp-6.0.0a.tar.bz2;
     cd gmp-6.0.0 && ./configure --prefix=$our_install_dir --enable-cxx && make -j8 install && cd ..;

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -214,12 +214,12 @@ public:
 
     const Cf &get_coeff_ref(unsigned int x) const
     {
-        static Cf PZERO(0);
+        static Cf pzero(0);
 
         term temp = term(0, pmonomial{x});
         auto it = this->poly_._container().find(temp);
         if (it == this->poly_._container().end())
-            return PZERO;
+            return pzero;
         return it->m_cf;
     }
 

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -112,11 +112,14 @@ using pratpoly = piranha::polynomial<rational_class, pmonomial>;
 template <typename Cf, typename Container>
 class PiranhaForIter
 {
-    typename Container::container_type::const_iterator ptr_;
+public:
+    typedef decltype(std::declval<Container &>()._container().begin()) ptr_type;
+
+private:
+    ptr_type ptr_;
 
 public:
-    PiranhaForIter(typename Container::container_type::const_iterator ptr)
-        : ptr_{ptr}
+    PiranhaForIter(ptr_type ptr) : ptr_{ptr}
     {
     }
 


### PR DESCRIPTION
PZERO is a macro in some system headers and conflicts with symengine's definition

Fixes #1083
Fixes #1085

@jppelteret, can you confirm that this fixes the problem for you?
Btw, what is the OS you are building symengine on?