### PR TITLE
Added support for down_cast() and made changes in the codebase

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,10 +18,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 
-All files in src/teuchos were taken from the Trilinos package and are licensed
-under the modified BSD license:
+All files in symengine/utilities/teuchos were taken from the Trilinos package
+and are licensed under the modified BSD license:
 
                    Teuchos: Common Tools Package
                 Copyright (2004) Sandia Corporation
@@ -58,10 +58,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Questions? Contact Michael A. Heroux (maherou@sandia.gov)
 
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 
-Code in src/sparse_matrix.cpp is a port from scipy sparse matrix module and
-licensed under the modified BSD license:
+Code in symengine/sparse_matrix.cpp is a port from scipy sparse matrix module
+and licensed under the modified BSD license:
 
 Copyright (c) 2001, 2002 Enthought, Inc.
 All rights reserved.
@@ -93,3 +93,37 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+Code in symengine/symengine_casts.h is licensed under the modified BSD license:
+
+Protocol Buffers - Google's data interchange format
+Copyright 2014 Google Inc.  All rights reserved.
+https://developers.google.com/protocol-buffers/
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -145,6 +145,7 @@ set(HEADERS
     subs.h
     symbol.h
     symengine_assert.h
+    symengine_casts.h
     symengine_exception.h
     symengine_rcp.h
     type_codes.inc

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -63,8 +63,8 @@ hash_t Add::__hash__() const
 
 bool Add::__eq__(const Basic &o) const
 {
-    if (is_a<Add>(o) and eq(*coef_, *(static_cast<const Add &>(o).coef_))
-        and unified_eq(dict_, static_cast<const Add &>(o).dict_))
+    if (is_a<Add>(o) and eq(*coef_, *(down_cast<const Add &>(o).coef_))
+        and unified_eq(dict_, down_cast<const Add &>(o).dict_))
         return true;
 
     return false;
@@ -73,7 +73,7 @@ bool Add::__eq__(const Basic &o) const
 int Add::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Add>(o))
-    const Add &s = static_cast<const Add &>(o);
+    const Add &s = down_cast<const Add &>(o);
     // # of elements
     if (dict_.size() != s.dict_.size())
         return (dict_.size() < s.dict_.size()) ? -1 : 1;

--- a/symengine/complex.cpp
+++ b/symengine/complex.cpp
@@ -47,7 +47,7 @@ hash_t Complex::__hash__() const
 bool Complex::__eq__(const Basic &o) const
 {
     if (is_a<Complex>(o)) {
-        const Complex &s = static_cast<const Complex &>(o);
+        const Complex &s = down_cast<const Complex &>(o);
         return ((this->real_ == s.real_)
                 and (this->imaginary_ == s.imaginary_));
     }
@@ -57,7 +57,7 @@ bool Complex::__eq__(const Basic &o) const
 int Complex::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Complex>(o))
-    const Complex &s = static_cast<const Complex &>(o);
+    const Complex &s = down_cast<const Complex &>(o);
     if (real_ == s.real_) {
         if (imaginary_ == s.imaginary_) {
             return 0;
@@ -88,24 +88,24 @@ RCP<const Number> Complex::from_two_rats(const Rational &re, const Rational &im)
 RCP<const Number> Complex::from_two_nums(const Number &re, const Number &im)
 {
     if (is_a<Integer>(re) and is_a<Integer>(im)) {
-        rational_class re_mpq(static_cast<const Integer &>(re).i,
-                              static_cast<const Integer &>(*one).i);
-        rational_class im_mpq(static_cast<const Integer &>(im).i,
-                              static_cast<const Integer &>(*one).i);
+        rational_class re_mpq(down_cast<const Integer &>(re).i,
+                              down_cast<const Integer &>(*one).i);
+        rational_class im_mpq(down_cast<const Integer &>(im).i,
+                              down_cast<const Integer &>(*one).i);
         return Complex::from_mpq(re_mpq, im_mpq);
     } else if (is_a<Rational>(re) and is_a<Integer>(im)) {
-        rational_class re_mpq = static_cast<const Rational &>(re).i;
-        rational_class im_mpq(static_cast<const Integer &>(im).i,
-                              static_cast<const Integer &>(*one).i);
+        rational_class re_mpq = down_cast<const Rational &>(re).i;
+        rational_class im_mpq(down_cast<const Integer &>(im).i,
+                              down_cast<const Integer &>(*one).i);
         return Complex::from_mpq(re_mpq, im_mpq);
     } else if (is_a<Integer>(re) and is_a<Rational>(im)) {
-        rational_class re_mpq(static_cast<const Integer &>(re).i,
-                              static_cast<const Integer &>(*one).i);
-        rational_class im_mpq = static_cast<const Rational &>(im).i;
+        rational_class re_mpq(down_cast<const Integer &>(re).i,
+                              down_cast<const Integer &>(*one).i);
+        rational_class im_mpq = down_cast<const Rational &>(im).i;
         return Complex::from_mpq(re_mpq, im_mpq);
     } else if (is_a<Rational>(re) and is_a<Rational>(im)) {
-        rational_class re_mpq = static_cast<const Rational &>(re).i;
-        rational_class im_mpq = static_cast<const Rational &>(im).i;
+        rational_class re_mpq = down_cast<const Rational &>(re).i;
+        rational_class im_mpq = down_cast<const Rational &>(im).i;
         return Complex::from_mpq(re_mpq, im_mpq);
     } else {
         throw SymEngineException(

--- a/symengine/complex.h
+++ b/symengine/complex.h
@@ -243,11 +243,11 @@ public:
     virtual RCP<const Number> add(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return addcomp(static_cast<const Rational &>(other));
+            return addcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return addcomp(static_cast<const Integer &>(other));
+            return addcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return addcomp(static_cast<const Complex &>(other));
+            return addcomp(down_cast<const Complex &>(other));
         } else {
             return other.add(*this);
         }
@@ -256,11 +256,11 @@ public:
     virtual RCP<const Number> sub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return subcomp(static_cast<const Rational &>(other));
+            return subcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return subcomp(static_cast<const Integer &>(other));
+            return subcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return subcomp(static_cast<const Complex &>(other));
+            return subcomp(down_cast<const Complex &>(other));
         } else {
             return other.rsub(*this);
         }
@@ -269,9 +269,9 @@ public:
     virtual RCP<const Number> rsub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rsubcomp(static_cast<const Rational &>(other));
+            return rsubcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rsubcomp(static_cast<const Integer &>(other));
+            return rsubcomp(down_cast<const Integer &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -280,11 +280,11 @@ public:
     virtual RCP<const Number> mul(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return mulcomp(static_cast<const Rational &>(other));
+            return mulcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return mulcomp(static_cast<const Integer &>(other));
+            return mulcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return mulcomp(static_cast<const Complex &>(other));
+            return mulcomp(down_cast<const Complex &>(other));
         } else {
             return other.mul(*this);
         }
@@ -293,11 +293,11 @@ public:
     virtual RCP<const Number> div(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return divcomp(static_cast<const Rational &>(other));
+            return divcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return divcomp(static_cast<const Integer &>(other));
+            return divcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return divcomp(static_cast<const Complex &>(other));
+            return divcomp(down_cast<const Complex &>(other));
         } else {
             return other.rdiv(*this);
         }
@@ -306,7 +306,7 @@ public:
     virtual RCP<const Number> rdiv(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return rdivcomp(static_cast<const Integer &>(other));
+            return rdivcomp(down_cast<const Integer &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -315,7 +315,7 @@ public:
     virtual RCP<const Number> pow(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return powcomp(static_cast<const Integer &>(other));
+            return powcomp(down_cast<const Integer &>(other));
         } else {
             return other.rpow(*this);
         }

--- a/symengine/complex_double.cpp
+++ b/symengine/complex_double.cpp
@@ -33,7 +33,7 @@ hash_t ComplexDouble::__hash__() const
 bool ComplexDouble::__eq__(const Basic &o) const
 {
     if (is_a<ComplexDouble>(o)) {
-        const ComplexDouble &s = static_cast<const ComplexDouble &>(o);
+        const ComplexDouble &s = down_cast<const ComplexDouble &>(o);
         return this->i == s.i;
     }
     return false;
@@ -42,7 +42,7 @@ bool ComplexDouble::__eq__(const Basic &o) const
 int ComplexDouble::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<ComplexDouble>(o))
-    const ComplexDouble &s = static_cast<const ComplexDouble &>(o);
+    const ComplexDouble &s = down_cast<const ComplexDouble &>(o);
     if (i == s.i)
         return 0;
     if (i.real() == s.i.real()) {

--- a/symengine/complex_double.h
+++ b/symengine/complex_double.h
@@ -123,15 +123,15 @@ public:
     virtual RCP<const Number> add(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return addcomp(static_cast<const Rational &>(other));
+            return addcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return addcomp(static_cast<const Integer &>(other));
+            return addcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return addcomp(static_cast<const Complex &>(other));
+            return addcomp(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return addcomp(static_cast<const RealDouble &>(other));
+            return addcomp(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return addcomp(static_cast<const ComplexDouble &>(other));
+            return addcomp(down_cast<const ComplexDouble &>(other));
         } else {
             return other.add(*this);
         }
@@ -183,15 +183,15 @@ public:
     virtual RCP<const Number> sub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return subcomp(static_cast<const Rational &>(other));
+            return subcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return subcomp(static_cast<const Integer &>(other));
+            return subcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return subcomp(static_cast<const Complex &>(other));
+            return subcomp(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return subcomp(static_cast<const RealDouble &>(other));
+            return subcomp(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return subcomp(static_cast<const ComplexDouble &>(other));
+            return subcomp(down_cast<const ComplexDouble &>(other));
         } else {
             return other.rsub(*this);
         }
@@ -235,13 +235,13 @@ public:
     virtual RCP<const Number> rsub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rsubcomp(static_cast<const Rational &>(other));
+            return rsubcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rsubcomp(static_cast<const Integer &>(other));
+            return rsubcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rsubcomp(static_cast<const Complex &>(other));
+            return rsubcomp(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rsubcomp(static_cast<const RealDouble &>(other));
+            return rsubcomp(down_cast<const RealDouble &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -293,15 +293,15 @@ public:
     virtual RCP<const Number> mul(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return mulcomp(static_cast<const Rational &>(other));
+            return mulcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return mulcomp(static_cast<const Integer &>(other));
+            return mulcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return mulcomp(static_cast<const Complex &>(other));
+            return mulcomp(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return mulcomp(static_cast<const RealDouble &>(other));
+            return mulcomp(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return mulcomp(static_cast<const ComplexDouble &>(other));
+            return mulcomp(down_cast<const ComplexDouble &>(other));
         } else {
             return other.mul(*this);
         }
@@ -353,15 +353,15 @@ public:
     virtual RCP<const Number> div(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return divcomp(static_cast<const Rational &>(other));
+            return divcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return divcomp(static_cast<const Integer &>(other));
+            return divcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return divcomp(static_cast<const Complex &>(other));
+            return divcomp(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return divcomp(static_cast<const RealDouble &>(other));
+            return divcomp(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return divcomp(static_cast<const ComplexDouble &>(other));
+            return divcomp(down_cast<const ComplexDouble &>(other));
         } else {
             return other.rdiv(*this);
         }
@@ -406,13 +406,13 @@ public:
     virtual RCP<const Number> rdiv(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rdivcomp(static_cast<const Rational &>(other));
+            return rdivcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rdivcomp(static_cast<const Integer &>(other));
+            return rdivcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rdivcomp(static_cast<const Complex &>(other));
+            return rdivcomp(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rdivcomp(static_cast<const RealDouble &>(other));
+            return rdivcomp(down_cast<const RealDouble &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -467,15 +467,15 @@ public:
     virtual RCP<const Number> pow(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return powcomp(static_cast<const Rational &>(other));
+            return powcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return powcomp(static_cast<const Integer &>(other));
+            return powcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return powcomp(static_cast<const Complex &>(other));
+            return powcomp(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return powcomp(static_cast<const RealDouble &>(other));
+            return powcomp(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return powcomp(static_cast<const ComplexDouble &>(other));
+            return powcomp(down_cast<const ComplexDouble &>(other));
         } else {
             return other.rpow(*this);
         }
@@ -523,13 +523,13 @@ public:
     virtual RCP<const Number> rpow(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rpowcomp(static_cast<const Rational &>(other));
+            return rpowcomp(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rpowcomp(static_cast<const Integer &>(other));
+            return rpowcomp(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rpowcomp(static_cast<const Complex &>(other));
+            return rpowcomp(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rpowcomp(static_cast<const RealDouble &>(other));
+            return rpowcomp(down_cast<const RealDouble &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }

--- a/symengine/complex_mpc.cpp
+++ b/symengine/complex_mpc.cpp
@@ -25,7 +25,7 @@ hash_t ComplexMPC::__hash__() const
 bool ComplexMPC::__eq__(const Basic &o) const
 {
     if (is_a<ComplexMPC>(o)) {
-        const ComplexMPC &s = static_cast<const ComplexMPC &>(o);
+        const ComplexMPC &s = down_cast<const ComplexMPC &>(o);
         if (get_prec() == s.get_prec()) {
             return mpc_cmp(this->i.get_mpc_t(), s.i.get_mpc_t()) == 0;
         }
@@ -36,7 +36,7 @@ bool ComplexMPC::__eq__(const Basic &o) const
 int ComplexMPC::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<ComplexMPC>(o))
-    const ComplexMPC &s = static_cast<const ComplexMPC &>(o);
+    const ComplexMPC &s = down_cast<const ComplexMPC &>(o);
     if (get_prec() == s.get_prec()) {
         int cmp = mpc_cmp(this->i.get_mpc_t(), s.i.get_mpc_t());
         if (cmp == 0)
@@ -646,212 +646,212 @@ class EvaluateMPC : public Evaluate
     virtual RCP<const Basic> sin(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_sin(t.get_mpc_t(), static_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_sin(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> cos(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_cos(t.get_mpc_t(), static_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_cos(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> tan(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_tan(t.get_mpc_t(), static_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_tan(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> cot(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_tan(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> sec(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_cos(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> csc(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_sin(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> asin(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_asin(t.get_mpc_t(),
-                 static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_asin(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> acos(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_acos(t.get_mpc_t(),
-                 static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_acos(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> atan(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_atan(t.get_mpc_t(),
-                 static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_atan(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> acot(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_atan(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> asec(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_acos(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> acsc(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_asin(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> sinh(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_sinh(t.get_mpc_t(),
-                 static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_sinh(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> csch(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_sinh(t.get_mpc_t(),
-                 static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_sinh(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                 MPFR_RNDN);
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> cosh(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_cosh(t.get_mpc_t(),
-                 static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_cosh(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> sech(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_cosh(t.get_mpc_t(),
-                 static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_cosh(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                 MPFR_RNDN);
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> tanh(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_tanh(t.get_mpc_t(),
-                 static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_tanh(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> coth(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_tanh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> asinh(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_asinh(t.get_mpc_t(),
-                  static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_asinh(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> acsch(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_asinh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> acosh(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_acosh(t.get_mpc_t(),
-                  static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_acosh(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> atanh(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_atanh(t.get_mpc_t(),
-                  static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_atanh(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> acoth(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
         mpc_ui_div(t.get_mpc_t(), 1,
-                   static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+                   down_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
         mpc_atanh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> log(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpc_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_log(t.get_mpc_t(), static_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+        mpc_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_log(t.get_mpc_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> abs(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
-        mpfr_class t(static_cast<const ComplexMPC &>(x).i.get_prec());
-        mpc_abs(t.get_mpfr_t(),
-                static_cast<const ComplexMPC &>(x).i.get_mpc_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const ComplexMPC &>(x).i.get_prec());
+        mpc_abs(t.get_mpfr_t(), down_cast<const ComplexMPC &>(x).i.get_mpc_t(),
+                MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> gamma(Basic const &aConst) const

--- a/symengine/complex_mpc.h
+++ b/symengine/complex_mpc.h
@@ -159,19 +159,19 @@ public:
     virtual RCP<const Number> add(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return add(static_cast<const Rational &>(other));
+            return add(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return add(static_cast<const Integer &>(other));
+            return add(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return add(static_cast<const Complex &>(other));
+            return add(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return add(static_cast<const RealDouble &>(other));
+            return add(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return add(static_cast<const ComplexDouble &>(other));
+            return add(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return add(static_cast<const RealMPFR &>(other));
+            return add(down_cast<const RealMPFR &>(other));
         } else if (is_a<ComplexMPC>(other)) {
-            return add(static_cast<const ComplexMPC &>(other));
+            return add(down_cast<const ComplexMPC &>(other));
         } else {
             return other.add(*this);
         }
@@ -189,19 +189,19 @@ public:
     virtual RCP<const Number> sub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return sub(static_cast<const Rational &>(other));
+            return sub(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return sub(static_cast<const Integer &>(other));
+            return sub(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return sub(static_cast<const Complex &>(other));
+            return sub(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return sub(static_cast<const RealDouble &>(other));
+            return sub(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return sub(static_cast<const ComplexDouble &>(other));
+            return sub(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return sub(static_cast<const RealMPFR &>(other));
+            return sub(down_cast<const RealMPFR &>(other));
         } else if (is_a<ComplexMPC>(other)) {
-            return sub(static_cast<const ComplexMPC &>(other));
+            return sub(down_cast<const ComplexMPC &>(other));
         } else {
             return other.rsub(*this);
         }
@@ -218,17 +218,17 @@ public:
     virtual RCP<const Number> rsub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rsub(static_cast<const Rational &>(other));
+            return rsub(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rsub(static_cast<const Integer &>(other));
+            return rsub(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rsub(static_cast<const Complex &>(other));
+            return rsub(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rsub(static_cast<const RealDouble &>(other));
+            return rsub(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return rsub(static_cast<const ComplexDouble &>(other));
+            return rsub(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return rsub(static_cast<const RealMPFR &>(other));
+            return rsub(down_cast<const RealMPFR &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -246,19 +246,19 @@ public:
     virtual RCP<const Number> mul(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return mul(static_cast<const Rational &>(other));
+            return mul(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return mul(static_cast<const Integer &>(other));
+            return mul(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return mul(static_cast<const Complex &>(other));
+            return mul(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return mul(static_cast<const RealDouble &>(other));
+            return mul(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return mul(static_cast<const ComplexDouble &>(other));
+            return mul(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return mul(static_cast<const RealMPFR &>(other));
+            return mul(down_cast<const RealMPFR &>(other));
         } else if (is_a<ComplexMPC>(other)) {
-            return mul(static_cast<const ComplexMPC &>(other));
+            return mul(down_cast<const ComplexMPC &>(other));
         } else {
             return other.mul(*this);
         }
@@ -276,19 +276,19 @@ public:
     virtual RCP<const Number> div(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return div(static_cast<const Rational &>(other));
+            return div(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return div(static_cast<const Integer &>(other));
+            return div(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return div(static_cast<const Complex &>(other));
+            return div(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return div(static_cast<const RealDouble &>(other));
+            return div(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return div(static_cast<const ComplexDouble &>(other));
+            return div(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return div(static_cast<const RealMPFR &>(other));
+            return div(down_cast<const RealMPFR &>(other));
         } else if (is_a<ComplexMPC>(other)) {
-            return div(static_cast<const ComplexMPC &>(other));
+            return div(down_cast<const ComplexMPC &>(other));
         } else {
             return other.rdiv(*this);
         }
@@ -305,17 +305,17 @@ public:
     virtual RCP<const Number> rdiv(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rdiv(static_cast<const Rational &>(other));
+            return rdiv(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rdiv(static_cast<const Integer &>(other));
+            return rdiv(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rdiv(static_cast<const Complex &>(other));
+            return rdiv(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rdiv(static_cast<const RealDouble &>(other));
+            return rdiv(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return rdiv(static_cast<const ComplexDouble &>(other));
+            return rdiv(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return rdiv(static_cast<const RealMPFR &>(other));
+            return rdiv(down_cast<const RealMPFR &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -333,19 +333,19 @@ public:
     virtual RCP<const Number> pow(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return pow(static_cast<const Rational &>(other));
+            return pow(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return pow(static_cast<const Integer &>(other));
+            return pow(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return pow(static_cast<const Complex &>(other));
+            return pow(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return pow(static_cast<const RealDouble &>(other));
+            return pow(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return pow(static_cast<const ComplexDouble &>(other));
+            return pow(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return pow(static_cast<const RealMPFR &>(other));
+            return pow(down_cast<const RealMPFR &>(other));
         } else if (is_a<ComplexMPC>(other)) {
-            return pow(static_cast<const ComplexMPC &>(other));
+            return pow(down_cast<const ComplexMPC &>(other));
         } else {
             return other.rpow(*this);
         }
@@ -362,17 +362,17 @@ public:
     virtual RCP<const Number> rpow(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rpow(static_cast<const Rational &>(other));
+            return rpow(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rpow(static_cast<const Integer &>(other));
+            return rpow(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rpow(static_cast<const Complex &>(other));
+            return rpow(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rpow(static_cast<const RealDouble &>(other));
+            return rpow(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return rpow(static_cast<const ComplexDouble &>(other));
+            return rpow(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return rpow(static_cast<const RealMPFR &>(other));
+            return rpow(down_cast<const RealMPFR &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }

--- a/symengine/constants.cpp
+++ b/symengine/constants.cpp
@@ -20,14 +20,14 @@ hash_t Constant::__hash__() const
 bool Constant::__eq__(const Basic &o) const
 {
     if (is_a<Constant>(o))
-        return name_ == static_cast<const Constant &>(o).name_;
+        return name_ == down_cast<const Constant &>(o).name_;
     return false;
 }
 
 int Constant::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Constant>(o))
-    const Constant &s = static_cast<const Constant &>(o);
+    const Constant &s = down_cast<const Constant &>(o);
     if (name_ == s.name_)
         return 0;
     return name_ < s.name_ ? -1 : 1;

--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -62,7 +62,7 @@ RCP<const Basic> DenseMatrix::det() const
 void DenseMatrix::inv(MatrixBase &result) const
 {
     if (is_a<DenseMatrix>(result)) {
-        DenseMatrix &r = static_cast<DenseMatrix &>(result);
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
         inverse_LU(*this, r);
     }
 }
@@ -72,8 +72,8 @@ void DenseMatrix::add_matrix(const MatrixBase &other, MatrixBase &result) const
     SYMENGINE_ASSERT(row_ == result.nrows() and col_ == result.ncols());
 
     if (is_a<DenseMatrix>(other) and is_a<DenseMatrix>(result)) {
-        const DenseMatrix &o = static_cast<const DenseMatrix &>(other);
-        DenseMatrix &r = static_cast<DenseMatrix &>(result);
+        const DenseMatrix &o = down_cast<const DenseMatrix &>(other);
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
         add_dense_dense(*this, o, r);
     }
 }
@@ -84,8 +84,8 @@ void DenseMatrix::mul_matrix(const MatrixBase &other, MatrixBase &result) const
                      and other.ncols() == result.ncols());
 
     if (is_a<DenseMatrix>(other) and is_a<DenseMatrix>(result)) {
-        const DenseMatrix &o = static_cast<const DenseMatrix &>(other);
-        DenseMatrix &r = static_cast<DenseMatrix &>(result);
+        const DenseMatrix &o = down_cast<const DenseMatrix &>(other);
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
         mul_dense_dense(*this, o, r);
     }
 }
@@ -95,7 +95,7 @@ void DenseMatrix::add_scalar(const RCP<const Basic> &k,
                              MatrixBase &result) const
 {
     if (is_a<DenseMatrix>(result)) {
-        DenseMatrix &r = static_cast<DenseMatrix &>(result);
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
         add_dense_scalar(*this, k, r);
     }
 }
@@ -105,7 +105,7 @@ void DenseMatrix::mul_scalar(const RCP<const Basic> &k,
                              MatrixBase &result) const
 {
     if (is_a<DenseMatrix>(result)) {
-        DenseMatrix &r = static_cast<DenseMatrix &>(result);
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
         mul_dense_scalar(*this, k, r);
     }
 }
@@ -114,7 +114,7 @@ void DenseMatrix::mul_scalar(const RCP<const Basic> &k,
 void DenseMatrix::transpose(MatrixBase &result) const
 {
     if (is_a<DenseMatrix>(result)) {
-        DenseMatrix &r = static_cast<DenseMatrix &>(result);
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
         transpose_dense(*this, r);
     }
 }
@@ -126,7 +126,7 @@ void DenseMatrix::submatrix(MatrixBase &result, unsigned row_start,
                             unsigned col_step) const
 {
     if (is_a<DenseMatrix>(result)) {
-        DenseMatrix &r = static_cast<DenseMatrix &>(result);
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
         submatrix_dense(*this, r, row_start, col_start, row_end, col_end,
                         row_step, col_step);
     }
@@ -136,8 +136,8 @@ void DenseMatrix::submatrix(MatrixBase &result, unsigned row_start,
 void DenseMatrix::LU(MatrixBase &L, MatrixBase &U) const
 {
     if (is_a<DenseMatrix>(L) and is_a<DenseMatrix>(U)) {
-        DenseMatrix &L_ = static_cast<DenseMatrix &>(L);
-        DenseMatrix &U_ = static_cast<DenseMatrix &>(U);
+        DenseMatrix &L_ = down_cast<DenseMatrix &>(L);
+        DenseMatrix &U_ = down_cast<DenseMatrix &>(U);
         SymEngine::LU(*this, L_, U_);
     }
 }
@@ -146,8 +146,8 @@ void DenseMatrix::LU(MatrixBase &L, MatrixBase &U) const
 void DenseMatrix::LDL(MatrixBase &L, MatrixBase &D) const
 {
     if (is_a<DenseMatrix>(L) and is_a<DenseMatrix>(D)) {
-        DenseMatrix &L_ = static_cast<DenseMatrix &>(L);
-        DenseMatrix &D_ = static_cast<DenseMatrix &>(D);
+        DenseMatrix &L_ = down_cast<DenseMatrix &>(L);
+        DenseMatrix &D_ = down_cast<DenseMatrix &>(D);
         SymEngine::LDL(*this, L_, D_);
     }
 }
@@ -156,8 +156,8 @@ void DenseMatrix::LDL(MatrixBase &L, MatrixBase &D) const
 void DenseMatrix::LU_solve(const MatrixBase &b, MatrixBase &x) const
 {
     if (is_a<DenseMatrix>(b) and is_a<DenseMatrix>(x)) {
-        const DenseMatrix &b_ = static_cast<const DenseMatrix &>(b);
-        DenseMatrix &x_ = static_cast<DenseMatrix &>(x);
+        const DenseMatrix &b_ = down_cast<const DenseMatrix &>(b);
+        DenseMatrix &x_ = down_cast<DenseMatrix &>(x);
         SymEngine::LU_solve(*this, b_, x_);
     }
 }
@@ -166,7 +166,7 @@ void DenseMatrix::LU_solve(const MatrixBase &b, MatrixBase &x) const
 void DenseMatrix::FFLU(MatrixBase &LU) const
 {
     if (is_a<DenseMatrix>(LU)) {
-        DenseMatrix &LU_ = static_cast<DenseMatrix &>(LU);
+        DenseMatrix &LU_ = down_cast<DenseMatrix &>(LU);
         fraction_free_LU(*this, LU_);
     }
 }
@@ -176,9 +176,9 @@ void DenseMatrix::FFLDU(MatrixBase &L, MatrixBase &D, MatrixBase &U) const
 {
     if (is_a<DenseMatrix>(L) and is_a<DenseMatrix>(D)
         and is_a<DenseMatrix>(U)) {
-        DenseMatrix &L_ = static_cast<DenseMatrix &>(L);
-        DenseMatrix &D_ = static_cast<DenseMatrix &>(D);
-        DenseMatrix &U_ = static_cast<DenseMatrix &>(U);
+        DenseMatrix &L_ = down_cast<DenseMatrix &>(L);
+        DenseMatrix &D_ = down_cast<DenseMatrix &>(D);
+        DenseMatrix &U_ = down_cast<DenseMatrix &>(U);
         fraction_free_LDU(*this, L_, D_, U_);
     }
 }

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -1,5 +1,6 @@
 #include <symengine/visitor.h>
 #include <symengine/subs.h>
+#include <symengine/symengine_casts.h>
 
 namespace SymEngine
 {
@@ -195,7 +196,7 @@ public:
         }
         // Avoid cycles
         if (is_a<Derivative>(*ret)
-            && eq(*static_cast<const Derivative &>(*ret).get_arg(),
+            && eq(*down_cast<const Derivative &>(*ret).get_arg(),
                   *self.get_arg())) {
             t.insert(x);
             return Derivative::create(self.get_arg(), t);

--- a/symengine/fields.h
+++ b/symengine/fields.h
@@ -154,7 +154,7 @@ public:
             dict_ = std::move(other.dict_);
             modulo_ = std::move(other.modulo_);
         }
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     template <typename T>
@@ -170,10 +170,10 @@ public:
         if (modulo_ != other.modulo_)
             throw SymEngineException("Error: field must be same.");
         if (other.dict_.size() == 0)
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         if (this->dict_.size() == 0) {
             *this = other;
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
         if (other.dict_.size() < this->dict_.size()) {
             for (unsigned int i = 0; i < other.dict_.size(); i++) {
@@ -201,19 +201,19 @@ public:
                 dict_.insert(dict_.end(), other.dict_.begin() + dict_.size(),
                              other.dict_.end());
         }
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     GaloisFieldDict &operator+=(const integer_class &other)
     {
         if (dict_.empty() or other == integer_class(0))
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         integer_class temp = dict_[0] + other;
         mp_fdiv_r(temp, temp, modulo_);
         dict_[0] = temp;
         if (dict_.size() == 1)
             gf_istrip();
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     template <typename T>
@@ -246,10 +246,10 @@ public:
         if (modulo_ != other.modulo_)
             throw SymEngineException("Error: field must be same.");
         if (other.dict_.size() == 0)
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         if (this->dict_.size() == 0) {
             *this = -other;
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
         if (other.dict_.size() < this->dict_.size()) {
             for (unsigned int i = 0; i < other.dict_.size(); i++) {
@@ -283,7 +283,7 @@ public:
                 }
             }
         }
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     static GaloisFieldDict mul(const GaloisFieldDict &a,
@@ -298,11 +298,11 @@ public:
     GaloisFieldDict &operator*=(const integer_class &other)
     {
         if (dict_.empty())
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
 
         if (other == integer_class(0)) {
             dict_.clear();
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
 
         for (auto &arg : dict_) {
@@ -312,7 +312,7 @@ public:
             }
         }
         gf_istrip();
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     GaloisFieldDict &operator*=(const GaloisFieldDict &other)
@@ -320,12 +320,12 @@ public:
         if (modulo_ != other.modulo_)
             throw SymEngineException("Error: field must be same.");
         if (dict_.empty())
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
 
         auto o_dict = other.dict_;
         if (o_dict.empty()) {
             dict_.clear();
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
 
         // ! other is a just constant term
@@ -337,13 +337,13 @@ public:
                 }
             }
             gf_istrip();
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
         // mul will return a stripped dict
-        GaloisFieldDict res = GaloisFieldDict::mul(
-            static_cast<GaloisFieldDict &>(*this), other);
+        GaloisFieldDict res
+            = GaloisFieldDict::mul(down_cast<GaloisFieldDict &>(*this), other);
         res.dict_.swap(this->dict_);
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     template <class T>
@@ -360,7 +360,7 @@ public:
             throw DivisionByZeroError("ZeroDivisionError");
         }
         if (dict_.empty())
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         integer_class inv;
         mp_invert(inv, other, modulo_);
         for (auto &arg : dict_) {
@@ -370,7 +370,7 @@ public:
             }
         }
         gf_istrip();
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     GaloisFieldDict &operator/=(const GaloisFieldDict &other)
@@ -382,7 +382,7 @@ public:
             throw DivisionByZeroError("ZeroDivisionError");
         }
         if (dict_.empty())
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         integer_class inv;
         mp_invert(inv, *(dict_divisor.rbegin()), modulo_);
 
@@ -394,14 +394,14 @@ public:
                     mp_fdiv_r(iter, iter, modulo_);
                 }
             }
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
         std::vector<integer_class> dict_out;
         size_t deg_dividend = this->degree();
         size_t deg_divisor = other.degree();
         if (deg_dividend < deg_divisor) {
             dict_.clear();
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
         dict_out.swap(dict_);
         dict_.resize(deg_dividend - deg_divisor + 1);
@@ -421,7 +421,7 @@ public:
             dict_out[riter] = dict_[riter - deg_divisor] = coeff;
         }
         gf_istrip();
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     template <class T>
@@ -438,9 +438,9 @@ public:
             throw DivisionByZeroError("ZeroDivisionError");
         }
         if (dict_.empty())
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         dict_.clear();
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     GaloisFieldDict &operator%=(const GaloisFieldDict &other)
@@ -452,20 +452,20 @@ public:
             throw DivisionByZeroError("ZeroDivisionError");
         }
         if (dict_.empty())
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         integer_class inv;
         mp_invert(inv, *(dict_divisor.rbegin()), modulo_);
 
         // ! other is a just constant term
         if (dict_divisor.size() == 1) {
             dict_.clear();
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
         std::vector<integer_class> dict_out;
         size_t deg_dividend = this->degree();
         size_t deg_divisor = other.degree();
         if (deg_dividend < deg_divisor) {
-            return static_cast<GaloisFieldDict &>(*this);
+            return down_cast<GaloisFieldDict &>(*this);
         }
         dict_out.swap(dict_);
         dict_.resize(deg_divisor);
@@ -490,7 +490,7 @@ public:
             }
         }
         gf_istrip();
-        return static_cast<GaloisFieldDict &>(*this);
+        return down_cast<GaloisFieldDict &>(*this);
     }
 
     static GaloisFieldDict pow(const GaloisFieldDict &a, unsigned int p)

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -8,6 +8,7 @@
 #define SYMENGINE_FUNCTIONS_H
 
 #include <symengine/basic.h>
+#include <symengine/symengine_casts.h>
 
 namespace SymEngine
 {
@@ -49,14 +50,14 @@ public:
     {
         return is_same_type(*this, o)
                and eq(*get_arg(),
-                      *static_cast<const OneArgFunction &>(o).get_arg());
+                      *down_cast<const OneArgFunction &>(o).get_arg());
     }
     //! Structural equality comparator
     virtual inline int compare(const Basic &o) const
     {
         SYMENGINE_ASSERT(is_same_type(*this, o))
         return get_arg()->__cmp__(
-            *(static_cast<const OneArgFunction &>(o).get_arg()));
+            *(down_cast<const OneArgFunction &>(o).get_arg()));
     }
 };
 
@@ -102,21 +103,21 @@ public:
     {
         return is_same_type(*this, o)
                and eq(*get_arg1(),
-                      *static_cast<const TwoArgFunction &>(o).get_arg1())
+                      *down_cast<const TwoArgFunction &>(o).get_arg1())
                and eq(*get_arg2(),
-                      *static_cast<const TwoArgFunction &>(o).get_arg2());
+                      *down_cast<const TwoArgFunction &>(o).get_arg2());
     }
     //! Structural equality comparator
     virtual inline int compare(const Basic &o) const
     {
         SYMENGINE_ASSERT(is_same_type(*this, o))
-        const TwoArgFunction &t = static_cast<const TwoArgFunction &>(o);
+        const TwoArgFunction &t = down_cast<const TwoArgFunction &>(o);
         if (neq(*get_arg1(), *(t.get_arg1()))) {
             return get_arg1()->__cmp__(
-                *(static_cast<const TwoArgFunction &>(o).get_arg1()));
+                *(down_cast<const TwoArgFunction &>(o).get_arg1()));
         } else {
             return get_arg2()->__cmp__(
-                *(static_cast<const TwoArgFunction &>(o).get_arg2()));
+                *(down_cast<const TwoArgFunction &>(o).get_arg2()));
         }
     }
 };
@@ -154,16 +155,15 @@ public:
     virtual inline bool __eq__(const Basic &o) const
     {
         return is_same_type(*this, o)
-               and unified_eq(
-                       get_vec(),
-                       static_cast<const MultiArgFunction &>(o).get_vec());
+               and unified_eq(get_vec(),
+                              down_cast<const MultiArgFunction &>(o).get_vec());
     }
     //! Structural equality comparator
     virtual inline int compare(const Basic &o) const
     {
         SYMENGINE_ASSERT(is_same_type(*this, o))
         return unified_compare(
-            get_vec(), static_cast<const MultiArgFunction &>(o).get_vec());
+            get_vec(), down_cast<const MultiArgFunction &>(o).get_vec());
     }
 };
 

--- a/symengine/infinity.cpp
+++ b/symengine/infinity.cpp
@@ -53,7 +53,7 @@ hash_t Infty::__hash__() const
 bool Infty::__eq__(const Basic &o) const
 {
     if (is_a<Infty>(o)) {
-        const Infty &s = static_cast<const Infty &>(o);
+        const Infty &s = down_cast<const Infty &>(o);
         return eq(*_direction, *(s.get_direction()));
     }
 
@@ -63,7 +63,7 @@ bool Infty::__eq__(const Basic &o) const
 int Infty::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Infty>(o))
-    const Infty &s = static_cast<const Infty &>(o);
+    const Infty &s = down_cast<const Infty &>(o);
     return _direction->compare(*(s.get_direction()));
 }
 
@@ -87,7 +87,7 @@ RCP<const Number> Infty::add(const Number &other) const
     if (not is_a<Infty>(other))
         return rcp_from_this_cast<Number>();
 
-    const Infty &s = static_cast<const Infty &>(other);
+    const Infty &s = down_cast<const Infty &>(other);
 
     if (not eq(*s.get_direction(), *_direction)) {
         if (is_unsigned_infinity() or s.is_unsigned_infinity())
@@ -112,7 +112,7 @@ RCP<const Number> Infty::mul(const Number &other) const
         throw NotImplementedError("Multiplation with Complex not implemented");
 
     if (is_a<Infty>(other)) {
-        const Infty &s = static_cast<const Infty &>(other);
+        const Infty &s = down_cast<const Infty &>(other);
 
         return make_rcp<const Infty>(this->_direction->mul(*(s._direction)));
     } else {

--- a/symengine/integer.cpp
+++ b/symengine/integer.cpp
@@ -77,7 +77,7 @@ RCP<const Number> Integer::pow_negint(const Integer &other) const
 {
     RCP<const Number> tmp = powint(*other.neg());
     if (is_a<Integer>(*tmp)) {
-        const integer_class &j = static_cast<const Integer &>(*tmp).i;
+        const integer_class &j = down_cast<const Integer &>(*tmp).i;
 #if SYMENGINE_INTEGER_CLASS == SYMENGINE_BOOSTMP
         // boost::multiprecision::cpp_rational lacks an (int, cpp_int)
         // constructor. must use cpp_rational(cpp_int,cpp_int)

--- a/symengine/integer.cpp
+++ b/symengine/integer.cpp
@@ -1,6 +1,7 @@
 #include <symengine/rational.h>
 #include <symengine/pow.h>
 #include <symengine/symengine_exception.h>
+#include <symengine/symengine_casts.h>
 
 namespace SymEngine
 {
@@ -15,7 +16,7 @@ hash_t Integer::__hash__() const
 bool Integer::__eq__(const Basic &o) const
 {
     if (is_a<Integer>(o)) {
-        const Integer &s = static_cast<const Integer &>(o);
+        const Integer &s = down_cast<const Integer &>(o);
         return this->i == s.i;
     }
     return false;
@@ -24,7 +25,7 @@ bool Integer::__eq__(const Basic &o) const
 int Integer::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Integer>(o))
-    const Integer &s = static_cast<const Integer &>(o);
+    const Integer &s = down_cast<const Integer &>(o);
     if (i == s.i)
         return 0;
     return i < s.i ? -1 : 1;
@@ -60,7 +61,7 @@ RCP<const Number> Integer::rdiv(const Number &other) const
         if (this->i == 0) {
             throw DivisionByZeroError("Division By Zero");
         }
-        rational_class q((static_cast<const Integer &>(other)).i, this->i);
+        rational_class q((down_cast<const Integer &>(other)).i, this->i);
 
         // This is potentially slow, but has to be done, since q might not
         // be in canonical form.

--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -9,6 +9,7 @@
 
 #include <symengine/number.h>
 #include <symengine/symengine_exception.h>
+#include <symengine/symengine_casts.h>
 
 namespace SymEngine
 {
@@ -118,7 +119,7 @@ public:
     virtual RCP<const Number> add(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return addint(static_cast<const Integer &>(other));
+            return addint(down_cast<const Integer &>(other));
         } else {
             return other.add(*this);
         }
@@ -127,7 +128,7 @@ public:
     virtual RCP<const Number> sub(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return subint(static_cast<const Integer &>(other));
+            return subint(down_cast<const Integer &>(other));
         } else {
             return other.rsub(*this);
         }
@@ -142,7 +143,7 @@ public:
     virtual RCP<const Number> mul(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return mulint(static_cast<const Integer &>(other));
+            return mulint(down_cast<const Integer &>(other));
         } else {
             return other.mul(*this);
         }
@@ -151,7 +152,7 @@ public:
     virtual RCP<const Number> div(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return divint(static_cast<const Integer &>(other));
+            return divint(down_cast<const Integer &>(other));
         } else {
             return other.rdiv(*this);
         }
@@ -163,7 +164,7 @@ public:
     virtual RCP<const Number> pow(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return powint(static_cast<const Integer &>(other));
+            return powint(down_cast<const Integer &>(other));
         } else {
             return other.rpow(*this);
         }

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -347,7 +347,7 @@ public:
                     return;
                 } else {
                     args.push_back(apply(*x.get_base()));
-                    bvisit(static_cast<const Integer &>(*x.get_exp()), true);
+                    bvisit(down_cast<const Integer &>(*x.get_exp()), true);
                     args.push_back(result_);
                     fun = get_powi();
                 }

--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -27,13 +27,13 @@ vec_basic BooleanAtom::get_args() const
 bool BooleanAtom::__eq__(const Basic &o) const
 {
     return is_a<BooleanAtom>(o)
-           and get_val() == static_cast<const BooleanAtom &>(o).get_val();
+           and get_val() == down_cast<const BooleanAtom &>(o).get_val();
 }
 
 int BooleanAtom::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<BooleanAtom>(o))
-    bool ob = static_cast<const BooleanAtom &>(o).get_val();
+    bool ob = down_cast<const BooleanAtom &>(o).get_val();
     if (get_val()) {
         return (ob) ? 0 : 1;
     } else {
@@ -78,16 +78,14 @@ vec_basic Contains::get_args() const
 bool Contains::__eq__(const Basic &o) const
 {
     return is_a<Contains>(o)
-           and unified_eq(get_expr(),
-                          static_cast<const Contains &>(o).get_expr())
-           and unified_eq(get_set(),
-                          static_cast<const Contains &>(o).get_set());
+           and unified_eq(get_expr(), down_cast<const Contains &>(o).get_expr())
+           and unified_eq(get_set(), down_cast<const Contains &>(o).get_set());
 }
 
 int Contains::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Contains>(o))
-    const Contains &c = static_cast<const Contains &>(o);
+    const Contains &c = down_cast<const Contains &>(o);
     int cmp = unified_compare(get_expr(), c.get_expr());
     if (cmp != 0)
         return cmp;
@@ -136,8 +134,7 @@ vec_basic Piecewise::get_args() const
 bool Piecewise::__eq__(const Basic &o) const
 {
     return is_a<Piecewise>(o)
-           and unified_eq(get_vec(),
-                          static_cast<const Piecewise &>(o).get_vec());
+           and unified_eq(get_vec(), down_cast<const Piecewise &>(o).get_vec());
 }
 
 int Piecewise::compare(const Basic &o) const
@@ -168,7 +165,7 @@ vec_basic And::get_args() const
 
 bool And::__eq__(const Basic &o) const
 {
-    return is_a<And>(o) and unified_eq(container_, static_cast<const And &>(o)
+    return is_a<And>(o) and unified_eq(container_, down_cast<const And &>(o)
                                                        .get_container());
 }
 
@@ -176,7 +173,7 @@ int And::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<And>(o))
     return unified_compare(container_,
-                           static_cast<const And &>(o).get_container());
+                           down_cast<const And &>(o).get_container());
 }
 
 bool And::is_canonical(const set_boolean &container_)
@@ -219,15 +216,15 @@ vec_basic Or::get_args() const
 
 bool Or::__eq__(const Basic &o) const
 {
-    return is_a<Or>(o) and unified_eq(container_, static_cast<const Or &>(o)
-                                                      .get_container());
+    return is_a<Or>(o)
+           and unified_eq(container_, down_cast<const Or &>(o).get_container());
 }
 
 int Or::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Or>(o))
     return unified_compare(container_,
-                           static_cast<const Or &>(o).get_container());
+                           down_cast<const Or &>(o).get_container());
 }
 
 bool Or::is_canonical(const set_boolean &container_)
@@ -270,13 +267,13 @@ vec_basic Not::get_args() const
 
 bool Not::__eq__(const Basic &o) const
 {
-    return is_a<Not>(o) and eq(*arg_, *static_cast<const Not &>(o).get_arg());
+    return is_a<Not>(o) and eq(*arg_, *down_cast<const Not &>(o).get_arg());
 }
 
 int Not::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Not>(o))
-    return arg_->__cmp__(*static_cast<const Not &>(o).get_arg());
+    return arg_->__cmp__(*down_cast<const Not &>(o).get_arg());
 }
 
 bool Not::is_canonical(const RCP<const Boolean> &in)
@@ -297,14 +294,14 @@ RCP<const Boolean> and_or(const set_boolean &s, const bool &op_x_notx)
     set_boolean args;
     for (auto &a : s) {
         if (is_a<BooleanAtom>(*a)) {
-            auto val = static_cast<const BooleanAtom &>(*a).get_val();
+            auto val = down_cast<const BooleanAtom &>(*a).get_val();
             if (val == op_x_notx)
                 return boolean(op_x_notx);
             else
                 continue;
         }
         if (is_a<caller>(*a)) {
-            const caller &to_insert = static_cast<const caller &>(*a);
+            const caller &to_insert = down_cast<const caller &>(*a);
             auto container = to_insert.get_container();
             args.insert(container.begin(), container.end());
             continue;
@@ -325,20 +322,20 @@ RCP<const Boolean> and_or(const set_boolean &s, const bool &op_x_notx)
 RCP<const Boolean> logical_not(const RCP<const Boolean> &s)
 {
     if (is_a<BooleanAtom>(*s)) {
-        const BooleanAtom &a = static_cast<const BooleanAtom &>(*s);
+        const BooleanAtom &a = down_cast<const BooleanAtom &>(*s);
         return boolean(not a.get_val());
     } else if (is_a<Not>(*s)) {
-        const Not &a = static_cast<const Not &>(*s);
+        const Not &a = down_cast<const Not &>(*s);
         return a.get_arg();
     } else if (is_a<Or>(*s)) {
-        auto container = static_cast<const Or &>(*s).get_container();
+        auto container = down_cast<const Or &>(*s).get_container();
         set_boolean cont;
         for (auto &a : container) {
             cont.insert(logical_not(a));
         }
         return make_rcp<const And>(cont);
     } else if (is_a<And>(*s)) {
-        auto container = static_cast<const And &>(*s).get_container();
+        auto container = down_cast<const And &>(*s).get_container();
         set_boolean cont;
         for (auto &a : container) {
             cont.insert(logical_not(a));

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -55,8 +55,8 @@ bool Mul::is_canonical(const RCP<const Number> &coef,
         if (is_a<Mul>(*p.first)) {
             if (is_a<Integer>(*p.second))
                 return false;
-            if (neq(*static_cast<const Mul &>(*p.first).coef_, *one)
-                and neq(*static_cast<const Mul &>(*p.first).coef_, *minus_one))
+            if (neq(*down_cast<const Mul &>(*p.first).coef_, *one)
+                and neq(*down_cast<const Mul &>(*p.first).coef_, *minus_one))
                 return false;
         }
         // e.g. x**2**y (={x**2:y}), which should be represented as x**(2y)
@@ -86,8 +86,8 @@ hash_t Mul::__hash__() const
 
 bool Mul::__eq__(const Basic &o) const
 {
-    if (is_a<Mul>(o) and eq(*coef_, *(static_cast<const Mul &>(o).coef_))
-        and unified_eq(dict_, static_cast<const Mul &>(o).dict_))
+    if (is_a<Mul>(o) and eq(*coef_, *(down_cast<const Mul &>(o).coef_))
+        and unified_eq(dict_, down_cast<const Mul &>(o).dict_))
         return true;
 
     return false;
@@ -96,7 +96,7 @@ bool Mul::__eq__(const Basic &o) const
 int Mul::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Mul>(o))
-    const Mul &s = static_cast<const Mul &>(o);
+    const Mul &s = down_cast<const Mul &>(o);
     // # of elements
     if (dict_.size() != s.dict_.size())
         return (dict_.size() < s.dict_.size()) ? -1 : 1;
@@ -189,11 +189,11 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef,
             } else if (is_a<Rational>(*exp)) {
                 RCP<const Basic> res;
                 if (is_a<Integer>(*t)) {
-                    res = static_cast<const Rational &>(*exp)
-                              .rpowrat(static_cast<const Integer &>(*t));
+                    res = down_cast<const Rational &>(*exp)
+                              .rpowrat(down_cast<const Integer &>(*t));
                 } else {
-                    res = static_cast<const Rational &>(*t)
-                              .powrat(static_cast<const Rational &>(*exp));
+                    res = down_cast<const Rational &>(*t)
+                              .powrat(down_cast<const Rational &>(*exp));
                 }
                 if (is_a_Number(*res)) {
                     imulnum(outArg(*coef), rcp_static_cast<const Number>(res));
@@ -257,11 +257,11 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef,
             if (is_a<Integer>(*t) or is_a<Rational>(*t)) {
                 RCP<const Basic> res;
                 if (is_a<Integer>(*t)) {
-                    res = static_cast<const Rational &>(*it->second)
-                              .rpowrat(static_cast<const Integer &>(*t));
+                    res = down_cast<const Rational &>(*it->second)
+                              .rpowrat(down_cast<const Integer &>(*t));
                 } else {
-                    res = static_cast<const Rational &>(*t).powrat(
-                        static_cast<const Rational &>(*it->second));
+                    res = down_cast<const Rational &>(*t)
+                              .powrat(down_cast<const Rational &>(*it->second));
                 }
                 if (is_a_Number(*res)) {
                     d.erase(it);
@@ -279,7 +279,7 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef,
             }
         }
         if (is_a_Number(*it->second)) {
-            if (static_cast<const Number &>(*it->second).is_zero()) {
+            if (down_cast<const Number &>(*it->second).is_zero()) {
                 // In 1*x**0.0, result should be 1.0
                 imulnum(
                     outArg(*coef),
@@ -448,7 +448,7 @@ void Mul::power_num(const Ptr<RCP<const Number>> &coef, map_basic_basic &d,
         for (const auto &p : dict_) {
             new_exp = mul(p.second, exp);
             if (is_a<Integer>(*new_exp) and is_a<Mul>(*p.first)) {
-                static_cast<const Mul &>(*p.first)
+                down_cast<const Mul &>(*p.first)
                     .power_num(coef, d, rcp_static_cast<const Number>(new_exp));
             } else {
                 // No need for additional dict checks here.

--- a/symengine/ntheory.cpp
+++ b/symengine/ntheory.cpp
@@ -518,7 +518,7 @@ void Sieve::_extend(unsigned limit)
     if (_primes.back() < limit)
         primesieve::generate_primes(_primes.back() + 1, limit, &_primes);
 #else
-    const unsigned sqrt_limit = static_cast<unsigned>(std::sqrt(limit));
+    const unsigned sqrt_limit = implicit_cast<unsigned>(std::sqrt(limit));
     unsigned start = _primes.back() + 1;
     if (limit <= start)
         return;
@@ -1557,8 +1557,7 @@ bool powermod(const Ptr<RCP<const Integer>> &powm, const RCP<const Integer> &a,
         return true;
     } else if (is_a<Rational>(*b)) {
         RCP<const Integer> num, den, r;
-        get_num_den(static_cast<const Rational &>(*b), outArg(num),
-                    outArg(den));
+        get_num_den(down_cast<const Rational &>(*b), outArg(num), outArg(den));
         if (den->is_negative()) {
             den = den->mulint(*minus_one);
             num = num->mulint(*minus_one);
@@ -1592,8 +1591,7 @@ void powermod_list(std::vector<RCP<const Integer>> &pows,
         pows.push_back(integer(std::move(t)));
     } else if (is_a<Rational>(*b)) {
         RCP<const Integer> num, den, r;
-        get_num_den(static_cast<const Rational &>(*b), outArg(num),
-                    outArg(den));
+        get_num_den(down_cast<const Rational &>(*b), outArg(num), outArg(den));
         if (den->is_negative()) {
             den = den->mulint(*integer(-1));
             num = num->mulint(*integer(-1));

--- a/symengine/polys/basic_conversions.cpp
+++ b/symengine/polys/basic_conversions.cpp
@@ -34,10 +34,10 @@ public:
 
         if (is_a<const Rational>(*exp)) {
             RCP<const Integer> den
-                = static_cast<const Rational &>(*exp).get_den();
+                = down_cast<const Rational &>(*exp).get_den();
             if (is_a<const Rational>(*it->second))
                 gen_set[base] = divnum(
-                    one, lcm(*den, *static_cast<const Rational &>(*it->second)
+                    one, lcm(*den, *down_cast<const Rational &>(*it->second)
                                         .get_den()));
             else
                 gen_set[base] = divnum(one, den);
@@ -122,7 +122,7 @@ public:
                 mulx = minus_one;
 
             if (is_a<const Rational>(*it.second))
-                divx = static_cast<const Rational &>(*it.second).get_den();
+                divx = down_cast<const Rational &>(*it.second).get_den();
 
             gen_set[mul(mulx, it.first)] = divnum(one, divx);
         }
@@ -138,7 +138,7 @@ public:
             mulx = minus_one;
 
         if (is_a<const Rational>(*x.coef_))
-            divx = static_cast<const Rational &>(*x.coef_).get_den();
+            divx = down_cast<const Rational &>(*x.coef_).get_den();
 
         auto dict = x.dict_;
         gen_set[Mul::from_dict(mulx, std::move(dict))] = divnum(one, divx);

--- a/symengine/polys/basic_conversions.h
+++ b/symengine/polys/basic_conversions.h
@@ -50,7 +50,7 @@ public:
 
     void dict_set(unsigned int pow, const Basic &x)
     {
-        static_cast<V *>(this)->dict_set(pow, x);
+        down_cast<V *>(this)->dict_set(pow, x);
     }
 
     void bvisit(const Pow &x)
@@ -69,8 +69,8 @@ public:
 
         RCP<const Basic> genbase = gen, genpow = one, coef = one, tmp;
         if (is_a<const Pow>(*gen)) {
-            genbase = static_cast<const Pow &>(*gen).get_base();
-            genpow = static_cast<const Pow &>(*gen).get_exp();
+            genbase = down_cast<const Pow &>(*gen).get_base();
+            genpow = down_cast<const Pow &>(*gen).get_exp();
         }
 
         if (eq(*genbase, *x.get_base())) {
@@ -173,7 +173,7 @@ public:
     {
         if (is_a<const Integer>(x))
             this->dict = Poly::container_from_dict(
-                this->gen, {{pow, static_cast<const Integer &>(x).i}});
+                this->gen, {{pow, down_cast<const Integer &>(x).i}});
         else
             throw SymEngineException("Non-integer found");
     }
@@ -293,7 +293,7 @@ public:
 
     void dict_set(Vec pow, const Basic &x)
     {
-        static_cast<V *>(this)->dict_set(pow, x);
+        down_cast<V *>(this)->dict_set(pow, x);
     }
 
     void bvisit(const Pow &x)
@@ -422,7 +422,7 @@ public:
     {
         if (is_a<const Integer>(x))
             dict = MIntPoly::container_from_dict(
-                gens, {{pow, static_cast<const Integer &>(x).i}});
+                gens, {{pow, down_cast<const Integer &>(x).i}});
         else
             throw SymEngineException("Non-integer found");
     }

--- a/symengine/polys/uexprpoly.h
+++ b/symengine/polys/uexprpoly.h
@@ -89,7 +89,7 @@ public:
                     if (it->second == -1)
                         o << "-";
                 } else {
-                    if (static_cast<const Integer &>(*it->second.get_basic())
+                    if (down_cast<const Integer &>(*it->second.get_basic())
                             .as_integer_class()
                         < 0) {
                         o << " "

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -30,7 +30,7 @@ public:
     int compare(const Basic &o) const
     {
         SYMENGINE_ASSERT(is_a<Poly>(o))
-        const Poly &s = static_cast<const Poly &>(o);
+        const Poly &s = down_cast<const Poly &>(o);
 
         if (this->poly_.degree() != s.poly_.degree())
             return (this->poly_.degree() < s.poly_.degree()) ? -1 : 1;

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -167,7 +167,7 @@ public:
     int compare(const Basic &o) const
     {
         SYMENGINE_ASSERT(is_a<Poly>(o))
-        const Poly &s = static_cast<const Poly &>(o);
+        const Poly &s = down_cast<const Poly &>(o);
         int cmp = this->var_->compare(*s.var_);
         if (cmp != 0)
             return cmp;

--- a/symengine/polys/usymenginepoly.h
+++ b/symengine/polys/usymenginepoly.h
@@ -22,7 +22,7 @@ public:
     int compare(const Basic &o) const
     {
         SYMENGINE_ASSERT(is_a<Poly>(o))
-        const Poly &s = static_cast<const Poly &>(o);
+        const Poly &s = down_cast<const Poly &>(o);
 
         if (this->poly_.size() != s.poly_.size())
             return (this->poly_.size() < s.poly_.size()) ? -1 : 1;

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -15,16 +15,16 @@ Pow::Pow(const RCP<const Basic> &base, const RCP<const Basic> &exp)
 bool Pow::is_canonical(const Basic &base, const Basic &exp) const
 {
     // e.g. 0**x
-    if (is_a<Integer>(base) and static_cast<const Integer &>(base).is_zero())
+    if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_zero())
         return false;
     // e.g. 1**x
-    if (is_a<Integer>(base) and static_cast<const Integer &>(base).is_one())
+    if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_one())
         return false;
     // e.g. x**0.0
-    if (is_a_Number(exp) and static_cast<const Number &>(exp).is_zero())
+    if (is_a_Number(exp) and down_cast<const Number &>(exp).is_zero())
         return false;
     // e.g. x**1
-    if (is_a<Integer>(exp) and static_cast<const Integer &>(exp).is_one())
+    if (is_a<Integer>(exp) and down_cast<const Integer &>(exp).is_one())
         return false;
     // e.g. 2**3, (2/3)**4
     if ((is_a<Integer>(base) or is_a<Rational>(base)) and is_a<Integer>(exp))
@@ -38,18 +38,17 @@ bool Pow::is_canonical(const Basic &base, const Basic &exp) const
     // If exp is a rational, it should be between 0  and 1, i.e. we don't
     // allow things like 2**(-1/2) or 2**(3/2)
     if ((is_a<Rational>(base) or is_a<Integer>(base)) and is_a<Rational>(exp)
-        and (static_cast<const Rational &>(exp).i < 0
-             or static_cast<const Rational &>(exp).i > 1))
+        and (down_cast<const Rational &>(exp).i < 0
+             or down_cast<const Rational &>(exp).i > 1))
         return false;
     // Purely Imaginary complex numbers with integral powers are expanded
     // e.g (2I)**3
-    if (is_a<Complex>(base) and static_cast<const Complex &>(base).is_re_zero()
+    if (is_a<Complex>(base) and down_cast<const Complex &>(base).is_re_zero()
         and is_a<Integer>(exp))
         return false;
     // e.g. 0.5^2.0 should be represented as 0.25
-    if (is_a_Number(base) and not static_cast<const Number &>(base).is_exact()
-        and is_a_Number(exp)
-        and not static_cast<const Number &>(exp).is_exact())
+    if (is_a_Number(base) and not down_cast<const Number &>(base).is_exact()
+        and is_a_Number(exp) and not down_cast<const Number &>(exp).is_exact())
         return false;
     return true;
 }
@@ -64,8 +63,8 @@ hash_t Pow::__hash__() const
 
 bool Pow::__eq__(const Basic &o) const
 {
-    if (is_a<Pow>(o) and eq(*base_, *(static_cast<const Pow &>(o).base_))
-        and eq(*exp_, *(static_cast<const Pow &>(o).exp_)))
+    if (is_a<Pow>(o) and eq(*base_, *(down_cast<const Pow &>(o).base_))
+        and eq(*exp_, *(down_cast<const Pow &>(o).exp_)))
         return true;
 
     return false;
@@ -74,7 +73,7 @@ bool Pow::__eq__(const Basic &o) const
 int Pow::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Pow>(o))
-    const Pow &s = static_cast<const Pow &>(o);
+    const Pow &s = down_cast<const Pow &>(o);
     int base_cmp = base_->__cmp__(*s.base_);
     if (base_cmp == 0)
         return exp_->__cmp__(*s.exp_);
@@ -123,11 +122,11 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
             }
         } else if (is_a<Rational>(*b)) {
             if (is_a<Rational>(*a)) {
-                return static_cast<const Rational &>(*a)
-                    .powrat(static_cast<const Rational &>(*b));
+                return down_cast<const Rational &>(*a)
+                    .powrat(down_cast<const Rational &>(*b));
             } else if (is_a<Integer>(*a)) {
-                return static_cast<const Rational &>(*b)
-                    .rpowrat(static_cast<const Integer &>(*a));
+                return down_cast<const Rational &>(*b)
+                    .rpowrat(down_cast<const Integer &>(*a));
             } else if (is_a<Complex>(*a)) {
                 return make_rcp<const Pow>(a, b);
             } else {
@@ -267,19 +266,19 @@ Log::Log(const RCP<const Basic> &arg) : OneArgFunction(arg)
 bool Log::is_canonical(const Basic &arg) const
 {
     //  log(0)
-    if (is_a<Integer>(arg) and static_cast<const Integer &>(arg).is_zero())
+    if (is_a<Integer>(arg) and down_cast<const Integer &>(arg).is_zero())
         return false;
     //  log(1)
-    if (is_a<Integer>(arg) and static_cast<const Integer &>(arg).is_one())
+    if (is_a<Integer>(arg) and down_cast<const Integer &>(arg).is_one())
         return false;
     // log(E)
     if (eq(arg, *E))
         return false;
     // Currently not implemented, however should be expanded as `-ipi +
     // log(-arg)`
-    if (is_a_Number(arg) and static_cast<const Number &>(arg).is_negative())
+    if (is_a_Number(arg) and down_cast<const Number &>(arg).is_negative())
         return false;
-    if (is_a_Number(arg) and not static_cast<const Number &>(arg).is_exact())
+    if (is_a_Number(arg) and not down_cast<const Number &>(arg).is_exact())
         return false;
     // log(num/den) = log(num) - log(den)
     if (is_a<Rational>(arg))
@@ -313,7 +312,7 @@ RCP<const Basic> log(const RCP<const Basic> &arg)
     }
     if (is_a<Rational>(*arg)) {
         RCP<const Integer> num, den;
-        get_num_den(static_cast<const Rational &>(*arg), outArg(num),
+        get_num_den(down_cast<const Rational &>(*arg), outArg(num),
                     outArg(den));
         return sub(log(num), log(den));
     }

--- a/symengine/printer.h
+++ b/symengine/printer.h
@@ -59,7 +59,7 @@ public:
     template <typename Container, typename Poly>
     void bvisit(const UPolyBase<Container, Poly> &x)
     {
-        bvisit_upoly(static_cast<const Poly &>(x));
+        bvisit_upoly(down_cast<const Poly &>(x));
     }
 
     void bvisit(const GaloisField &x)

--- a/symengine/rational.cpp
+++ b/symengine/rational.cpp
@@ -80,7 +80,7 @@ hash_t Rational::__hash__() const
 bool Rational::__eq__(const Basic &o) const
 {
     if (is_a<Rational>(o)) {
-        const Rational &s = static_cast<const Rational &>(o);
+        const Rational &s = down_cast<const Rational &>(o);
         return this->i == s.i;
     }
     return false;
@@ -89,13 +89,13 @@ bool Rational::__eq__(const Basic &o) const
 int Rational::compare(const Basic &o) const
 {
     if (is_a<Rational>(o)) {
-        const Rational &s = static_cast<const Rational &>(o);
+        const Rational &s = down_cast<const Rational &>(o);
         if (i == s.i)
             return 0;
         return i < s.i ? -1 : 1;
     }
     if (is_a<Integer>(o)) {
-        const Integer &s = static_cast<const Integer &>(o);
+        const Integer &s = down_cast<const Integer &>(o);
         return i < s.i ? -1 : 1;
     }
     throw SymEngineException("unhandled comparison of Rational");

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -217,9 +217,9 @@ public:
     virtual RCP<const Number> add(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return addrat(static_cast<const Rational &>(other));
+            return addrat(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return addrat(static_cast<const Integer &>(other));
+            return addrat(down_cast<const Integer &>(other));
         } else {
             return other.add(*this);
         }
@@ -228,9 +228,9 @@ public:
     virtual RCP<const Number> sub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return subrat(static_cast<const Rational &>(other));
+            return subrat(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return subrat(static_cast<const Integer &>(other));
+            return subrat(down_cast<const Integer &>(other));
         } else {
             return other.rsub(*this);
         }
@@ -239,7 +239,7 @@ public:
     virtual RCP<const Number> rsub(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return rsubrat(static_cast<const Integer &>(other));
+            return rsubrat(down_cast<const Integer &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -248,9 +248,9 @@ public:
     virtual RCP<const Number> mul(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return mulrat(static_cast<const Rational &>(other));
+            return mulrat(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return mulrat(static_cast<const Integer &>(other));
+            return mulrat(down_cast<const Integer &>(other));
         } else {
             return other.mul(*this);
         }
@@ -259,9 +259,9 @@ public:
     virtual RCP<const Number> div(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return divrat(static_cast<const Rational &>(other));
+            return divrat(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return divrat(static_cast<const Integer &>(other));
+            return divrat(down_cast<const Integer &>(other));
         } else {
             return other.rdiv(*this);
         }
@@ -270,7 +270,7 @@ public:
     virtual RCP<const Number> rdiv(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return rdivrat(static_cast<const Integer &>(other));
+            return rdivrat(down_cast<const Integer &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -279,7 +279,7 @@ public:
     virtual RCP<const Number> pow(const Number &other) const
     {
         if (is_a<Integer>(other)) {
-            return powrat(static_cast<const Integer &>(other));
+            return powrat(down_cast<const Integer &>(other));
         } else {
             return other.rpow(*this);
         }

--- a/symengine/real_double.cpp
+++ b/symengine/real_double.cpp
@@ -22,7 +22,7 @@ hash_t RealDouble::__hash__() const
 bool RealDouble::__eq__(const Basic &o) const
 {
     if (is_a<RealDouble>(o)) {
-        const RealDouble &s = static_cast<const RealDouble &>(o);
+        const RealDouble &s = down_cast<const RealDouble &>(o);
         return this->i == s.i;
     }
     return false;
@@ -31,7 +31,7 @@ bool RealDouble::__eq__(const Basic &o) const
 int RealDouble::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<RealDouble>(o))
-    const RealDouble &s = static_cast<const RealDouble &>(o);
+    const RealDouble &s = down_cast<const RealDouble &>(o);
     if (i == s.i)
         return 0;
     return i < s.i ? -1 : 1;
@@ -58,87 +58,87 @@ class EvaluateDouble : public Evaluate
     virtual RCP<const Basic> sin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::sin(static_cast<const T &>(x).i));
+        return number(std::sin(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> cos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::cos(static_cast<const T &>(x).i));
+        return number(std::cos(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> tan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::tan(static_cast<const T &>(x).i));
+        return number(std::tan(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> cot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(1.0 / std::tan(static_cast<const T &>(x).i));
+        return number(1.0 / std::tan(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> sec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(1.0 / std::sin(static_cast<const T &>(x).i));
+        return number(1.0 / std::sin(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> csc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(1.0 / std::cos(static_cast<const T &>(x).i));
+        return number(1.0 / std::cos(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> atan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::atan(static_cast<const T &>(x).i));
+        return number(std::atan(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> acot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::atan(1.0 / static_cast<const T &>(x).i));
+        return number(std::atan(1.0 / down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> sinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::sinh(static_cast<const T &>(x).i));
+        return number(std::sinh(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> csch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(1.0 / std::sinh(static_cast<const T &>(x).i));
+        return number(1.0 / std::sinh(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> cosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::cosh(static_cast<const T &>(x).i));
+        return number(std::cosh(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> sech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(1.0 / std::cosh(static_cast<const T &>(x).i));
+        return number(1.0 / std::cosh(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> tanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::tanh(static_cast<const T &>(x).i));
+        return number(std::tanh(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> coth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(1.0 / std::tanh(static_cast<const T &>(x).i));
+        return number(1.0 / std::tanh(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> asinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::asinh(static_cast<const T &>(x).i));
+        return number(std::asinh(down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> acsch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::asinh(1.0 / static_cast<const T &>(x).i));
+        return number(std::asinh(1.0 / down_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> abs(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
-        return number(std::abs(static_cast<const T &>(x).i));
+        return number(std::abs(down_cast<const T &>(x).i));
     }
 };
 
@@ -147,12 +147,12 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
     virtual RCP<const Basic> gamma(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return number(std::tgamma(static_cast<const RealDouble &>(x).i));
+        return number(std::tgamma(down_cast<const RealDouble &>(x).i));
     }
     virtual RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        double d = static_cast<const RealDouble &>(x).i;
+        double d = down_cast<const RealDouble &>(x).i;
         if (d <= 1.0 and d >= -1.0) {
             return number(std::asin(d));
         } else {
@@ -162,7 +162,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
     virtual RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        double d = static_cast<const RealDouble &>(x).i;
+        double d = down_cast<const RealDouble &>(x).i;
         if (d <= 1.0 and d >= -1.0) {
             return number(std::acos(d));
         } else {
@@ -172,7 +172,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
     virtual RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        double d = static_cast<const RealDouble &>(x).i;
+        double d = down_cast<const RealDouble &>(x).i;
         if (d >= 1.0 or d <= -1.0) {
             return number(std::asin(1.0 / d));
         } else {
@@ -182,7 +182,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
     virtual RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        double d = static_cast<const RealDouble &>(x).i;
+        double d = down_cast<const RealDouble &>(x).i;
         if (d >= 1.0 or d <= -1.0) {
             return number(std::acos(1.0 / d));
         } else {
@@ -192,7 +192,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
     virtual RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        double d = static_cast<const RealDouble &>(x).i;
+        double d = down_cast<const RealDouble &>(x).i;
         if (d >= 1.0) {
             return number(std::acosh(d));
         } else {
@@ -202,7 +202,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
     virtual RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        double d = static_cast<const RealDouble &>(x).i;
+        double d = down_cast<const RealDouble &>(x).i;
         if (d <= 1.0 and d >= -1.0) {
             return number(std::atanh(d));
         } else {
@@ -212,7 +212,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
     virtual RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        double d = static_cast<const RealDouble &>(x).i;
+        double d = down_cast<const RealDouble &>(x).i;
         if (d >= 1.0 or d <= -1.0) {
             return number(std::atanh(1.0 / d));
         } else {
@@ -222,7 +222,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
     virtual RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        double d = static_cast<const RealDouble &>(x).i;
+        double d = down_cast<const RealDouble &>(x).i;
         if (d >= 0.0) {
             return number(std::log(d));
         } else {
@@ -241,43 +241,42 @@ class EvaluateComplexDouble : public EvaluateDouble<ComplexDouble>
     virtual RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(std::asin(static_cast<const ComplexDouble &>(x).i));
+        return number(std::asin(down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(std::acos(static_cast<const ComplexDouble &>(x).i));
+        return number(std::acos(down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(1.0 / std::asin(static_cast<const ComplexDouble &>(x).i));
+        return number(1.0 / std::asin(down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(1.0 / std::acos(static_cast<const ComplexDouble &>(x).i));
+        return number(1.0 / std::acos(down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(std::acosh(static_cast<const ComplexDouble &>(x).i));
+        return number(std::acosh(down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(std::atanh(static_cast<const ComplexDouble &>(x).i));
+        return number(std::atanh(down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(
-            std::atanh(1.0 / static_cast<const ComplexDouble &>(x).i));
+        return number(std::atanh(1.0 / down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(std::log(static_cast<const ComplexDouble &>(x).i));
+        return number(std::log(down_cast<const ComplexDouble &>(x).i));
     }
 };
 

--- a/symengine/real_double.h
+++ b/symengine/real_double.h
@@ -111,13 +111,13 @@ public:
     virtual RCP<const Number> add(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return addreal(static_cast<const Rational &>(other));
+            return addreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return addreal(static_cast<const Integer &>(other));
+            return addreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return addreal(static_cast<const Complex &>(other));
+            return addreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return addreal(static_cast<const RealDouble &>(other));
+            return addreal(down_cast<const RealDouble &>(other));
         } else {
             return other.add(*this);
         }
@@ -160,13 +160,13 @@ public:
     virtual RCP<const Number> sub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return subreal(static_cast<const Rational &>(other));
+            return subreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return subreal(static_cast<const Integer &>(other));
+            return subreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return subreal(static_cast<const Complex &>(other));
+            return subreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return subreal(static_cast<const RealDouble &>(other));
+            return subreal(down_cast<const RealDouble &>(other));
         } else {
             return other.rsub(*this);
         }
@@ -201,11 +201,11 @@ public:
     virtual RCP<const Number> rsub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rsubreal(static_cast<const Rational &>(other));
+            return rsubreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rsubreal(static_cast<const Integer &>(other));
+            return rsubreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rsubreal(static_cast<const Complex &>(other));
+            return rsubreal(down_cast<const Complex &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -248,13 +248,13 @@ public:
     virtual RCP<const Number> mul(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return mulreal(static_cast<const Rational &>(other));
+            return mulreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return mulreal(static_cast<const Integer &>(other));
+            return mulreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return mulreal(static_cast<const Complex &>(other));
+            return mulreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return mulreal(static_cast<const RealDouble &>(other));
+            return mulreal(down_cast<const RealDouble &>(other));
         } else {
             return other.mul(*this);
         }
@@ -297,13 +297,13 @@ public:
     virtual RCP<const Number> div(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return divreal(static_cast<const Rational &>(other));
+            return divreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return divreal(static_cast<const Integer &>(other));
+            return divreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return divreal(static_cast<const Complex &>(other));
+            return divreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return divreal(static_cast<const RealDouble &>(other));
+            return divreal(down_cast<const RealDouble &>(other));
         } else {
             return other.rdiv(*this);
         }
@@ -339,11 +339,11 @@ public:
     virtual RCP<const Number> rdiv(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rdivreal(static_cast<const Rational &>(other));
+            return rdivreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rdivreal(static_cast<const Integer &>(other));
+            return rdivreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rdivreal(static_cast<const Complex &>(other));
+            return rdivreal(down_cast<const Complex &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -393,13 +393,13 @@ public:
     virtual RCP<const Number> pow(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return powreal(static_cast<const Rational &>(other));
+            return powreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return powreal(static_cast<const Integer &>(other));
+            return powreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return powreal(static_cast<const Complex &>(other));
+            return powreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return powreal(static_cast<const RealDouble &>(other));
+            return powreal(down_cast<const RealDouble &>(other));
         } else {
             return other.rpow(*this);
         }
@@ -441,11 +441,11 @@ public:
     virtual RCP<const Number> rpow(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rpowreal(static_cast<const Rational &>(other));
+            return rpowreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rpowreal(static_cast<const Integer &>(other));
+            return rpowreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rpowreal(static_cast<const Complex &>(other));
+            return rpowreal(down_cast<const Complex &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }

--- a/symengine/real_mpfr.cpp
+++ b/symengine/real_mpfr.cpp
@@ -32,7 +32,7 @@ void hash_combine_impl(hash_t &seed, mpfr_srcptr s)
 bool RealMPFR::__eq__(const Basic &o) const
 {
     if (is_a<RealMPFR>(o)) {
-        const RealMPFR &s = static_cast<const RealMPFR &>(o);
+        const RealMPFR &s = down_cast<const RealMPFR &>(o);
         if (get_prec() == s.get_prec()) {
             return mpfr_cmp(this->i.get_mpfr_t(), s.i.get_mpfr_t()) == 0;
         }
@@ -43,7 +43,7 @@ bool RealMPFR::__eq__(const Basic &o) const
 int RealMPFR::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<RealMPFR>(o))
-    const RealMPFR &s = static_cast<const RealMPFR &>(o);
+    const RealMPFR &s = down_cast<const RealMPFR &>(o);
     if (get_prec() == s.get_prec()) {
         int cmp = mpfr_cmp(this->i.get_mpfr_t(), s.i.get_mpfr_t());
         if (cmp == 0)
@@ -680,55 +680,55 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> sin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_sin(t.get_mpfr_t(),
-                 static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_sin(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> cos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_cos(t.get_mpfr_t(),
-                 static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_cos(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> tan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_tan(t.get_mpfr_t(),
-                 static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_tan(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> cot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_cot(t.get_mpfr_t(),
-                 static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_cot(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> sec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_sec(t.get_mpfr_t(),
-                 static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_sec(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> csc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_csc(t.get_mpfr_t(),
-                 static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_csc(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) <= 0 and mpfr_cmp_si(x_, -1) >= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_asin(t.get_mpfr_t(), x_, MPFR_RNDN);
@@ -747,7 +747,7 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) <= 0 and mpfr_cmp_si(x_, -1) >= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_acos(t.get_mpfr_t(), x_, MPFR_RNDN);
@@ -766,24 +766,24 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> atan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_atan(t.get_mpfr_t(),
-                  static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_atan(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> acot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
         mpfr_ui_div(t.get_mpfr_t(), 1,
-                    static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+                    down_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
         mpfr_atan(t.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) >= 0 or mpfr_cmp_si(x_, -1) <= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_ui_div(t.get_mpfr_t(), 1, x_, MPFR_RNDN);
@@ -804,7 +804,7 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) >= 0 or mpfr_cmp_si(x_, -1) <= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_ui_div(t.get_mpfr_t(), 1, x_, MPFR_RNDN);
@@ -825,63 +825,63 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> sinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_sinh(t.get_mpfr_t(),
-                  static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_sinh(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> csch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_csch(t.get_mpfr_t(),
-                  static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_csch(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> cosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_cosh(t.get_mpfr_t(),
-                  static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_cosh(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> sech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_sech(t.get_mpfr_t(),
-                  static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_sech(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> tanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_tanh(t.get_mpfr_t(),
-                  static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_tanh(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> coth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_coth(t.get_mpfr_t(),
-                  static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_coth(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> asinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
         mpfr_asinh(t.get_mpfr_t(),
-                   static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+                   down_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> acsch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         mpfr_class t(mpfr_get_prec(x_));
         mpfr_ui_div(t.get_mpfr_t(), 1, t.get_mpfr_t(), MPFR_RNDN);
         mpfr_asinh(t.get_mpfr_t(), x_, MPFR_RNDN);
@@ -890,7 +890,7 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) >= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_acosh(t.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
@@ -909,7 +909,7 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) <= 0 and mpfr_cmp_si(x_, -1) >= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_atanh(t.get_mpfr_t(), x_, MPFR_RNDN);
@@ -928,7 +928,7 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) >= 0 or mpfr_cmp_si(x_, -1) <= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_ui_div(t.get_mpfr_t(), 1, t.get_mpfr_t(), MPFR_RNDN);
@@ -949,7 +949,7 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 0) >= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_log(t.get_mpfr_t(), x_, MPFR_RNDN);
@@ -968,16 +968,16 @@ class EvaluateMPFR : public Evaluate
     virtual RCP<const Basic> abs(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_class t(static_cast<const RealMPFR &>(x).i.get_prec());
-        mpfr_abs(t.get_mpfr_t(),
-                 static_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
+        mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
+        mpfr_abs(t.get_mpfr_t(), down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
 
     virtual RCP<const Basic> gamma(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
-        mpfr_srcptr x_ = static_cast<const RealMPFR &>(x).i.get_mpfr_t();
+        mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 0) >= 0) {
             mpfr_class t(mpfr_get_prec(x_));
             mpfr_gamma(t.get_mpfr_t(), x_, MPFR_RNDN);

--- a/symengine/real_mpfr.h
+++ b/symengine/real_mpfr.h
@@ -156,17 +156,17 @@ public:
     virtual RCP<const Number> add(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return addreal(static_cast<const Rational &>(other));
+            return addreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return addreal(static_cast<const Integer &>(other));
+            return addreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return addreal(static_cast<const Complex &>(other));
+            return addreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return addreal(static_cast<const RealDouble &>(other));
+            return addreal(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return addreal(static_cast<const ComplexDouble &>(other));
+            return addreal(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return addreal(static_cast<const RealMPFR &>(other));
+            return addreal(down_cast<const RealMPFR &>(other));
         } else {
             return other.add(*this);
         }
@@ -183,17 +183,17 @@ public:
     virtual RCP<const Number> sub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return subreal(static_cast<const Rational &>(other));
+            return subreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return subreal(static_cast<const Integer &>(other));
+            return subreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return subreal(static_cast<const Complex &>(other));
+            return subreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return subreal(static_cast<const RealDouble &>(other));
+            return subreal(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return subreal(static_cast<const ComplexDouble &>(other));
+            return subreal(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return subreal(static_cast<const RealMPFR &>(other));
+            return subreal(down_cast<const RealMPFR &>(other));
         } else {
             return other.rsub(*this);
         }
@@ -209,15 +209,15 @@ public:
     virtual RCP<const Number> rsub(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rsubreal(static_cast<const Rational &>(other));
+            return rsubreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rsubreal(static_cast<const Integer &>(other));
+            return rsubreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rsubreal(static_cast<const Complex &>(other));
+            return rsubreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rsubreal(static_cast<const RealDouble &>(other));
+            return rsubreal(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return rsubreal(static_cast<const ComplexDouble &>(other));
+            return rsubreal(down_cast<const ComplexDouble &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -234,17 +234,17 @@ public:
     virtual RCP<const Number> mul(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return mulreal(static_cast<const Rational &>(other));
+            return mulreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return mulreal(static_cast<const Integer &>(other));
+            return mulreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return mulreal(static_cast<const Complex &>(other));
+            return mulreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return mulreal(static_cast<const RealDouble &>(other));
+            return mulreal(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return mulreal(static_cast<const ComplexDouble &>(other));
+            return mulreal(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return mulreal(static_cast<const RealMPFR &>(other));
+            return mulreal(down_cast<const RealMPFR &>(other));
         } else {
             return other.mul(*this);
         }
@@ -261,17 +261,17 @@ public:
     virtual RCP<const Number> div(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return divreal(static_cast<const Rational &>(other));
+            return divreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return divreal(static_cast<const Integer &>(other));
+            return divreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return divreal(static_cast<const Complex &>(other));
+            return divreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return divreal(static_cast<const RealDouble &>(other));
+            return divreal(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return divreal(static_cast<const ComplexDouble &>(other));
+            return divreal(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return divreal(static_cast<const RealMPFR &>(other));
+            return divreal(down_cast<const RealMPFR &>(other));
         } else {
             return other.rdiv(*this);
         }
@@ -287,15 +287,15 @@ public:
     virtual RCP<const Number> rdiv(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rdivreal(static_cast<const Rational &>(other));
+            return rdivreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rdivreal(static_cast<const Integer &>(other));
+            return rdivreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rdivreal(static_cast<const Complex &>(other));
+            return rdivreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rdivreal(static_cast<const RealDouble &>(other));
+            return rdivreal(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return rdivreal(static_cast<const ComplexDouble &>(other));
+            return rdivreal(down_cast<const ComplexDouble &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }
@@ -312,17 +312,17 @@ public:
     virtual RCP<const Number> pow(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return powreal(static_cast<const Rational &>(other));
+            return powreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return powreal(static_cast<const Integer &>(other));
+            return powreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return powreal(static_cast<const Complex &>(other));
+            return powreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return powreal(static_cast<const RealDouble &>(other));
+            return powreal(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return powreal(static_cast<const ComplexDouble &>(other));
+            return powreal(down_cast<const ComplexDouble &>(other));
         } else if (is_a<RealMPFR>(other)) {
-            return powreal(static_cast<const RealMPFR &>(other));
+            return powreal(down_cast<const RealMPFR &>(other));
         } else {
             return other.rpow(*this);
         }
@@ -338,15 +338,15 @@ public:
     virtual RCP<const Number> rpow(const Number &other) const
     {
         if (is_a<Rational>(other)) {
-            return rpowreal(static_cast<const Rational &>(other));
+            return rpowreal(down_cast<const Rational &>(other));
         } else if (is_a<Integer>(other)) {
-            return rpowreal(static_cast<const Integer &>(other));
+            return rpowreal(down_cast<const Integer &>(other));
         } else if (is_a<Complex>(other)) {
-            return rpowreal(static_cast<const Complex &>(other));
+            return rpowreal(down_cast<const Complex &>(other));
         } else if (is_a<RealDouble>(other)) {
-            return rpowreal(static_cast<const RealDouble &>(other));
+            return rpowreal(down_cast<const RealDouble &>(other));
         } else if (is_a<ComplexDouble>(other)) {
-            return rpowreal(static_cast<const ComplexDouble &>(other));
+            return rpowreal(down_cast<const ComplexDouble &>(other));
         } else {
             throw NotImplementedError("Not Implemented");
         }

--- a/symengine/series.h
+++ b/symengine/series.h
@@ -79,15 +79,15 @@ public:
 
     inline virtual bool __eq__(const Basic &o) const
     {
-        return (is_a<Series>(o) and var_ == static_cast<const Series &>(o).var_
-                and p_ == static_cast<const Series &>(o).p_
-                and degree_ == static_cast<const Series &>(o).degree_);
+        return (is_a<Series>(o) and var_ == down_cast<const Series &>(o).var_
+                and p_ == down_cast<const Series &>(o).p_
+                and degree_ == down_cast<const Series &>(o).degree_);
     }
 
     virtual RCP<const Number> add(const Number &other) const
     {
         if (is_a<Series>(other)) {
-            const Series &o = static_cast<const Series &>(other);
+            const Series &o = down_cast<const Series &>(other);
             long deg = std::min(degree_, o.degree_);
             if (var_ != o.var_) {
                 throw NotImplementedError(
@@ -105,7 +105,7 @@ public:
     virtual RCP<const Number> mul(const Number &other) const
     {
         if (is_a<Series>(other)) {
-            const Series &o = static_cast<const Series &>(other);
+            const Series &o = down_cast<const Series &>(other);
             long deg = std::min(degree_, o.degree_);
             if (var_ != o.var_) {
                 throw NotImplementedError(
@@ -125,7 +125,7 @@ public:
         long deg = degree_;
         Poly p;
         if (is_a<Series>(other)) {
-            const Series &o = static_cast<const Series &>(other);
+            const Series &o = down_cast<const Series &>(other);
             deg = std::min(deg, o.degree_);
             if (var_ != o.var_) {
                 throw NotImplementedError(
@@ -135,12 +135,12 @@ public:
         } else if (is_a<Integer>(other)) {
             if (other.is_negative()) {
                 p = Series::pow(
-                    p_, (static_cast<const Integer &>(other).neg()->as_int()),
+                    p_, (down_cast<const Integer &>(other).neg()->as_int()),
                     deg);
                 p = Series::series_invert(p, Series::var(var_), deg);
                 return make_rcp<Series>(p, var_, deg);
             }
-            p = Series::pow(p_, (static_cast<const Integer &>(other).as_int()),
+            p = Series::pow(p_, (down_cast<const Integer &>(other).as_int()),
                             deg);
             return make_rcp<Series>(p, var_, deg);
         } else if (other.get_type_code() < Series::type_code_id) {

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -83,7 +83,7 @@ RCP<const Basic> URatPSeriesFlint::get_coeff(int n) const
 int URatPSeriesFlint::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<URatPSeriesFlint>(o))
-    const URatPSeriesFlint &s = static_cast<const URatPSeriesFlint &>(o);
+    const URatPSeriesFlint &s = down_cast<const URatPSeriesFlint &>(o);
     if (var_ != s.var_)
         return (var_ < s.var_) ? -1 : 1;
     if (degree_ != s.degree_)

--- a/symengine/series_generic.cpp
+++ b/symengine/series_generic.cpp
@@ -35,7 +35,7 @@ hash_t UnivariateSeries::__hash__() const
 int UnivariateSeries::compare(const Basic &other) const
 {
     SYMENGINE_ASSERT(is_a<UnivariateSeries>(other))
-    const UnivariateSeries &o_ = static_cast<const UnivariateSeries &>(other);
+    const UnivariateSeries &o_ = down_cast<const UnivariateSeries &>(other);
     return p_.compare(o_.get_poly());
 }
 

--- a/symengine/series_piranha.cpp
+++ b/symengine/series_piranha.cpp
@@ -153,7 +153,7 @@ piranha::rational URatPSeriesPiranha::root(piranha::rational &c, unsigned n)
         res = cterm->nth_root(outArg(cout), n);
         if (not res)
             throw SymEngineException("constant term is not an nth power");
-        return convert(static_cast<const Rational &>(*cout).i);
+        return convert(down_cast<const Rational &>(*cout).i);
     }
 }
 

--- a/symengine/series_piranha.cpp
+++ b/symengine/series_piranha.cpp
@@ -29,7 +29,7 @@ hash_t URatPSeriesPiranha::__hash__() const
 int URatPSeriesPiranha::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<URatPSeriesPiranha>(o))
-    const URatPSeriesPiranha &s = static_cast<const URatPSeriesPiranha &>(o);
+    const URatPSeriesPiranha &s = down_cast<const URatPSeriesPiranha &>(o);
     if (var_ != s.var_)
         return (var_ < s.var_) ? -1 : 1;
     if (degree_ != s.degree_)
@@ -203,7 +203,7 @@ hash_t UPSeriesPiranha::__hash__() const
 int UPSeriesPiranha::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<UPSeriesPiranha>(o))
-    const UPSeriesPiranha &s = static_cast<const UPSeriesPiranha &>(o);
+    const UPSeriesPiranha &s = down_cast<const UPSeriesPiranha &>(o);
     if (var_ != s.var_)
         return (var_ < s.var_) ? -1 : 1;
     if (degree_ != s.degree_)

--- a/symengine/series_visitor.h
+++ b/symengine/series_visitor.h
@@ -53,7 +53,7 @@ public:
     {
         const RCP<const Basic> &base = x.get_base(), exp = x.get_exp();
         if (is_a<Integer>(*exp)) {
-            const Integer &ii = (static_cast<const Integer &>(*exp));
+            const Integer &ii = (down_cast<const Integer &>(*exp));
             if (not mp_fits_slong_p(ii.i))
                 throw SymEngineException("series power exponent size");
             const int sh = mp_get_si(ii.i);
@@ -72,7 +72,7 @@ public:
             }
 
         } else if (is_a<Rational>(*exp)) {
-            const Rational &rat = (static_cast<const Rational &>(*exp));
+            const Rational &rat = (down_cast<const Rational &>(*exp));
             const integer_class &expnumz = get_num(rat.i);
             const integer_class &expdenz = get_den(rat.i);
             if (not mp_fits_slong_p(expnumz) or not mp_fits_slong_p(expdenz))
@@ -134,13 +134,13 @@ public:
         if (eq(*arg->subs({{s, zero}}), *zero)) {
             RCP<const Basic> g = gamma(add(arg, one));
             if (is_a<Gamma>(*g)) {
-                bvisit(static_cast<const Function &>(*g));
+                bvisit(down_cast<const Function &>(*g));
                 p *= Series::pow(var, -1, prec);
             } else {
                 g->accept(*this);
             }
         } else {
-            bvisit(static_cast<const Function &>(x));
+            bvisit(implicit_cast<const Function &>(x));
         }
     }
 
@@ -324,7 +324,7 @@ public:
         // exp(const) or x^-1
         if ((base->__eq__(*E) and exp->subs(subsx0)->__neq__(*integer(0)))
             or (is_a_Number(*exp)
-                and static_cast<const Number &>(*exp).is_negative()
+                and down_cast<const Number &>(*exp).is_negative()
                 and base->subs(subsx0)->__eq__(*integer(0)))) {
             needs_ = true;
             stop_ = true;

--- a/symengine/sets.cpp
+++ b/symengine/sets.cpp
@@ -1,4 +1,5 @@
 #include <symengine/logic.h>
+#include <symengine/symengine_casts.h>
 #include <iterator>
 
 namespace SymEngine
@@ -39,7 +40,7 @@ hash_t Interval::__hash__() const
 bool Interval::__eq__(const Basic &o) const
 {
     if (is_a<Interval>(o)) {
-        const Interval &s = static_cast<const Interval &>(o);
+        const Interval &s = down_cast<const Interval &>(o);
         return ((this->left_open_ == s.left_open_)
                 and (this->right_open_ == s.right_open_)
                 and eq(*this->start_, *s.start_) and eq(*this->end_, *s.end_));
@@ -51,7 +52,7 @@ int Interval::compare(const Basic &s) const
 {
     // compares two interval based on their length
     SYMENGINE_ASSERT(is_a<Interval>(s))
-    const Interval &o = static_cast<const Interval &>(s);
+    const Interval &o = down_cast<const Interval &>(s);
     if (left_open_ and not o.left_open_) {
         return -1;
     } else if (not left_open_ and o.left_open_) {
@@ -106,7 +107,7 @@ RCP<const Boolean> Interval::contains(const RCP<const Basic> &a) const
 RCP<const Set> Interval::set_intersection(const RCP<const Set> &o) const
 {
     if (is_a<Interval>(*o)) {
-        const Interval &other = static_cast<const Interval &>(*o);
+        const Interval &other = down_cast<const Interval &>(*o);
         RCP<const Number> start, end;
         bool left_open, right_open;
         RCP<const Basic> start_end, end_start;
@@ -157,7 +158,7 @@ RCP<const Set> Interval::set_intersection(const RCP<const Set> &o) const
 RCP<const Set> Interval::set_union(const RCP<const Set> &o) const
 {
     if (is_a<Interval>(*o)) {
-        const Interval &other = static_cast<const Interval &>(*o);
+        const Interval &other = down_cast<const Interval &>(*o);
         RCP<const Basic> start_start, end_end, m;
         RCP<const Number> start, end;
         bool left_open, right_open;
@@ -289,7 +290,7 @@ hash_t FiniteSet::__hash__() const
 bool FiniteSet::__eq__(const Basic &o) const
 {
     if (is_a<FiniteSet>(o)) {
-        const FiniteSet &other = static_cast<const FiniteSet &>(o);
+        const FiniteSet &other = down_cast<const FiniteSet &>(o);
         return unified_eq(container_, other.container_);
     }
     return false;
@@ -299,7 +300,7 @@ int FiniteSet::compare(const Basic &o) const
 {
     // compares two FiniteSet based on their length
     SYMENGINE_ASSERT(is_a<FiniteSet>(o))
-    const FiniteSet &other = static_cast<const FiniteSet &>(o);
+    const FiniteSet &other = down_cast<const FiniteSet &>(o);
     return unified_compare(container_, other.container_);
 }
 
@@ -311,7 +312,7 @@ RCP<const Boolean> FiniteSet::contains(const RCP<const Basic> &a) const
 RCP<const Set> FiniteSet::set_union(const RCP<const Set> &o) const
 {
     if (is_a<FiniteSet>(*o)) {
-        const FiniteSet &other = static_cast<const FiniteSet &>(*o);
+        const FiniteSet &other = down_cast<const FiniteSet &>(*o);
         set_basic container;
         std::set_union(container_.begin(), container_.end(),
                        other.container_.begin(), other.container_.end(),
@@ -321,7 +322,7 @@ RCP<const Set> FiniteSet::set_union(const RCP<const Set> &o) const
     }
     if (is_a<Interval>(*o)) {
         set_basic container;
-        const Interval &other = static_cast<const Interval &>(*o);
+        const Interval &other = down_cast<const Interval &>(*o);
         bool left = other.left_open_, right = other.right_open_;
         for (const auto &a : container_) {
             auto contain = o->contains(a);
@@ -365,7 +366,7 @@ RCP<const Set> FiniteSet::set_union(const RCP<const Set> &o) const
 RCP<const Set> FiniteSet::set_intersection(const RCP<const Set> &o) const
 {
     if (is_a<FiniteSet>(*o)) {
-        const FiniteSet &other = static_cast<const FiniteSet &>(*o);
+        const FiniteSet &other = down_cast<const FiniteSet &>(*o);
         set_basic container;
         std::set_intersection(container_.begin(), container_.end(),
                               other.container_.begin(), other.container_.end(),
@@ -405,7 +406,7 @@ hash_t Union::__hash__() const
 bool Union::__eq__(const Basic &o) const
 {
     if (is_a<Union>(o)) {
-        const Union &other = static_cast<const Union &>(o);
+        const Union &other = down_cast<const Union &>(o);
         return unified_eq(container_, other.container_);
     }
     return false;
@@ -414,7 +415,7 @@ bool Union::__eq__(const Basic &o) const
 int Union::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Union>(o))
-    const Union &other = static_cast<const Union &>(o);
+    const Union &other = down_cast<const Union &>(o);
     return unified_compare(container_, other.container_);
 }
 

--- a/symengine/sets.h
+++ b/symengine/sets.h
@@ -7,6 +7,7 @@
 
 #include <symengine/functions.h>
 #include <symengine/complex.h>
+#include <symengine/symengine_casts.h>
 #include <iterator>
 namespace SymEngine
 {
@@ -220,7 +221,7 @@ inline RCP<const Set> set_union(const set_set &in, bool solve = true)
     set_basic combined_FiniteSet;
     for (auto it = in.begin(); it != in.end(); ++it) {
         if (is_a<FiniteSet>(**it)) {
-            const FiniteSet &other = static_cast<const FiniteSet &>(**it);
+            const FiniteSet &other = down_cast<const FiniteSet &>(**it);
             combined_FiniteSet.insert(other.container_.begin(),
                                       other.container_.end());
         } else if (is_a<UniversalSet>(**it)) {

--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -31,7 +31,7 @@ bool CSRMatrix::eq(const MatrixBase &other) const
         return false;
 
     if (is_a<CSRMatrix>(other)) {
-        const CSRMatrix &o = static_cast<const CSRMatrix &>(other);
+        const CSRMatrix &o = down_cast<const CSRMatrix &>(other);
 
         if (this->p_[row] != o.p_[row])
             return false;

--- a/symengine/subs.h
+++ b/symengine/subs.h
@@ -220,10 +220,10 @@ public:
         }
         RCP<const Basic> presub = x.get_arg()->subs(n);
         if (is_a<Subs>(*presub)) {
-            for (auto &q : static_cast<const Subs &>(*presub).get_dict()) {
+            for (auto &q : down_cast<const Subs &>(*presub).get_dict()) {
                 insert(m, q.first, q.second);
             }
-            result_ = static_cast<const Subs &>(*presub).get_arg()->subs(m);
+            result_ = down_cast<const Subs &>(*presub).get_arg()->subs(m);
         } else {
             result_ = presub->subs(m);
         }

--- a/symengine/symbol.cpp
+++ b/symengine/symbol.cpp
@@ -1,4 +1,5 @@
 #include <symengine/constants.h>
+#include <symengine/symengine_casts.h>
 
 namespace SymEngine
 {
@@ -17,14 +18,14 @@ hash_t Symbol::__hash__() const
 bool Symbol::__eq__(const Basic &o) const
 {
     if (is_a<Symbol>(o))
-        return name_ == static_cast<const Symbol &>(o).name_;
+        return name_ == down_cast<const Symbol &>(o).name_;
     return false;
 }
 
 int Symbol::compare(const Basic &o) const
 {
     SYMENGINE_ASSERT(is_a<Symbol>(o))
-    const Symbol &s = static_cast<const Symbol &>(o);
+    const Symbol &s = down_cast<const Symbol &>(o);
     if (name_ == s.name_)
         return 0;
     return name_ < s.name_ ? -1 : 1;

--- a/symengine/symengine_casts.h
+++ b/symengine/symengine_casts.h
@@ -54,7 +54,7 @@ template<typename T> struct remove_reference<T&> { typedef T type; };
 //   implicit_cast<ToType>(expr)
 
 template <typename To, typename From>
-inline To implicit_cast(const From &f){
+inline To implicit_cast(const From &f) {
     return f;
 }
 
@@ -77,7 +77,7 @@ inline To implicit_cast(const From &f){
 // You should design the code some other way not to need this.
 
 template <typename To, typename From>	 // use like this: down_cast<T*>(foo).
-inline To down_cast(From* f){				// only accept pointers.
+inline To down_cast(From* f) {				// only accept pointers.
     // Ensures that To is a sub-type of From *.  This test is here only
     // for compile-time type checking, and has no overhead in an
     // optimized build at run-time, as it will be optimized away
@@ -86,9 +86,8 @@ inline To down_cast(From* f){				// only accept pointers.
         implicit_cast<From*, To>(0);
     }
 
-#if defined(TEUCHOS_DEBUG) 
     SYMENGINE_ASSERT(f == NULL || dynamic_cast<To>(f) != NULL);  // debug mode only!
-#endif
+    
     return static_cast<To>(f);
 }
 
@@ -103,9 +102,8 @@ inline To down_cast(From& f) {
         implicit_cast<From*, ToAsPointer>(0);
     }
 
-#if defined(TEUCHOS_DEBUG) 
     SYMENGINE_ASSERT(dynamic_cast<ToAsPointer>(&f) != NULL); // debug mode only!
-#endif
+
     return *static_cast<ToAsPointer>(&f);
 }
 

--- a/symengine/symengine_casts.h
+++ b/symengine/symengine_casts.h
@@ -1,33 +1,3 @@
-// Protocol Buffers - Google's data interchange format
-// Copyright 2014 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 #ifndef SYMENGINE_CASTS_H
 #define SYMENGINE_CASTS_H
 

--- a/symengine/symengine_casts.h
+++ b/symengine/symengine_casts.h
@@ -1,0 +1,114 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2014 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef SYMENGINE_CASTS_H
+#define SYMENGINE_CASTS_H
+
+#include <symengine/symengine_assert.h>
+
+namespace SymEngine {
+
+// Reference modifications.
+template<typename T> struct remove_reference { typedef T type; };
+template<typename T> struct remove_reference<T&> { typedef T type; };
+
+// Use implicit_cast as a safe version of static_cast or const_cast
+// for upcasting in the type hierarchy (i.e. casting a pointer to Foo
+// to a pointer to SuperclassOfFoo or casting a pointer to Foo to
+// a const pointer to Foo).
+// When you use implicit_cast, the compiler checks that the cast is safe.
+// Such explicit implicit_casts are necessary in surprisingly many
+// situations where C++ demands an exact type match instead of an
+// argument type convertable to a target type.
+//
+// The From type can be inferred, so the preferred syntax for using
+// implicit_cast is the same as for static_cast etc.:
+//
+//   implicit_cast<ToType>(expr)
+
+template <typename To, typename From>
+inline To implicit_cast(const From &f){
+    return f;
+}
+
+// When you upcast (that is, cast a pointer from type Foo to type
+// SuperclassOfFoo), it's fine to use implicit_cast<>, since upcasts
+// always succeed.  When you downcast (that is, cast a pointer from
+// type Foo to type SubclassOfFoo), static_cast<> isn't safe, because
+// how do you know the pointer is really of type SubclassOfFoo?  It
+// could be a bare Foo, or of type DifferentSubclassOfFoo.  Thus,
+// when you downcast, you should use this macro.  In debug mode, we
+// use dynamic_cast<> to double-check the downcast is legal (we die
+// if it's not).  In normal mode, we do the efficient static_cast<>
+// instead.  Thus, it's important to test in debug mode to make sure
+// the cast is legal!
+//    This is the only place in the code we should use dynamic_cast<>.
+// In particular, you SHOULDN'T be using dynamic_cast<> in order to
+// do RTTI (eg code like this:
+//    if (dynamic_cast<Subclass1>(foo)) HandleASubclass1Object(foo);
+//    if (dynamic_cast<Subclass2>(foo)) HandleASubclass2Object(foo);
+// You should design the code some other way not to need this.
+
+template <typename To, typename From>	 // use like this: down_cast<T*>(foo).
+inline To down_cast(From* f){				// only accept pointers.
+    // Ensures that To is a sub-type of From *.  This test is here only
+    // for compile-time type checking, and has no overhead in an
+    // optimized build at run-time, as it will be optimized away
+    // completely.
+    if (false) {
+        implicit_cast<From*, To>(0);
+    }
+
+#if defined(TEUCHOS_DEBUG) 
+    SYMENGINE_ASSERT(f == NULL || dynamic_cast<To>(f) != NULL);  // debug mode only!
+#endif
+    return static_cast<To>(f);
+}
+
+template<typename To, typename From>	// use like this: down_cast<T&>(foo);
+inline To down_cast(From& f) {
+    typedef typename remove_reference<To>::type* ToAsPointer;
+    // Ensures that To is a sub-type of From *.  This test is here only
+    // for compile-time type checking, and has no overhead in an
+    // optimized build at run-time, as it will be optimized away
+    // completely.
+    if (false) {
+        implicit_cast<From*, ToAsPointer>(0);
+    }
+
+#if defined(TEUCHOS_DEBUG) 
+    SYMENGINE_ASSERT(dynamic_cast<ToAsPointer>(&f) != NULL); // debug mode only!
+#endif
+    return *static_cast<ToAsPointer>(&f);
+}
+
+} // SymEngine
+
+#endif  // SYMENGINE_CASTS_H

--- a/symengine/symengine_casts.h
+++ b/symengine/symengine_casts.h
@@ -33,11 +33,18 @@
 
 #include <symengine/symengine_assert.h>
 
-namespace SymEngine {
+namespace SymEngine
+{
 
 // Reference modifications.
-template<typename T> struct remove_reference { typedef T type; };
-template<typename T> struct remove_reference<T&> { typedef T type; };
+template <typename T>
+struct remove_reference {
+    typedef T type;
+};
+template <typename T>
+struct remove_reference<T &> {
+    typedef T type;
+};
 
 // Use implicit_cast as a safe version of static_cast or const_cast
 // for upcasting in the type hierarchy (i.e. casting a pointer to Foo
@@ -54,7 +61,8 @@ template<typename T> struct remove_reference<T&> { typedef T type; };
 //   implicit_cast<ToType>(expr)
 
 template <typename To, typename From>
-inline To implicit_cast(const From &f) {
+inline To implicit_cast(const From &f)
+{
     return f;
 }
 
@@ -76,37 +84,39 @@ inline To implicit_cast(const From &f) {
 //    if (dynamic_cast<Subclass2>(foo)) HandleASubclass2Object(foo);
 // You should design the code some other way not to need this.
 
-template <typename To, typename From>	 // use like this: down_cast<T*>(foo).
-inline To down_cast(From* f) {				// only accept pointers.
+template <typename To, typename From> // use like this: down_cast<T*>(foo).
+inline To down_cast(From *f)          // only accept pointers.
+{
     // Ensures that To is a sub-type of From *.  This test is here only
     // for compile-time type checking, and has no overhead in an
     // optimized build at run-time, as it will be optimized away
     // completely.
     if (false) {
-        implicit_cast<From*, To>(0);
+        implicit_cast<From *, To>(0);
     }
 
-    SYMENGINE_ASSERT(f == NULL || dynamic_cast<To>(f) != NULL);  // debug mode only!
-    
+    SYMENGINE_ASSERT(f == NULL || dynamic_cast<To>(f) != NULL);
+
     return static_cast<To>(f);
 }
 
-template<typename To, typename From>	// use like this: down_cast<T&>(foo);
-inline To down_cast(From& f) {
-    typedef typename remove_reference<To>::type* ToAsPointer;
+template <typename To, typename From> // use like this: down_cast<T&>(foo);
+inline To down_cast(From &f)
+{
+    typedef typename remove_reference<To>::type *ToAsPointer;
     // Ensures that To is a sub-type of From *.  This test is here only
     // for compile-time type checking, and has no overhead in an
     // optimized build at run-time, as it will be optimized away
     // completely.
     if (false) {
-        implicit_cast<From*, ToAsPointer>(0);
+        implicit_cast<From *, ToAsPointer>(0);
     }
 
-    SYMENGINE_ASSERT(dynamic_cast<ToAsPointer>(&f) != NULL); // debug mode only!
+    SYMENGINE_ASSERT(dynamic_cast<ToAsPointer>(&f) != NULL);
 
     return *static_cast<ToAsPointer>(&f);
 }
 
 } // SymEngine
 
-#endif  // SYMENGINE_CASTS_H
+#endif // SYMENGINE_CASTS_H

--- a/symengine/symengine_casts.h
+++ b/symengine/symengine_casts.h
@@ -55,8 +55,9 @@ inline To implicit_cast(const From &f)
 // You should design the code some other way not to need this.
 
 template <typename To, typename From> // use like this: down_cast<T*>(foo).
-inline To down_cast(From *f)          // only accept pointers.
+inline To down_cast(From *f)
 {
+    // Only accept pointers.
     // Ensures that To is a sub-type of From *.  This test is here only
     // for compile-time type checking, and has no overhead in an
     // optimized build at run-time, as it will be optimized away

--- a/symengine/symengine_casts.h
+++ b/symengine/symengine_casts.h
@@ -55,9 +55,8 @@ inline To implicit_cast(const From &f)
 // You should design the code some other way not to need this.
 
 template <typename To, typename From> // use like this: down_cast<T*>(foo).
-inline To down_cast(From *f)
+inline To down_cast(From *f)          // Only accept pointers.
 {
-    // Only accept pointers.
     // Ensures that To is a sub-type of From *.  This test is here only
     // for compile-time type checking, and has no overhead in an
     // optimized build at run-time, as it will be optimized away

--- a/symengine/utilities/teuchos/Teuchos_RCP.hpp
+++ b/symengine/utilities/teuchos/Teuchos_RCP.hpp
@@ -733,6 +733,7 @@ Teuchos::rcp_static_cast(const RCP<T1>& p1)
 #endif
 }
 
+
 template<class T2, class T1>
 inline
 Teuchos::RCP<T2>

--- a/symengine/utilities/teuchos/Teuchos_RCP.hpp
+++ b/symengine/utilities/teuchos/Teuchos_RCP.hpp
@@ -733,7 +733,6 @@ Teuchos::rcp_static_cast(const RCP<T1>& p1)
 #endif
 }
 
-
 template<class T2, class T1>
 inline
 Teuchos::RCP<T2>

--- a/symengine/visitor.cpp
+++ b/symengine/visitor.cpp
@@ -63,7 +63,7 @@ RCP<const Basic> coeff(const Basic &b, const Basic &x, const Basic &n)
     if (!is_a<Symbol>(x)) {
         throw NotImplementedError("Not implemented for non Symbols.");
     }
-    CoeffVisitor v(ptrFromRef(static_cast<const Symbol &>(x)), ptrFromRef(n));
+    CoeffVisitor v(ptrFromRef(down_cast<const Symbol &>(x)), ptrFromRef(n));
     return v.apply(b);
 }
 

--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -21,6 +21,7 @@
 #include <symengine/fields.h>
 #include <symengine/logic.h>
 #include <symengine/infinity.h>
+#include <symengine/symengine_casts.h>
 
 namespace SymEngine
 {
@@ -63,7 +64,7 @@ public:
 #define SYMENGINE_ENUM(TypeID, Class)                                          \
     virtual void visit(const Class &x)                                         \
     {                                                                          \
-        static_cast<Derived *>(this)->bvisit(x);                               \
+        down_cast<Derived *>(this)->bvisit(x);                                 \
     };
 #include "symengine/type_codes.inc"
 #undef SYMENGINE_ENUM


### PR DESCRIPTION
This is a follow up for PR #746 by Abhimanyu Siwach. 
down_cast() has been used in place of static_cast() strictly in places where the arguments were of the type Basic or any of its derived classes. 
Please suggest any changes if required.