### PR TITLE
Use C99 complex type in C wrappers

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -434,15 +434,15 @@ CWRAPPER_OUTPUT_TYPE complex_double_imaginary_part(basic s, const basic com)
     CWRAPPER_END
 }
 
+dcomplex csqrt(dcomplex z);
+
 dcomplex complex_double_get(const basic s)
 {
     SYMENGINE_ASSERT(is_a<ComplexDouble>(*(s->m)));
-    dcomplex d;
-    d.real = (static_cast<const ComplexDouble &>(*(s->m)).as_complex_double())
-                 .real();
-    d.imag = (static_cast<const ComplexDouble &>(*(s->m)).as_complex_double())
-                 .imag();
-    return d;
+    std::complex<double> cd
+        = static_cast<const ComplexDouble &>(*(s->m)).as_complex_double();
+    static const dcomplex ImagI = csqrt(-1);
+    return cd.real() + cd.imag() * ImagI;
 }
 
 CWRAPPER_OUTPUT_TYPE basic_diff(basic s, const basic expr, basic const symbol)

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -39,12 +39,7 @@ typedef enum {
     SYMENGINE_TypeID_Count
 } TypeID;
 
-//! Struct to hold the real and imaginary parts of std::complex<double>
-//! extracted from basic
-typedef struct dcomplex {
-    double real;
-    double imag;
-} dcomplex;
+typedef double _Complex dcomplex;
 
 // The size of 'CRCPBasic_C' must be the same as CRCPBasic (which contains a
 // single RCP<const Basic> member) *and* they must have the same alignment

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -12,6 +12,8 @@
 #include <mpfr.h>
 #endif // HAVE_SYMENGINE_MPFR
 
+#include <complex.h>
+
 void test_cwrapper()
 {
     char *s;
@@ -209,8 +211,8 @@ void test_complex_double()
     basic_str_free(s);
 
     k = complex_double_get(e);
-    SYMENGINE_C_ASSERT(k.real == 100.47);
-    SYMENGINE_C_ASSERT(k.imag == 76.59);
+    SYMENGINE_C_ASSERT(creal(k) == 100.47);
+    SYMENGINE_C_ASSERT(cimag(k) == 76.59);
 
     complex_double_real_part(f, e);
     s = basic_str(f);


### PR DESCRIPTION
Fixes #1131.

I am checking if this passes all tests.

TODO:
* [ ] Include `<complex.h>` in the C header file when compiled with a C compiler, but not when compiled with a C++ compiler (otherwise the macro `I` clashes with `SymEngine::I`)
* [ ] Figure out how to remove the `dcomplex csqrt(dcomplex z);` declaration, as it is included in `<complex.h>`, but `<complex.h>` can't be included in C++ mode. One idea is to declare `static const dcomplex ImagI = csqrt(-1);` as extern, and then define it in a `.c` file that includes the `<complex.h>`. Perhaps one can then even use the standard C99 `I` macro in that `.c` file.