### PR TITLE
wrapped vecbasic_* calls in CWRAPPER

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -737,14 +737,23 @@ void vecbasic_free(CVecBasic *self)
     delete self;
 }
 
-void vecbasic_push_back(CVecBasic *self, const basic value)
+CWRAPPER_OUTPUT_TYPE vecbasic_push_back(CVecBasic *self, const basic value)
 {
+    CWRAPPER_BEGIN
+
     self->m.push_back(value->m);
+
+    CWRAPPER_END
 }
 
-void vecbasic_get(CVecBasic *self, int n, basic result)
+CWRAPPER_OUTPUT_TYPE vecbasic_get(CVecBasic *self, size_t n, basic result)
 {
+    CWRAPPER_BEGIN
+
+    assert(n < self->m.size());
     result->m = self->m[n];
+
+    CWRAPPER_END
 }
 
 size_t vecbasic_size(CVecBasic *self)

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -750,7 +750,7 @@ CWRAPPER_OUTPUT_TYPE vecbasic_get(CVecBasic *self, size_t n, basic result)
 {
     CWRAPPER_BEGIN
 
-    assert(n < self->m.size());
+    SYMENGINE_ASSERT(n < self->m.size());
     result->m = self->m[n];
 
     CWRAPPER_END

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -367,8 +367,8 @@ typedef struct CVecBasic CVecBasic;
 
 CVecBasic *vecbasic_new();
 void vecbasic_free(CVecBasic *self);
-void vecbasic_push_back(CVecBasic *self, const basic value);
-void vecbasic_get(CVecBasic *self, int n, basic result);
+CWRAPPER_OUTPUT_TYPE vecbasic_push_back(CVecBasic *self, const basic value);
+CWRAPPER_OUTPUT_TYPE vecbasic_get(CVecBasic *self, size_t n, basic result);
 size_t vecbasic_size(CVecBasic *self);
 
 //! Wrappers for Matrices


### PR DESCRIPTION
Fixed, this is from my fork.

I've wrapped `vecbasic_push_back` and `vecbasic_get` with the `CWRAPPER` macros.