### PR TITLE
Added Function for Issue #1088 (Second Feature)

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -570,28 +570,22 @@ void basic_str_free(char *s)
 
 int symengine_have_component(const char *c)
 {
-    bool t[4] = {};
 #ifdef HAVE_SYMENGINE_MPFR
-    t[0] = true;
+    if (std::strcmp("mpfr", c) == 0)
+        return 1;
 #endif
 #ifdef HAVE_SYMENGINE_MPC
-    t[1] = true;
+    if (std::strcmp("mpc", c) == 0)
+        return 1;
 #endif
 #ifdef HAVE_SYMENGINE_FLINT
-    t[2] = true;
+    if (std::strcmp("flint", c) == 0)
+        return 1;
 #endif
 #ifdef HAVE_SYMENGINE_ARB
-    t[3] = true;
+    if (std::strcmp("arb", c) == 0)
+        return 1;
 #endif
-    const char *component[] = {"mpfr", "mpc", "flint", "arb"};
-    for (int i = 0; i < 4; i++) {
-        if (std::strcmp(component[i], c) == 0) {
-            if (t[i])
-                return 1;
-            else
-                return 0;
-        }
-    }
     return 0;
 }
 

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -568,6 +568,33 @@ void basic_str_free(char *s)
     delete[] s;
 }
 
+int symengine_have_component(const char *c)
+{
+    bool t[4] = {};
+#ifdef HAVE_SYMENGINE_MPFR
+    t[0] = true;
+#endif
+#ifdef HAVE_SYMENGINE_MPC
+    t[1] = true;
+#endif
+#ifdef HAVE_SYMENGINE_FLINT
+    t[2] = true;
+#endif
+#ifdef HAVE_SYMENGINE_ARB
+    t[3] = true;
+#endif
+    const char *component[] = {"mpfr", "mpc", "flint", "arb"};
+    for (int i = 0; i < 4; i++) {
+        if (std::strcmp(component[i], c) == 0) {
+            if (t[i])
+                return 1;
+            else
+                return 0;
+        }
+    }
+    return 0;
+}
+
 int is_a_Number(const basic s)
 {
     return (int)is_a_Number(*(s->m));

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -586,6 +586,30 @@ int symengine_have_component(const char *c)
     if (std::strcmp("arb", c) == 0)
         return 1;
 #endif
+#ifdef HAVE_SYMENGINE_ECM
+    if (std::strcmp("ecm", c) == 0)
+        return 1;
+#endif
+#ifdef HAVE_SYMENGINE_PRIMESIEVE
+    if (std::strcmp("primesieve", c) == 0)
+        return 1;
+#endif
+#ifdef HAVE_SYMENGINE_PIRANHA
+    if (std::strcmp("piranha", c) == 0)
+        return 1;
+#endif
+#ifdef HAVE_SYMENGINE_BOOST
+    if (std::strcmp("boost", c) == 0)
+        return 1;
+#endif
+#ifdef HAVE_SYMENGINE_PTHREAD
+    if (std::strcmp("pthread", c) == 0)
+        return 1;
+#endif
+#ifdef HAVE_SYMENGINE_LLVM
+    if (std::strcmp("llvm", c) == 0)
+        return 1;
+#endif
     return 0;
 }
 

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -301,6 +301,8 @@ char *basic_str(const basic s);
 void basic_str_free(char *s);
 
 //! Returns 1 if a specific component is installed, 0 if not.
+//! Component can be "mpfr", "flint", "arb", "mpc", "ecm", "primesieve",
+//! "piranha", "boost", "pthread" or "llvm".
 int symengine_have_component(const char *c);
 
 //! Return 1 if s is a Number, 0 if not.

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -300,6 +300,9 @@ char *basic_str(const basic s);
 //! Frees the string s
 void basic_str_free(char *s);
 
