### PR TITLE
Wrap more functions in ntheory.h.

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -1228,6 +1228,23 @@ CWRAPPER_OUTPUT_TYPE ntheory_lcm(basic s, const basic a, const basic b)
     CWRAPPER_END
 }
 
+CWRAPPER_OUTPUT_TYPE ntheory_gcd_ext(basic g, basic s, basic t, const basic a,
+                                     const basic b)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
+    SYMENGINE_ASSERT(is_a<Integer>(*(b->m)));
+    SymEngine::RCP<const Integer> g_, s_, t_;
+    SymEngine::gcd_ext(
+        SymEngine::outArg_Integer(g_), SymEngine::outArg_Integer(s_),
+        SymEngine::outArg_Integer(t_), static_cast<const Integer &>(*(a->m)),
+        static_cast<const Integer &>(*(b->m)));
+    g->m = g_;
+    s->m = s_;
+    t->m = t_;
+    CWRAPPER_END
+}
+
 CWRAPPER_OUTPUT_TYPE ntheory_nextprime(basic s, const basic a)
 {
     CWRAPPER_BEGIN
@@ -1256,6 +1273,22 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient(basic s, const basic n, const basic d)
     CWRAPPER_END
 }
 
+CWRAPPER_OUTPUT_TYPE ntheory_quotient_mod(basic q, basic r, const basic n,
+                                          const basic d)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
+    SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
+    SymEngine::RCP<const Integer> q_, r_;
+    SymEngine::quotient_mod(SymEngine::outArg_Integer(q_),
+                            SymEngine::outArg_Integer(r_),
+                            static_cast<const Integer &>(*(n->m)),
+                            static_cast<const Integer &>(*(d->m)));
+    q->m = q_;
+    r->m = r_;
+    CWRAPPER_END
+}
+
 CWRAPPER_OUTPUT_TYPE ntheory_mod_f(basic s, const basic n, const basic d)
 {
     CWRAPPER_BEGIN
@@ -1276,10 +1309,50 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient_f(basic s, const basic n, const basic d)
     CWRAPPER_END
 }
 
+CWRAPPER_OUTPUT_TYPE ntheory_quotient_mod_f(basic q, basic r, const basic n,
+                                            const basic d)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
+    SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
+    SymEngine::RCP<const Integer> q_, r_;
+    SymEngine::quotient_mod_f(SymEngine::outArg_Integer(q_),
+                              SymEngine::outArg_Integer(r_),
+                              static_cast<const Integer &>(*(n->m)),
+                              static_cast<const Integer &>(*(d->m)));
+    q->m = q_;
+    r->m = r_;
+    CWRAPPER_END
+}
+
+int ntheory_mod_inverse(basic b, const basic a, const basic m)
+{
+    int ret_val;
+    SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
+    SYMENGINE_ASSERT(is_a<Integer>(*(m->m)));
+    SymEngine::RCP<const Integer> b_;
+    ret_val = SymEngine::mod_inverse(SymEngine::outArg_Integer(b_),
+                                     static_cast<const Integer &>(*(a->m)),
+                                     static_cast<const Integer &>(*(m->m)));
+    b->m = b_;
+    return ret_val;
+}
+
 CWRAPPER_OUTPUT_TYPE ntheory_fibonacci(basic s, unsigned long a)
 {
     CWRAPPER_BEGIN
     s->m = SymEngine::fibonacci(a);
+    CWRAPPER_END
+}
+
+CWRAPPER_OUTPUT_TYPE ntheory_fibonacci2(basic g, basic s, unsigned long a)
+{
+    CWRAPPER_BEGIN
+    SymEngine::RCP<const Integer> g_, s_;
+    SymEngine::fibonacci2(SymEngine::outArg_Integer(g_),
+                          SymEngine::outArg_Integer(s_), a);
+    g->m = g_;
+    s->m = s_;
     CWRAPPER_END
 }
 
@@ -1290,11 +1363,29 @@ CWRAPPER_OUTPUT_TYPE ntheory_lucas(basic s, unsigned long a)
     CWRAPPER_END
 }
 
