### PR TITLE
wrapped vecbasic_* calls in CWRAPPER

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -737,14 +737,22 @@ void vecbasic_free(CVecBasic *self)
     delete self;
 }
 
-void vecbasic_push_back(CVecBasic *self, const basic value)
+CWRAPPER_OUTPUT_TYPE vecbasic_push_back(CVecBasic *self, const basic value)
 {
+    CWRAPPER_BEGIN
+
     self->m.push_back(value->m);
+
+    CWRAPPER_END
 }
 
-void vecbasic_get(CVecBasic *self, int n, basic result)
+CWRAPPER_OUTPUT_TYPE vecbasic_get(CVecBasic *self, int n, basic result)
 {
+    CWRAPPER_BEGIN
+
     result->m = self->m[n];
+
+    CWRAPPER_END
 }
 
 size_t vecbasic_size(CVecBasic *self)

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -367,8 +367,8 @@ typedef struct CVecBasic CVecBasic;
 
 CVecBasic *vecbasic_new();
 void vecbasic_free(CVecBasic *self);
-void vecbasic_push_back(CVecBasic *self, const basic value);
-void vecbasic_get(CVecBasic *self, int n, basic result);
+CWRAPPER_OUTPUT_TYPE vecbasic_push_back(CVecBasic *self, const basic value);
+CWRAPPER_OUTPUT_TYPE vecbasic_get(CVecBasic *self, int n, basic result);
 size_t vecbasic_size(CVecBasic *self);
 
 //! Wrappers for Matrices


### PR DESCRIPTION
I've wrapped `vecbasic_push_back` and `vecbasic_get` with the `CWRAPPER` macros.