+//! Returns 1 if a specific component is installed, 0 if not.
+int symengine_have_component(const char *c);
+
 //! Return 1 if s is a Number, 0 if not.
 int is_a_Number(const basic s);
 //! Return 1 if s is an Integer, 0 if not.

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -300,9 +300,14 @@ char *basic_str(const basic s);
 //! Frees the string s
 void basic_str_free(char *s);
 
-//! Returns 1 if a specific component is installed, 0 if not.
+//! Returns 1 if a specific component is installed and 0 if not.
 //! Component can be "mpfr", "flint", "arb", "mpc", "ecm", "primesieve",
-//! "piranha", "boost", "pthread" or "llvm".
+//! "piranha", "boost", "pthread" or "llvm" (all in lowercase).
+//! This function, using string comparison, was implemented for particular
+//! libraries that do not provide header access (i.e. SymEngine.jl
+//! and other related shared libraries).
+//! Avoid usage while having access to the headers. Instead simply use
+//! HAVE_SYMENGINE_MPFR and other related macros directly.
 int symengine_have_component(const char *c);
 
 //! Return 1 if s is a Number, 0 if not.

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -678,6 +678,10 @@ void test_constants()
     SYMENGINE_C_ASSERT(strcmp(s, "EulerGamma") == 0);
     basic_str_free(s);
 
+    // Rejecting non mpfr builds
+    s = "mpfr";
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+
     basic_free_stack(custom);
     basic_free_stack(pi);
     basic_free_stack(e);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -685,6 +685,69 @@ void test_constants()
 #else
     SYMENGINE_C_ASSERT(!symengine_have_component(s));
 #endif
+    // Checking mpc builds
+    s = "mpc";
+#ifdef HAVE_SYMENGINE_MPC
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
+    // Checking arb builds
+    s = "arb";
+#ifdef HAVE_SYMENGINE_ARB
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
+    // Checking flint builds
+    s = "flint";
+#ifdef HAVE_SYMENGINE_FLINT
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
+    // Checking ecm builds
+    s = "ecm";
+#ifdef HAVE_SYMENGINE_ECM
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
+    // Checking primesieve builds
+    s = "primesieve";
+#ifdef HAVE_SYMENGINE_PRIMESIEVE
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
+    // Checking piranha builds
+    s = "piranha";
+#ifdef HAVE_SYMENGINE_PIRANHA
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
+    // Checking boost builds
+    s = "boost";
+#ifdef HAVE_SYMENGINE_BOOST
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
+    // Checking pthread builds
+    s = "pthread";
+#ifdef HAVE_SYMENGINE_PTHREAD
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
+    // Checking llvm builds
+    s = "llvm";
+#ifdef HAVE_SYMENGINE_LLVM
+    SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
 
     basic_free_stack(custom);
     basic_free_stack(pi);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -678,9 +678,13 @@ void test_constants()
     SYMENGINE_C_ASSERT(strcmp(s, "EulerGamma") == 0);
     basic_str_free(s);
 
-    // Rejecting non mpfr builds
+    // Checking mpfr builds
     s = "mpfr";
+#ifdef HAVE_SYMENGINE_MPFR
     SYMENGINE_C_ASSERT(symengine_have_component(s));
+#else
+    SYMENGINE_C_ASSERT(!symengine_have_component(s));
+#endif
 
     basic_free_stack(custom);
     basic_free_stack(pi);


### PR DESCRIPTION
Added a function to call to indicate whether some components (namely flint, arb, mpc and mpfr) are installed or not. No tests are added (to prevent travis build failures). However the following links may be referred to for cross-checking the functionality:
(Build #9 For Rejecting Non MPFR builds)
https://travis-ci.org/ShikharJ/symengine/builds/172672603

(Build #8 For Rejecting MPFR builds)
https://travis-ci.org/ShikharJ/symengine/builds/172666980
The above tests have been conducted by patching the following lines of code:
char *s = "mpfr";
(#9)SYMENGINE_C_ASSERT(symengine_have_component(s));
(#8)SYMENGINE_C_ASSERT(!symengine_have_component(s));