+CWRAPPER_OUTPUT_TYPE ntheory_lucas2(basic g, basic s, unsigned long a)
+{
+    CWRAPPER_BEGIN
+    SymEngine::RCP<const Integer> g_, s_;
+    SymEngine::lucas2(SymEngine::outArg_Integer(g_),
+                      SymEngine::outArg_Integer(s_), a);
+    g->m = g_;
+    s->m = s_;
+    CWRAPPER_END
+}
+
 CWRAPPER_OUTPUT_TYPE ntheory_binomial(basic s, const basic a, unsigned long b)
 {
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
     s->m = SymEngine::binomial(static_cast<const Integer &>(*(a->m)), b);
+    CWRAPPER_END
+}
+
+CWRAPPER_OUTPUT_TYPE ntheory_factorial(basic s, unsigned long n)
+{
+    CWRAPPER_BEGIN
+    s->m = SymEngine::factorial(n);
     CWRAPPER_END
 }
 

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -55,14 +55,6 @@ inline bool is_aligned(T *p, size_t n = alignof(T))
 {
     return 0 == reinterpret_cast<uintptr_t>(p) % n;
 }
-
-// Make a value with type Ptr<RCP<const Integer>>, which is commonly used in
-// ntheory.h.
-inline SymEngine::Ptr<RCP<const Integer>>
-outArg_Integer(RCP<const Integer> &arg)
-{
-    return SymEngine::outArg<RCP<const Integer>>(arg);
-}
 }
 
 extern "C" {
@@ -1235,10 +1227,10 @@ CWRAPPER_OUTPUT_TYPE ntheory_gcd_ext(basic g, basic s, basic t, const basic a,
     SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(b->m)));
     SymEngine::RCP<const Integer> g_, s_, t_;
-    SymEngine::gcd_ext(
-        SymEngine::outArg_Integer(g_), SymEngine::outArg_Integer(s_),
-        SymEngine::outArg_Integer(t_), static_cast<const Integer &>(*(a->m)),
-        static_cast<const Integer &>(*(b->m)));
+    SymEngine::gcd_ext(SymEngine::outArg(g_), SymEngine::outArg(s_),
+                       SymEngine::outArg(t_),
+                       static_cast<const Integer &>(*(a->m)),
+                       static_cast<const Integer &>(*(b->m)));
     g->m = g_;
     s->m = s_;
     t->m = t_;
