### PR TITLE
Add a benchmark for general symbolic arithmetic and series

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -53,6 +53,9 @@ target_link_libraries(expand7 symengine)
 add_executable(series series.cpp)
 target_link_libraries(series symengine)
 
+add_executable(symengine_bench symengine_bench.cpp)
+target_link_libraries(symengine_bench symengine)
+
 if (WITH_FLINT)
     add_executable(series_expansion_sincos_flint series_expansion_sincos_flint.cpp)
     target_link_libraries(series_expansion_sincos_flint symengine)

--- a/benchmarks/symengine_bench.cpp
+++ b/benchmarks/symengine_bench.cpp
@@ -1,0 +1,52 @@
+/*
+    This benchmark is used for benchmarking the speed of symbolics and not
+    for benchmarking series expansion.
+*/
+
+#include <symengine/symengine_config.h>
+#include <symengine/series_generic.h>
+
+#include <iostream>
+#include <chrono>
+
+#include <symengine/functions.h>
+#include <symengine/symbol.h>
+#include <symengine/mul.h>
+#include <symengine/series.h>
+
+using SymEngine::Basic;
+using SymEngine::Symbol;
+using SymEngine::symbol;
+using SymEngine::integer;
+using SymEngine::add;
+using SymEngine::mul;
+using SymEngine::pow;
+using SymEngine::sin;
+using SymEngine::cos;
+using SymEngine::RCP;
+using SymEngine::series;
+using SymEngine::rcp_dynamic_cast;
+
+int main(int argc, char *argv[])
+{
+    SymEngine::print_stack_on_segfault();
+
+    RCP<const Symbol> x = symbol("x");
+    int N;
+    if (argc == 2) {
+        N = std::atoi(argv[1]);
+    } else {
+        N = 15;
+    }
+    auto arg = x;
+    auto ex = sin(cos(add(integer(1), x)));
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+    auto res = SymEngine::UnivariateSeries::series(ex, "x", N);
+    auto t2 = std::chrono::high_resolution_clock::now();
+    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    return 0;
+}

--- a/benchmarks/symengine_bench.m
+++ b/benchmarks/symengine_bench.m
@@ -1,0 +1,7 @@
+#!/usr/local/bin/WolframScript -script
+
+If[Length[$ScriptCommandLine] == 1, n = 15, n = ToExpression[$ScriptCommandLine[[2]]]];
+
+e = Sin[Cos[x+1]];
+Print[AbsoluteTiming[Series[e, {x, 0, n}];][[1]] * 1000];
+

--- a/benchmarks/symengine_bench.mpl
+++ b/benchmarks/symengine_bench.mpl
@@ -1,0 +1,9 @@
+#!/bin/bash maple
+# Use `maple -q symengine_bench.mpl -D n=15` to run
+
+e := sin(cos(x+1)):
+st := time[real]():
+f := series(e, x=0,n):
+1000*(time[real]()-st);
+
+done

--- a/benchmarks/symengine_bench_ginac.cpp
+++ b/benchmarks/symengine_bench_ginac.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <chrono>
+#include <ginac/ginac.h>
+using namespace GiNaC;
+
+int main(int argc, char *argv[])
+{
+    int N;
+    if (argc == 2) {
+        N = std::atoi(argv[1]);
+    } else {
+        N = 15;
+    }
+
+    symbol x("x");
+    ex e = sin(cos(x + 1));
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+    ex g = e.series(x == 0, N);
+    auto t2 = std::chrono::high_resolution_clock::now();
+    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
Even though this involves a series, the coefficients are symbolics
and therefore benchmarks both the series function and symbolic
arithmetics.

NOTE: this is a pretty good benchmark when you want to check if
a change in symengine, slows down symbolic arithmetic.