### PR TITLE
Wrap ntheory_mod_f and ntheory_quotient_f in C.

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -1239,6 +1239,26 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient(basic s, const basic n, const basic d)
     CWRAPPER_END
 }
 
+CWRAPPER_OUTPUT_TYPE ntheory_mod_f(basic s, const basic n, const basic d)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
+    SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
+    s->m = SymEngine::mod_f(static_cast<const Integer &>(*(n->m)),
+                          static_cast<const Integer &>(*(d->m)));
+    CWRAPPER_END
+}
+
+CWRAPPER_OUTPUT_TYPE ntheory_quotient_f(basic s, const basic n, const basic d)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
+    SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
+    s->m = SymEngine::quotient_f(static_cast<const Integer &>(*(n->m)),
+                               static_cast<const Integer &>(*(d->m)));
+    CWRAPPER_END
+}
+
 CWRAPPER_OUTPUT_TYPE ntheory_fibonacci(basic s, unsigned long a)
 {
     CWRAPPER_BEGIN

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -1245,7 +1245,7 @@ CWRAPPER_OUTPUT_TYPE ntheory_mod_f(basic s, const basic n, const basic d)
     SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
     s->m = SymEngine::mod_f(static_cast<const Integer &>(*(n->m)),
-                          static_cast<const Integer &>(*(d->m)));
+                            static_cast<const Integer &>(*(d->m)));
     CWRAPPER_END
 }
 
@@ -1255,7 +1255,7 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient_f(basic s, const basic n, const basic d)
     SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
     s->m = SymEngine::quotient_f(static_cast<const Integer &>(*(n->m)),
-                               static_cast<const Integer &>(*(d->m)));
+                                 static_cast<const Integer &>(*(d->m)));
     CWRAPPER_END
 }
 

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -559,6 +559,10 @@ CWRAPPER_OUTPUT_TYPE ntheory_nextprime(basic s, const basic a);
 CWRAPPER_OUTPUT_TYPE ntheory_mod(basic s, const basic n, const basic d);
 //! \return quotient round toward zero when `n` is divided by `d`
 CWRAPPER_OUTPUT_TYPE ntheory_quotient(basic s, const basic n, const basic d);
+//! modulo round toward -inf
+CWRAPPER_OUTPUT_TYPE ntheory_mod_f(basic s, const basic n, const basic d);
+//! \return quotient round toward -inf when `n` is divided by `d`
+CWRAPPER_OUTPUT_TYPE ntheory_quotient_f(basic s, const basic n, const basic d);
 //! nth Fibonacci number //  fibonacci(0) = 0 and fibonacci(1) = 1
 CWRAPPER_OUTPUT_TYPE ntheory_fibonacci(basic s, unsigned long a);
 //! Lucas number

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -922,6 +922,8 @@ void test_ntheory()
     basic_new_stack(i2);
     basic_new_stack(i4);
     basic_new_stack(i5);
+    basic_new_stack(im2);
+    basic_new_stack(im7);
 
     integer_set_si(i1, 1);
     integer_set_si(i2, 2);
@@ -965,6 +967,8 @@ void test_ntheory()
     basic_free_stack(i2);
     basic_free_stack(i4);
     basic_free_stack(i5);
+    basic_free_stack(im2);
+    basic_free_stack(im7);
 }
 
 void test_eval()

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -916,7 +916,7 @@ void test_functions()
 
 void test_ntheory()
 {
-    basic x, i1, i2, i4, i5;
+    basic x, i1, i2, i4, i5, im2, im7;
     basic_new_stack(x);
     basic_new_stack(i1);
     basic_new_stack(i2);
@@ -927,6 +927,8 @@ void test_ntheory()
     integer_set_si(i2, 2);
     integer_set_si(i4, 4);
     integer_set_si(i5, 5);
+    integer_set_si(im2, -2);
+    integer_set_si(im7, -7);
 
     ntheory_gcd(x, i2, i4);
     SYMENGINE_C_ASSERT(basic_eq(x, i2));
@@ -942,6 +944,12 @@ void test_ntheory()
 
     ntheory_quotient(x, i5, i2);
     SYMENGINE_C_ASSERT(basic_eq(x, i2));
+
+    ntheory_mod_f(x, im7, i4);
+    SYMENGINE_C_ASSERT(basic_eq(x, i1));
+
+    ntheory_quotient_f(x, im7, i4);
+    SYMENGINE_C_ASSERT(basic_eq(x, im2));
 
     ntheory_fibonacci(x, 5);
     SYMENGINE_C_ASSERT(basic_eq(x, i5));


### PR DESCRIPTION
Add c wrapper code for `mod_f` and `quotient_f` function in `ntheory` module, as well as corresponding test cases. Fix issue #939.