@@ -1280,8 +1272,7 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient_mod(basic q, basic r, const basic n,
     SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
     SymEngine::RCP<const Integer> q_, r_;
-    SymEngine::quotient_mod(SymEngine::outArg_Integer(q_),
-                            SymEngine::outArg_Integer(r_),
+    SymEngine::quotient_mod(SymEngine::outArg(q_), SymEngine::outArg(r_),
                             static_cast<const Integer &>(*(n->m)),
                             static_cast<const Integer &>(*(d->m)));
     q->m = q_;
@@ -1316,8 +1307,7 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient_mod_f(basic q, basic r, const basic n,
     SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
     SymEngine::RCP<const Integer> q_, r_;
-    SymEngine::quotient_mod_f(SymEngine::outArg_Integer(q_),
-                              SymEngine::outArg_Integer(r_),
+    SymEngine::quotient_mod_f(SymEngine::outArg(q_), SymEngine::outArg(r_),
                               static_cast<const Integer &>(*(n->m)),
                               static_cast<const Integer &>(*(d->m)));
     q->m = q_;
@@ -1331,7 +1321,7 @@ int ntheory_mod_inverse(basic b, const basic a, const basic m)
     SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(m->m)));
     SymEngine::RCP<const Integer> b_;
-    ret_val = SymEngine::mod_inverse(SymEngine::outArg_Integer(b_),
+    ret_val = SymEngine::mod_inverse(SymEngine::outArg(b_),
                                      static_cast<const Integer &>(*(a->m)),
                                      static_cast<const Integer &>(*(m->m)));
     b->m = b_;
@@ -1349,8 +1339,7 @@ CWRAPPER_OUTPUT_TYPE ntheory_fibonacci2(basic g, basic s, unsigned long a)
 {
     CWRAPPER_BEGIN
     SymEngine::RCP<const Integer> g_, s_;
-    SymEngine::fibonacci2(SymEngine::outArg_Integer(g_),
-                          SymEngine::outArg_Integer(s_), a);
+    SymEngine::fibonacci2(SymEngine::outArg(g_), SymEngine::outArg(s_), a);
     g->m = g_;
     s->m = s_;
     CWRAPPER_END
@@ -1367,8 +1356,7 @@ CWRAPPER_OUTPUT_TYPE ntheory_lucas2(basic g, basic s, unsigned long a)
 {
     CWRAPPER_BEGIN
     SymEngine::RCP<const Integer> g_, s_;
-    SymEngine::lucas2(SymEngine::outArg_Integer(g_),
-                      SymEngine::outArg_Integer(s_), a);
+    SymEngine::lucas2(SymEngine::outArg(g_), SymEngine::outArg(s_), a);
     g->m = g_;
     s->m = s_;
     CWRAPPER_END

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -55,6 +55,14 @@ inline bool is_aligned(T *p, size_t n = alignof(T))
 {
     return 0 == reinterpret_cast<uintptr_t>(p) % n;
 }
+
+// Make a value with type Ptr<RCP<const Integer>>, which is commonly used in
+// ntheory.h.
+inline SymEngine::Ptr<RCP<const Integer>>
+outArg_Integer(RCP<const Integer> &arg)
+{
+    return SymEngine::outArg<RCP<const Integer>>(arg);
+}
 }
 
 extern "C" {

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -553,22 +553,39 @@ char *ascii_art_str();
 CWRAPPER_OUTPUT_TYPE ntheory_gcd(basic s, const basic a, const basic b);
 //! Least Common Multiple
 CWRAPPER_OUTPUT_TYPE ntheory_lcm(basic s, const basic a, const basic b);
+//! Extended GCD
+CWRAPPER_OUTPUT_TYPE ntheory_gcd_ext(basic g, basic s, basic t, const basic a,
+                                     const basic b);
 //! \return next prime after `a`
 CWRAPPER_OUTPUT_TYPE ntheory_nextprime(basic s, const basic a);
 //! modulo round toward zero
 CWRAPPER_OUTPUT_TYPE ntheory_mod(basic s, const basic n, const basic d);
 //! \return quotient round toward zero when `n` is divided by `d`
 CWRAPPER_OUTPUT_TYPE ntheory_quotient(basic s, const basic n, const basic d);
+//! \return modulo and quotient round toward zero
+CWRAPPER_OUTPUT_TYPE ntheory_quotient_mod(basic q, basic r, const basic n,
+                                          const basic d);
 //! modulo round toward -inf
 CWRAPPER_OUTPUT_TYPE ntheory_mod_f(basic s, const basic n, const basic d);
 //! \return quotient round toward -inf when `n` is divided by `d`
 CWRAPPER_OUTPUT_TYPE ntheory_quotient_f(basic s, const basic n, const basic d);
+//! \return modulo and quotient round toward -inf
+CWRAPPER_OUTPUT_TYPE ntheory_quotient_mod_f(basic q, basic r, const basic n,
+                                            const basic d);
+//! inverse modulo
+int ntheory_mod_inverse(basic b, const basic a, const basic m);
 //! nth Fibonacci number //  fibonacci(0) = 0 and fibonacci(1) = 1
 CWRAPPER_OUTPUT_TYPE ntheory_fibonacci(basic s, unsigned long a);
+//! Fibonacci n and n-1
+CWRAPPER_OUTPUT_TYPE ntheory_fibonacci2(basic g, basic s, unsigned long a);
 //! Lucas number
 CWRAPPER_OUTPUT_TYPE ntheory_lucas(basic s, unsigned long a);
+//! Lucas number n and n-1
+CWRAPPER_OUTPUT_TYPE ntheory_lucas2(basic g, basic s, unsigned long a);
 //! Binomial Coefficient
 CWRAPPER_OUTPUT_TYPE ntheory_binomial(basic s, const basic a, unsigned long b);
+//! Factorial
+CWRAPPER_OUTPUT_TYPE ntheory_factorial(basic s, unsigned long n);
 //! Evaluate b and assign the value to s
 CWRAPPER_OUTPUT_TYPE basic_evalf(basic s, const basic b, unsigned long bits,
                                  int real);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -916,20 +916,32 @@ void test_functions()
 
 void test_ntheory()
 {
-    basic x, i1, i2, i4, i5, im2, im7;
+    int ret_val;
+    basic x, y, z, a, b, c, i1, i2, i3, i4, i5, im1, im2, im3, im7;
     basic_new_stack(x);
+    basic_new_stack(y);
+    basic_new_stack(z);
+    basic_new_stack(a);
+    basic_new_stack(b);
+    basic_new_stack(c);
     basic_new_stack(i1);
     basic_new_stack(i2);
+    basic_new_stack(i3);
     basic_new_stack(i4);
     basic_new_stack(i5);
+    basic_new_stack(im1);
     basic_new_stack(im2);
+    basic_new_stack(im3);
     basic_new_stack(im7);
 
     integer_set_si(i1, 1);
     integer_set_si(i2, 2);
+    integer_set_si(i3, 3);
     integer_set_si(i4, 4);
     integer_set_si(i5, 5);
+    integer_set_si(im1, -1);
     integer_set_si(im2, -2);
+    integer_set_si(im3, -3);
     integer_set_si(im7, -7);
 
     ntheory_gcd(x, i2, i4);
@@ -937,6 +949,13 @@ void test_ntheory()
 
     ntheory_lcm(x, i2, i4);
     SYMENGINE_C_ASSERT(basic_eq(x, i4));
+
+    ntheory_gcd_ext(x, y, z, i2, i3);
+    SYMENGINE_C_ASSERT(basic_eq(x, i1));
+    basic_mul(a, i2, y);
+    basic_mul(b, i3, z);
+    basic_add(c, a, b);
+    SYMENGINE_C_ASSERT(basic_eq(x, c));
 
     ntheory_nextprime(x, i4);
     SYMENGINE_C_ASSERT(basic_eq(x, i5));
@@ -947,27 +966,62 @@ void test_ntheory()
     ntheory_quotient(x, i5, i2);
     SYMENGINE_C_ASSERT(basic_eq(x, i2));
 
+    ntheory_quotient_mod(x, y, im7, i4);
+    SYMENGINE_C_ASSERT(basic_eq(x, im1));
+    SYMENGINE_C_ASSERT(basic_eq(y, im3));
+
     ntheory_mod_f(x, im7, i4);
     SYMENGINE_C_ASSERT(basic_eq(x, i1));
 
     ntheory_quotient_f(x, im7, i4);
     SYMENGINE_C_ASSERT(basic_eq(x, im2));
 
+    ntheory_quotient_mod_f(x, y, im7, i4);
+    SYMENGINE_C_ASSERT(basic_eq(x, im2));
+    SYMENGINE_C_ASSERT(basic_eq(y, i1));
+
+    ret_val = ntheory_mod_inverse(x, i3, i5);
+    SYMENGINE_C_ASSERT(ret_val != 0);
+    SYMENGINE_C_ASSERT(basic_eq(x, i2));
+
     ntheory_fibonacci(x, 5);
     SYMENGINE_C_ASSERT(basic_eq(x, i5));
+
+    ntheory_fibonacci2(x, y, 5);
+    SYMENGINE_C_ASSERT(basic_eq(x, i5));
+    SYMENGINE_C_ASSERT(basic_eq(y, i3));
 
     ntheory_lucas(x, 1);
     SYMENGINE_C_ASSERT(basic_eq(x, i1));
 
+    ntheory_lucas2(x, y, 3);
+    SYMENGINE_C_ASSERT(basic_eq(x, i4));
+    SYMENGINE_C_ASSERT(basic_eq(y, i3));
+
     ntheory_binomial(x, i5, 1);
     SYMENGINE_C_ASSERT(basic_eq(x, i5));
 
+    ntheory_factorial(x, 0);
+    ntheory_factorial(y, 1);
+    ntheory_factorial(z, 2);
+    SYMENGINE_C_ASSERT(basic_eq(x, i1));
+    SYMENGINE_C_ASSERT(basic_eq(y, i1));
+    SYMENGINE_C_ASSERT(basic_eq(z, i2));
+
     basic_free_stack(x);
+    basic_free_stack(y);
+    basic_free_stack(z);
+    basic_free_stack(a);
+    basic_free_stack(b);
+    basic_free_stack(c);
     basic_free_stack(i1);
     basic_free_stack(i2);
+    basic_free_stack(i3);
     basic_free_stack(i4);
     basic_free_stack(i5);
+    basic_free_stack(im1);
     basic_free_stack(im2);
+    basic_free_stack(im3);
     basic_free_stack(im7);
 }
 


### PR DESCRIPTION
~~This PR includes a function called `outArg_Integer` to make values with type `Ptr<RCP<const Integer>>`, which are commonly used in module [ntheory.h](https://github.com/symengine/symengine/blob/master/symengine/ntheory.h).~~

New wrapped functions are as follows:

+ `ntheory_gcd_ext`
+ `ntheory_quotient_mod`
+ `ntheory_quotient_mod_f`
+ `ntheory_mod_inverse`
+ `ntheory_fibonacci2`
+ `ntheory_lucas2`
+ `ntheory_factorial`