### PR TITLE
[WIP] Consolidation of Tests regarding Issue #1112

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,10 @@ env:
   # Debug build (with BFD and SYMENGINE_THREAD_SAFE)
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_THREAD_SAFE="yes"
   # Debug build (with BFD) with ECM
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_ECM="yes"
-  # Debug build (with BFD) with PRIMESIEVE
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_PRIMESIEVE="yes"
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_ECM="yes" WITH_MPC="yes" WITH_PRIMESIEVE="yes"
   # Debug build (with BFD) with Arb
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_ARB="yes" INTEGER_CLASS="flint"
-  # Debug build (with BFD) with MPC
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_MPC="yes"
-  # Debug build (with BFD) with MPC
+  # Debug build (with BFD) with MPFR
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_MPFR="yes" INTEGER_CLASS="gmpxx"
   # Debug build shared lib (with BFD)
   - BUILD_TYPE="Debug" WITH_BFD="yes" BUILD_SHARED_LIBS="yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
   - BUILD_TYPE="Debug" WITH_BFD="yes" TRIGGER_FEEDSTOCK="yes"
   # Debug build (with BFD and SYMENGINE_THREAD_SAFE)
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_THREAD_SAFE="yes"
-  # Debug build (with BFD) with ECM
+  # Debug build (with BFD) with ECM, MPC and PRIMESIEVE
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_ECM="yes" WITH_MPC="yes" WITH_PRIMESIEVE="yes"
   # Debug build (with BFD) with Arb
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_ARB="yes" INTEGER_CLASS="flint"


### PR DESCRIPTION
The ECM, MPC and PRIMESIEVE libraries seem to work without conflict on a single build. This patch reduces the total number of travis test builds from 20 to 18 ( regarding PR #1111 ) for the issue #1112. 