### PR TITLE
Additional Fixes for #1139

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -25,6 +25,7 @@ using SymEngine::Number;
 using SymEngine::Complex;
 using SymEngine::ComplexDouble;
 using SymEngine::RealDouble;
+using SymEngine::down_cast;
 #ifdef HAVE_SYMENGINE_MPFR
 using SymEngine::RealMPFR;
 using SymEngine::mpfr_class;
@@ -453,9 +454,9 @@ dcomplex complex_double_get(const basic s)
 {
     SYMENGINE_ASSERT(is_a<ComplexDouble>(*(s->m)));
     dcomplex d;
-    d.real = (static_cast<const ComplexDouble &>(*(s->m)).as_complex_double())
+    d.real = (down_cast<const ComplexDouble &>(*(s->m)).as_complex_double())
                  .real();
-    d.imag = (static_cast<const ComplexDouble &>(*(s->m)).as_complex_double())
+    d.imag = (down_cast<const ComplexDouble &>(*(s->m)).as_complex_double())
                  .imag();
     return d;
 }
@@ -1220,8 +1221,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_gcd(basic s, const basic a, const basic b)
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(b->m)));
-    s->m = SymEngine::gcd(static_cast<const Integer &>(*(a->m)),
-                          static_cast<const Integer &>(*(b->m)));
+    s->m = SymEngine::gcd(down_cast<const Integer &>(*(a->m)),
+                          down_cast<const Integer &>(*(b->m)));
     CWRAPPER_END
 }
 
@@ -1230,8 +1231,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_lcm(basic s, const basic a, const basic b)
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(b->m)));
-    s->m = SymEngine::lcm(static_cast<const Integer &>(*(a->m)),
-                          static_cast<const Integer &>(*(b->m)));
+    s->m = SymEngine::lcm(down_cast<const Integer &>(*(a->m)),
+                          down_cast<const Integer &>(*(b->m)));
     CWRAPPER_END
 }
 
@@ -1244,8 +1245,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_gcd_ext(basic g, basic s, basic t, const basic a,
     SymEngine::RCP<const Integer> g_, s_, t_;
     SymEngine::gcd_ext(SymEngine::outArg(g_), SymEngine::outArg(s_),
                        SymEngine::outArg(t_),
-                       static_cast<const Integer &>(*(a->m)),
-                       static_cast<const Integer &>(*(b->m)));
+                       down_cast<const Integer &>(*(a->m)),
+                       down_cast<const Integer &>(*(b->m)));
     g->m = g_;
     s->m = s_;
     t->m = t_;
@@ -1256,7 +1257,7 @@ CWRAPPER_OUTPUT_TYPE ntheory_nextprime(basic s, const basic a)
 {
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
-    s->m = SymEngine::nextprime(static_cast<const Integer &>(*(a->m)));
+    s->m = SymEngine::nextprime(down_cast<const Integer &>(*(a->m)));
     CWRAPPER_END
 }
 
@@ -1265,8 +1266,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_mod(basic s, const basic n, const basic d)
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
-    s->m = SymEngine::mod(static_cast<const Integer &>(*(n->m)),
-                          static_cast<const Integer &>(*(d->m)));
+    s->m = SymEngine::mod(down_cast<const Integer &>(*(n->m)),
+                          down_cast<const Integer &>(*(d->m)));
     CWRAPPER_END
 }
 
@@ -1275,8 +1276,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient(basic s, const basic n, const basic d)
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
-    s->m = SymEngine::quotient(static_cast<const Integer &>(*(n->m)),
-                               static_cast<const Integer &>(*(d->m)));
+    s->m = SymEngine::quotient(down_cast<const Integer &>(*(n->m)),
+                               down_cast<const Integer &>(*(d->m)));
     CWRAPPER_END
 }
 
@@ -1288,8 +1289,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient_mod(basic q, basic r, const basic n,
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
     SymEngine::RCP<const Integer> q_, r_;
     SymEngine::quotient_mod(SymEngine::outArg(q_), SymEngine::outArg(r_),
-                            static_cast<const Integer &>(*(n->m)),
-                            static_cast<const Integer &>(*(d->m)));
+                            down_cast<const Integer &>(*(n->m)),
+                            down_cast<const Integer &>(*(d->m)));
     q->m = q_;
     r->m = r_;
     CWRAPPER_END
@@ -1300,8 +1301,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_mod_f(basic s, const basic n, const basic d)
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
-    s->m = SymEngine::mod_f(static_cast<const Integer &>(*(n->m)),
-                            static_cast<const Integer &>(*(d->m)));
+    s->m = SymEngine::mod_f(down_cast<const Integer &>(*(n->m)),
+                            down_cast<const Integer &>(*(d->m)));
     CWRAPPER_END
 }
 
@@ -1310,8 +1311,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient_f(basic s, const basic n, const basic d)
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(n->m)));
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
-    s->m = SymEngine::quotient_f(static_cast<const Integer &>(*(n->m)),
-                                 static_cast<const Integer &>(*(d->m)));
+    s->m = SymEngine::quotient_f(down_cast<const Integer &>(*(n->m)),
+                                 down_cast<const Integer &>(*(d->m)));
     CWRAPPER_END
 }
 
@@ -1323,8 +1324,8 @@ CWRAPPER_OUTPUT_TYPE ntheory_quotient_mod_f(basic q, basic r, const basic n,
     SYMENGINE_ASSERT(is_a<Integer>(*(d->m)));
     SymEngine::RCP<const Integer> q_, r_;
     SymEngine::quotient_mod_f(SymEngine::outArg(q_), SymEngine::outArg(r_),
-                              static_cast<const Integer &>(*(n->m)),
-                              static_cast<const Integer &>(*(d->m)));
+                              down_cast<const Integer &>(*(n->m)),
+                              down_cast<const Integer &>(*(d->m)));
     q->m = q_;
     r->m = r_;
     CWRAPPER_END
@@ -1337,8 +1338,8 @@ int ntheory_mod_inverse(basic b, const basic a, const basic m)
     SYMENGINE_ASSERT(is_a<Integer>(*(m->m)));
     SymEngine::RCP<const Integer> b_;
     ret_val = SymEngine::mod_inverse(SymEngine::outArg(b_),
-                                     static_cast<const Integer &>(*(a->m)),
-                                     static_cast<const Integer &>(*(m->m)));
+                                     down_cast<const Integer &>(*(a->m)),
+                                     down_cast<const Integer &>(*(m->m)));
     b->m = b_;
     return ret_val;
 }
@@ -1381,7 +1382,7 @@ CWRAPPER_OUTPUT_TYPE ntheory_binomial(basic s, const basic a, unsigned long b)
 {
     CWRAPPER_BEGIN
     SYMENGINE_ASSERT(is_a<Integer>(*(a->m)));
-    s->m = SymEngine::binomial(static_cast<const Integer &>(*(a->m)), b);
+    s->m = SymEngine::binomial(down_cast<const Integer &>(*(a->m)), b);
     CWRAPPER_END
 }
 

--- a/symengine/eval_double.cpp
+++ b/symengine/eval_double.cpp
@@ -21,7 +21,7 @@ protected:
 public:
     T apply(const Basic &b)
     {
-        b.accept(*static_cast<C *>(this));
+        b.accept(*down_cast<C *>(this));
         return result_;
     }
 
@@ -399,20 +399,20 @@ std::vector<fn> init_eval_double()
         throw NotImplementedError("Not Implemented");
     });
     table[INTEGER] = [](const Basic &x) {
-        double tmp = mp_get_d((static_cast<const Integer &>(x)).i);
+        double tmp = mp_get_d((down_cast<const Integer &>(x)).i);
         return tmp;
     };
     table[RATIONAL] = [](const Basic &x) {
-        double tmp = mp_get_d((static_cast<const Rational &>(x)).i);
+        double tmp = mp_get_d((down_cast<const Rational &>(x)).i);
         return tmp;
     };
     table[REAL_DOUBLE] = [](const Basic &x) {
-        double tmp = (static_cast<const RealDouble &>(x)).i;
+        double tmp = (down_cast<const RealDouble &>(x)).i;
         return tmp;
     };
 #ifdef HAVE_SYMENGINE_MPFR
     table[REAL_MPFR] = [](const Basic &x) {
-        double tmp = mpfr_get_d(static_cast<const RealMPFR &>(x).i.get_mpfr_t(),
+        double tmp = mpfr_get_d(down_cast<const RealMPFR &>(x).i.get_mpfr_t(),
                                 MPFR_RNDN);
         return tmp;
     };
@@ -431,161 +431,161 @@ std::vector<fn> init_eval_double()
     };
     table[POW] = [](const Basic &x) {
         double a = eval_double_single_dispatch(
-            *(static_cast<const Pow &>(x)).get_base());
+            *(down_cast<const Pow &>(x)).get_base());
         double b = eval_double_single_dispatch(
-            *(static_cast<const Pow &>(x)).get_exp());
+            *(down_cast<const Pow &>(x)).get_exp());
         return ::pow(a, b);
     };
     table[SIN] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Sin &>(x)).get_arg());
+            *(down_cast<const Sin &>(x)).get_arg());
         return ::sin(tmp);
     };
     table[COS] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Cos &>(x)).get_arg());
+            *(down_cast<const Cos &>(x)).get_arg());
         return ::cos(tmp);
     };
     table[TAN] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Tan &>(x)).get_arg());
+            *(down_cast<const Tan &>(x)).get_arg());
         return ::tan(tmp);
     };
     table[LOG] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Log &>(x)).get_arg());
+            *(down_cast<const Log &>(x)).get_arg());
         return ::log(tmp);
     };
     table[COT] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Cot &>(x)).get_arg());
+            *(down_cast<const Cot &>(x)).get_arg());
         return 1 / ::tan(tmp);
     };
     table[CSC] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Csc &>(x)).get_arg());
+            *(down_cast<const Csc &>(x)).get_arg());
         return 1 / ::sin(tmp);
     };
     table[SEC] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Sec &>(x)).get_arg());
+            *(down_cast<const Sec &>(x)).get_arg());
         return 1 / ::cos(tmp);
     };
     table[ASIN] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ASin &>(x)).get_arg());
+            *(down_cast<const ASin &>(x)).get_arg());
         return ::asin(tmp);
     };
     table[ACOS] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ACos &>(x)).get_arg());
+            *(down_cast<const ACos &>(x)).get_arg());
         return ::acos(tmp);
     };
     table[ASEC] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ASec &>(x)).get_arg());
+            *(down_cast<const ASec &>(x)).get_arg());
         return ::acos(1 / tmp);
     };
     table[ACSC] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ACsc &>(x)).get_arg());
+            *(down_cast<const ACsc &>(x)).get_arg());
         return ::asin(1 / tmp);
     };
     table[ATAN] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ATan &>(x)).get_arg());
+            *(down_cast<const ATan &>(x)).get_arg());
         return ::atan(tmp);
     };
     table[ACOT] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ACot &>(x)).get_arg());
+            *(down_cast<const ACot &>(x)).get_arg());
         return ::atan(1 / tmp);
     };
     table[ATAN2] = [](const Basic &x) {
         double num = eval_double_single_dispatch(
-            *(static_cast<const ATan2 &>(x)).get_num());
+            *(down_cast<const ATan2 &>(x)).get_num());
         double den = eval_double_single_dispatch(
-            *(static_cast<const ATan2 &>(x)).get_den());
+            *(down_cast<const ATan2 &>(x)).get_den());
         return ::atan2(num, den);
     };
     table[SINH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Sinh &>(x)).get_arg());
+            *(down_cast<const Sinh &>(x)).get_arg());
         return ::sinh(tmp);
     };
     table[CSCH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Csch &>(x)).get_arg());
+            *(down_cast<const Csch &>(x)).get_arg());
         return 1 / ::sinh(tmp);
     };
     table[COSH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Cosh &>(x)).get_arg());
+            *(down_cast<const Cosh &>(x)).get_arg());
         return ::cosh(tmp);
     };
     table[SECH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Sech &>(x)).get_arg());
+            *(down_cast<const Sech &>(x)).get_arg());
         return 1 / ::cosh(tmp);
     };
     table[TANH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Tanh &>(x)).get_arg());
+            *(down_cast<const Tanh &>(x)).get_arg());
         return ::tanh(tmp);
     };
     table[COTH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Coth &>(x)).get_arg());
+            *(down_cast<const Coth &>(x)).get_arg());
         return 1 / ::tanh(tmp);
     };
     table[ASINH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ASinh &>(x)).get_arg());
+            *(down_cast<const ASinh &>(x)).get_arg());
         return ::asinh(tmp);
     };
     table[ACSCH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ACsch &>(x)).get_arg());
+            *(down_cast<const ACsch &>(x)).get_arg());
         return ::asinh(1 / tmp);
     };
     table[ACOSH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ACosh &>(x)).get_arg());
+            *(down_cast<const ACosh &>(x)).get_arg());
         return ::acosh(tmp);
     };
     table[ATANH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ATanh &>(x)).get_arg());
+            *(down_cast<const ATanh &>(x)).get_arg());
         return ::atanh(tmp);
     };
     table[ACOTH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ACoth &>(x)).get_arg());
+            *(down_cast<const ACoth &>(x)).get_arg());
         return std::atanh(1 / tmp);
     };
     table[ASECH] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const ASech &>(x)).get_arg());
+            *(down_cast<const ASech &>(x)).get_arg());
         return ::acosh(1 / tmp);
     };
     table[GAMMA] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Gamma &>(x)).get_args()[0]);
+            *(down_cast<const Gamma &>(x)).get_args()[0]);
         return ::tgamma(tmp);
     };
     table[LOGGAMMA] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const LogGamma &>(x)).get_args()[0]);
+            *(down_cast<const LogGamma &>(x)).get_args()[0]);
         return ::lgamma(tmp);
     };
     table[ERF] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Erf &>(x)).get_args()[0]);
+            *(down_cast<const Erf &>(x)).get_args()[0]);
         return ::erf(tmp);
     };
     table[ERFC] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Erfc &>(x)).get_args()[0]);
+            *(down_cast<const Erfc &>(x)).get_args()[0]);
         return ::erfc(tmp);
     };
     table[CONSTANT] = [](const Basic &x) {
@@ -597,21 +597,21 @@ std::vector<fn> init_eval_double()
             return 0.5772156649015328606065; // use until polygamma or digamma
                                              // is implemented
         } else {
-            throw SymEngineException(
-                "Constant " + static_cast<const Constant &>(x).get_name()
-                + " is not implemented.");
+            throw SymEngineException("Constant "
+                                     + down_cast<const Constant &>(x).get_name()
+                                     + " is not implemented.");
         }
     };
     table[ABS] = [](const Basic &x) {
         double tmp = eval_double_single_dispatch(
-            *(static_cast<const Abs &>(x)).get_arg());
+            *(down_cast<const Abs &>(x)).get_arg());
         return std::abs(tmp);
     };
     table[MAX] = [](const Basic &x) {
         double result;
         result = eval_double_single_dispatch(
-            *(static_cast<const Max &>(x).get_args()[0]));
-        for (const auto &p : static_cast<const Max &>(x).get_args()) {
+            *(down_cast<const Max &>(x).get_args()[0]));
+        for (const auto &p : down_cast<const Max &>(x).get_args()) {
             double tmp = eval_double_single_dispatch(*p);
             result = std::max(result, tmp);
         }
@@ -621,7 +621,7 @@ std::vector<fn> init_eval_double()
         double result;
         result = eval_double_single_dispatch(
             *(static_cast<const Max &>(x).get_args()[0]));
-        for (const auto &p : static_cast<const Min &>(x).get_args()) {
+        for (const auto &p : down_cast<const Min &>(x).get_args()) {
             double tmp = eval_double_single_dispatch(*p);
             result = std::min(result, tmp);
         }

--- a/symengine/eval_double.cpp
+++ b/symengine/eval_double.cpp
@@ -620,7 +620,7 @@ std::vector<fn> init_eval_double()
     table[MIN] = [](const Basic &x) {
         double result;
         result = eval_double_single_dispatch(
-            *(static_cast<const Max &>(x).get_args()[0]));
+            *(down_cast<const Min &>(x).get_args()[0]));
         for (const auto &p : down_cast<const Min &>(x).get_args()) {
             double tmp = eval_double_single_dispatch(*p);
             result = std::min(result, tmp);

--- a/symengine/fields.cpp
+++ b/symengine/fields.cpp
@@ -39,7 +39,7 @@ hash_t GaloisField::__hash__() const
 
 int GaloisField::compare(const Basic &o) const
 {
-    const GaloisField &s = static_cast<const GaloisField &>(o);
+    const GaloisField &s = down_cast<const GaloisField &>(o);
 
     if (poly_.size() != s.poly_.size())
         return (poly_.size() < s.poly_.size()) ? -1 : 1;
@@ -164,7 +164,7 @@ GaloisFieldDict &GaloisFieldDict::negate()
         if (a != 0_z)
             a += modulo_;
     }
-    return static_cast<GaloisFieldDict &>(*this);
+    return down_cast<GaloisFieldDict &>(*this);
 }
 
 void GaloisFieldDict::gf_istrip()

--- a/symengine/fields.cpp
+++ b/symengine/fields.cpp
@@ -284,7 +284,7 @@ void GaloisFieldDict::gf_rshift(const integer_class n,
                                             dict_.begin() + n_val);
         *rem = GaloisFieldDict::from_vec(dict_rem, modulo_);
     } else {
-        *rem = static_cast<GaloisFieldDict>(*this);
+        *rem = down_cast<const GaloisFieldDict &>(*this);
     }
 }
 
@@ -299,11 +299,11 @@ GaloisFieldDict GaloisFieldDict::gf_pow(const unsigned int n) const
         return GaloisFieldDict({integer_class(1)}, modulo_);
     }
     if (n == 1)
-        return static_cast<GaloisFieldDict>(*this);
+        return down_cast<const GaloisFieldDict &>(*this);
     if (n == 2)
         return gf_sqr();
     unsigned int num = n;
-    GaloisFieldDict to_sq = static_cast<GaloisFieldDict>(*this);
+    GaloisFieldDict to_sq = down_cast<const GaloisFieldDict &>(*this);
     GaloisFieldDict to_ret = GaloisFieldDict({integer_class(1)}, modulo_);
     while (1) {
         if (num & 1) {
@@ -319,7 +319,7 @@ GaloisFieldDict GaloisFieldDict::gf_pow(const unsigned int n) const
 void GaloisFieldDict::gf_monic(integer_class &res,
                                const Ptr<GaloisFieldDict> &monic) const
 {
-    *monic = static_cast<GaloisFieldDict>(*this);
+    *monic = down_cast<const GaloisFieldDict &>(*this);
     if (dict_.empty()) {
         res = integer_class(0);
     } else {
@@ -340,7 +340,7 @@ GaloisFieldDict GaloisFieldDict::gf_gcd(const GaloisFieldDict &o) const
 {
     if (modulo_ != o.modulo_)
         throw SymEngineException("Error: field must be same.");
-    GaloisFieldDict f = static_cast<GaloisFieldDict>(*this);
+    GaloisFieldDict f = down_cast<const GaloisFieldDict &>(*this);
     GaloisFieldDict g = o;
     GaloisFieldDict temp_out;
     while (not g.dict_.empty()) {
@@ -357,7 +357,7 @@ GaloisFieldDict GaloisFieldDict::gf_lcm(const GaloisFieldDict &o) const
     if (modulo_ != o.modulo_)
         throw SymEngineException("Error: field must be same.");
     if (dict_.empty())
-        return static_cast<GaloisFieldDict>(*this);
+        return down_cast<const GaloisFieldDict &>(*this);
     if (o.dict_.empty())
         return o;
     GaloisFieldDict out, temp_out;

--- a/symengine/polys/msymenginepoly.h
+++ b/symengine/polys/msymenginepoly.h
@@ -92,7 +92,7 @@ public:
                 dict_.insert(t, {iter.first, iter.second});
             }
         }
-        return static_cast<Wrapper &>(*this);
+        return down_cast<Wrapper &>(*this);
     }
 
     friend Wrapper operator-(const Wrapper &a, const Wrapper &b)
@@ -109,7 +109,7 @@ public:
         auto c = *this;
         for (auto &iter : c.dict_)
             iter.second *= -1;
-        return static_cast<Wrapper &>(c);
+        return down_cast<Wrapper &>(c);
     }
 
     // both wrappers must have "aligned" vectors, ie same size
@@ -128,7 +128,7 @@ public:
                 dict_.insert(t, {iter.first, -iter.second});
             }
         }
-        return static_cast<Wrapper &>(*this);
+        return down_cast<Wrapper &>(*this);
     }
 
     static Wrapper mul(const Wrapper &a, const Wrapper &b)
@@ -192,11 +192,11 @@ public:
         SYMENGINE_ASSERT(vec_size == other.vec_size)
 
         if (dict_.empty())
-            return static_cast<Wrapper &>(*this);
+            return down_cast<Wrapper &>(*this);
 
         if (other.dict_.empty()) {
             dict_.clear();
-            return static_cast<Wrapper &>(*this);
+            return down_cast<Wrapper &>(*this);
         }
 
         Vec zero_v(vec_size, 0);
@@ -206,12 +206,12 @@ public:
             auto t = other.dict_.begin();
             for (auto &i1 : dict_)
                 i1.second *= t->second;
-            return static_cast<Wrapper &>(*this);
+            return down_cast<Wrapper &>(*this);
         }
 
-        Wrapper res = Wrapper::mul(static_cast<Wrapper &>(*this), other);
+        Wrapper res = Wrapper::mul(down_cast<Wrapper &>(*this), other);
         res.dict_.swap(this->dict_);
-        return static_cast<Wrapper &>(*this);
+        return down_cast<Wrapper &>(*this);
     }
 
     bool operator==(const Wrapper &other) const

--- a/symengine/polys/msymenginepoly.h
+++ b/symengine/polys/msymenginepoly.h
@@ -5,6 +5,7 @@
 #include <symengine/monomials.h>
 #include <symengine/polys/uintpoly.h>
 #include <symengine/polys/uexprpoly.h>
+#include <symengine/symengine_casts.h>
 
 namespace SymEngine
 {
@@ -64,7 +65,7 @@ public:
     {
         if (this != &other)
             dict_ = std::move(other.dict_);
-        return static_cast<Wrapper &>(*this);
+        return down_cast<Wrapper &>(*this);
     }
 
     friend Wrapper operator+(const Wrapper &a, const Wrapper &b)
@@ -352,7 +353,7 @@ public:
     {
         SYMENGINE_ASSERT(is_a<Poly>(o))
 
-        const Poly &s = static_cast<const Poly &>(o);
+        const Poly &s = down_cast<const Poly &>(o);
 
         if (vars_.size() != s.vars_.size())
             return vars_.size() < s.vars_.size() ? -1 : 1;
@@ -424,7 +425,7 @@ public:
         // TODO : fix for when vars are different, but there is an intersection
         if (not is_a<Poly>(o))
             return false;
-        const Poly &o_ = static_cast<const Poly &>(o);
+        const Poly &o_ = down_cast<const Poly &>(o);
         // compare constants without regards to vars
         if (1 == poly_.dict_.size() && 1 == o_.poly_.dict_.size()) {
             if (poly_.dict_.begin()->second != o_.poly_.dict_.begin()->second)

--- a/symengine/polys/msymenginepoly.h
+++ b/symengine/polys/msymenginepoly.h
@@ -65,7 +65,7 @@ public:
     {
         if (this != &other)
             dict_ = std::move(other.dict_);
-        return down_cast<Wrapper &>(*this);
+        return static_cast<Wrapper &>(*this);
     }
 
     friend Wrapper operator+(const Wrapper &a, const Wrapper &b)
@@ -92,7 +92,7 @@ public:
                 dict_.insert(t, {iter.first, iter.second});
             }
         }
-        return down_cast<Wrapper &>(*this);
+        return static_cast<Wrapper &>(*this);
     }
 
     friend Wrapper operator-(const Wrapper &a, const Wrapper &b)
@@ -109,7 +109,7 @@ public:
         auto c = *this;
         for (auto &iter : c.dict_)
             iter.second *= -1;
-        return down_cast<Wrapper &>(c);
+        return static_cast<Wrapper &>(c);
     }
 
     // both wrappers must have "aligned" vectors, ie same size
@@ -128,7 +128,7 @@ public:
                 dict_.insert(t, {iter.first, -iter.second});
             }
         }
-        return down_cast<Wrapper &>(*this);
+        return static_cast<Wrapper &>(*this);
     }
 
     static Wrapper mul(const Wrapper &a, const Wrapper &b)
@@ -192,11 +192,11 @@ public:
         SYMENGINE_ASSERT(vec_size == other.vec_size)
 
         if (dict_.empty())
-            return down_cast<Wrapper &>(*this);
+            return static_cast<Wrapper &>(*this);
 
         if (other.dict_.empty()) {
             dict_.clear();
-            return down_cast<Wrapper &>(*this);
+            return static_cast<Wrapper &>(*this);
         }
 
         Vec zero_v(vec_size, 0);
@@ -206,12 +206,12 @@ public:
             auto t = other.dict_.begin();
             for (auto &i1 : dict_)
                 i1.second *= t->second;
-            return down_cast<Wrapper &>(*this);
+            return static_cast<Wrapper &>(*this);
         }
 
-        Wrapper res = Wrapper::mul(down_cast<Wrapper &>(*this), other);
+        Wrapper res = Wrapper::mul(static_cast<Wrapper &>(*this), other);
         res.dict_.swap(this->dict_);
-        return down_cast<Wrapper &>(*this);
+        return static_cast<Wrapper &>(*this);
     }
 
     bool operator==(const Wrapper &other) const

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -156,7 +156,7 @@ public:
     {
         if (this != &other)
             dict_ = std::move(other.dict_);
-        return down_cast<Wrapper &>(*this);
+        return static_cast<Wrapper &>(*this);
     }
 
     friend Wrapper operator+(const Wrapper &a, const Wrapper &b)
@@ -179,7 +179,7 @@ public:
                 dict_.insert(t, {iter.first, iter.second});
             }
         }
-        return down_cast<Wrapper &>(*this);
+        return static_cast<Wrapper &>(*this);
     }
 
     friend Wrapper operator-(const Wrapper &a, const Wrapper &b)
@@ -194,7 +194,7 @@ public:
         ODictWrapper c = *this;
         for (auto &iter : c.dict_)
             iter.second *= -1;
-        return down_cast<Wrapper &>(c);
+        return static_cast<Wrapper &>(c);
     }
 
     Wrapper &operator-=(const Wrapper &other)
@@ -210,7 +210,7 @@ public:
                 dict_.insert(t, {iter.first, -iter.second});
             }
         }
-        return down_cast<Wrapper &>(*this);
+        return static_cast<Wrapper &>(*this);
     }
 
     static Wrapper mul(const Wrapper &a, const Wrapper &b)
@@ -269,11 +269,11 @@ public:
     Wrapper &operator*=(const Wrapper &other)
     {
         if (dict_.empty())
-            return down_cast<Wrapper &>(*this);
+            return static_cast<Wrapper &>(*this);
 
         if (other.dict_.empty()) {
             dict_.clear();
-            return down_cast<Wrapper &>(*this);
+            return static_cast<Wrapper &>(*this);
         }
 
         // ! other is a just constant term
@@ -282,12 +282,12 @@ public:
             auto t = other.dict_.begin();
             for (auto &i1 : dict_)
                 i1.second *= t->second;
-            return down_cast<Wrapper &>(*this);
+            return static_cast<Wrapper &>(*this);
         }
 
-        Wrapper res = Wrapper::mul(down_cast<Wrapper &>(*this), other);
+        Wrapper res = Wrapper::mul(static_cast<Wrapper &>(*this), other);
         res.dict_.swap(this->dict_);
-        return down_cast<Wrapper &>(*this);
+        return static_cast<Wrapper &>(*this);
     }
 
     bool operator==(const Wrapper &other) const

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -156,7 +156,7 @@ public:
     {
         if (this != &other)
             dict_ = std::move(other.dict_);
-        return static_cast<Wrapper &>(*this);
+        return down_cast<Wrapper &>(*this);
     }
 
     friend Wrapper operator+(const Wrapper &a, const Wrapper &b)
@@ -366,8 +366,8 @@ public:
     inline bool __eq__(const Basic &o) const
     {
         if (is_a<Poly>(o))
-            return eq(*var_, *(static_cast<const Poly &>(o).var_))
-                   and poly_ == static_cast<const Poly &>(o).poly_;
+            return eq(*var_, *(down_cast<const Poly &>(o).var_))
+                   and poly_ == down_cast<const Poly &>(o).poly_;
         return false;
     }
 
@@ -418,8 +418,8 @@ public:
 
     RCP<const Basic> as_symbolic() const
     {
-        auto it = (static_cast<const Poly &>(*this)).begin();
-        auto end = (static_cast<const Poly &>(*this)).end();
+        auto it = (down_cast<const Poly &>(*this)).begin();
+        auto end = (down_cast<const Poly &>(*this)).end();
 
         vec_basic args;
         for (; it != end; ++it) {
@@ -498,8 +498,8 @@ public:
 
     RCP<const Basic> as_symbolic() const
     {
-        auto it = (static_cast<const Poly &>(*this)).begin();
-        auto end = (static_cast<const Poly &>(*this)).end();
+        auto it = (down_cast<const Poly &>(*this)).begin();
+        auto end = (down_cast<const Poly &>(*this)).end();
 
         vec_basic args;
         for (; it != end; ++it) {
@@ -539,8 +539,8 @@ public:
 
     RCP<const Basic> as_symbolic() const
     {
-        auto it = (static_cast<const Poly &>(*this)).begin();
-        auto end = (static_cast<const Poly &>(*this)).end();
+        auto it = (down_cast<const Poly &>(*this)).begin();
+        auto end = (down_cast<const Poly &>(*this)).end();
 
         vec_basic args;
         for (; it != end; ++it) {

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -179,7 +179,7 @@ public:
                 dict_.insert(t, {iter.first, iter.second});
             }
         }
-        return static_cast<Wrapper &>(*this);
+        return down_cast<Wrapper &>(*this);
     }
 
     friend Wrapper operator-(const Wrapper &a, const Wrapper &b)
@@ -194,7 +194,7 @@ public:
         ODictWrapper c = *this;
         for (auto &iter : c.dict_)
             iter.second *= -1;
-        return static_cast<Wrapper &>(c);
+        return down_cast<Wrapper &>(c);
     }
 
     Wrapper &operator-=(const Wrapper &other)
@@ -210,7 +210,7 @@ public:
                 dict_.insert(t, {iter.first, -iter.second});
             }
         }
-        return static_cast<Wrapper &>(*this);
+        return down_cast<Wrapper &>(*this);
     }
 
     static Wrapper mul(const Wrapper &a, const Wrapper &b)
@@ -269,11 +269,11 @@ public:
     Wrapper &operator*=(const Wrapper &other)
     {
         if (dict_.empty())
-            return static_cast<Wrapper &>(*this);
+            return down_cast<Wrapper &>(*this);
 
         if (other.dict_.empty()) {
             dict_.clear();
-            return static_cast<Wrapper &>(*this);
+            return down_cast<Wrapper &>(*this);
         }
 
         // ! other is a just constant term
@@ -282,12 +282,12 @@ public:
             auto t = other.dict_.begin();
             for (auto &i1 : dict_)
                 i1.second *= t->second;
-            return static_cast<Wrapper &>(*this);
+            return down_cast<Wrapper &>(*this);
         }
 
-        Wrapper res = Wrapper::mul(static_cast<Wrapper &>(*this), other);
+        Wrapper res = Wrapper::mul(down_cast<Wrapper &>(*this), other);
         res.dict_.swap(this->dict_);
-        return static_cast<Wrapper &>(*this);
+        return down_cast<Wrapper &>(*this);
     }
 
     bool operator==(const Wrapper &other) const

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -43,6 +43,7 @@ using SymEngine::pi;
 using SymEngine::diff;
 using SymEngine::sdiff;
 using SymEngine::DivisionByZeroError;
+using SymEngine::down_cast;
 
 using namespace SymEngine::literals;
 
@@ -666,12 +667,11 @@ TEST_CASE("Complex: Basic", "[basic]")
 
     // Basic check for equality in Complex::from_two_nums and
     // Complex::from_two_rats
+    REQUIRE(eq(*c1, *Complex::from_two_rats(down_cast<const Rational &>(*r1),
+                                            down_cast<const Rational &>(*r2))));
     REQUIRE(
-        eq(*c1, *Complex::from_two_rats(static_cast<const Rational &>(*r1),
-                                        static_cast<const Rational &>(*r2))));
-    REQUIRE(
-        neq(*c2, *Complex::from_two_rats(static_cast<const Rational &>(*r1),
-                                         static_cast<const Rational &>(*r2))));
+        neq(*c2, *Complex::from_two_rats(down_cast<const Rational &>(*r1),
+                                         down_cast<const Rational &>(*r2))));
 
     // Checks for complex addition
     // Final result is int

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -101,6 +101,7 @@ using SymEngine::Rational;
 using SymEngine::rcp_static_cast;
 using SymEngine::I;
 using SymEngine::integer_class;
+using SymEngine::down_cast;
 #if SYMENGINE_INTEGER_CLASS != SYMENGINE_BOOSTMP
 using SymEngine::get_mpz_t;
 #endif
@@ -255,9 +256,9 @@ TEST_CASE("Sin: functions", "[functions]")
     r2 = sin(sub(div(pi, i2), real_double(2.0)));
     REQUIRE(is_a<RealDouble>(*r1));
     REQUIRE(is_a<RealDouble>(*r2));
-    REQUIRE(std::abs(static_cast<const RealDouble &>(*r1).i - 0.841470984807897)
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.841470984807897)
             < 1e-12);
-    REQUIRE(std::abs(static_cast<const RealDouble &>(*r2).i + 0.416146836547142)
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r2).i + 0.416146836547142)
             < 1e-12);
 }
 
@@ -369,9 +370,9 @@ TEST_CASE("Cos: functions", "[functions]")
     r2 = cos(sub(div(pi, i2), real_double(2.0)));
     REQUIRE(is_a<RealDouble>(*r1));
     REQUIRE(is_a<RealDouble>(*r2));
-    REQUIRE(std::abs(static_cast<const RealDouble &>(*r1).i - 0.540302305868140)
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.540302305868140)
             < 1e-12);
-    REQUIRE(std::abs(static_cast<const RealDouble &>(*r2).i - 0.909297426825682)
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r2).i - 0.909297426825682)
             < 1e-12);
 }
 
@@ -1543,17 +1544,17 @@ TEST_CASE("Asin: functions", "[functions]")
 
     r1 = asin(real_double(0.5));
     REQUIRE(is_a<RealDouble>(*r1));
-    REQUIRE(std::abs(static_cast<const RealDouble &>(*r1).i - 0.523598775598299)
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.523598775598299)
             < 1e-12);
 
     r1 = asin(complex_double(std::complex<double>(1, 1)));
     r2 = asin(real_double(2.0));
     REQUIRE(is_a<ComplexDouble>(*r1));
     REQUIRE(is_a<ComplexDouble>(*r2));
-    REQUIRE(std::abs(std::abs(static_cast<const ComplexDouble &>(*r1).i)
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r1).i)
                      - 1.2530681300031)
             < 1e-10);
-    REQUIRE(std::abs(std::abs(static_cast<const ComplexDouble &>(*r2).i)
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
                      - 2.0498241882037)
             < 1e-10);
 }
@@ -2112,17 +2113,17 @@ TEST_CASE("Atanh: functions", "[functions]")
 
     r1 = atanh(real_double(0.5));
     REQUIRE(is_a<RealDouble>(*r1));
-    REQUIRE(std::abs(static_cast<const RealDouble &>(*r1).i - 0.549306144334055)
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.549306144334055)
             < 1e-12);
 
     r1 = atanh(complex_double(std::complex<double>(1, 1)));
     r2 = atanh(real_double(2.0));
     REQUIRE(is_a<ComplexDouble>(*r1));
     REQUIRE(is_a<ComplexDouble>(*r2));
-    REQUIRE(std::abs(std::abs(static_cast<const ComplexDouble &>(*r1).i)
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r1).i)
                      - 1.09390752881482)
             < 1e-12);
-    REQUIRE(std::abs(std::abs(static_cast<const ComplexDouble &>(*r2).i)
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
                      - 1.66407281705924)
             < 1e-12);
 }
@@ -2738,17 +2739,15 @@ TEST_CASE("MPFR and MPC: functions", "[functions]")
     REQUIRE(is_a<RealMPFR>(*r1));
     REQUIRE(is_a<RealMPFR>(*r2));
 
-    mpfr_mul_z(a.get_mpfr_t(),
-               static_cast<const RealMPFR &>(*r1).i.get_mpfr_t(), get_mpz_t(p),
-               MPFR_RNDN);
+    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r1).i.get_mpfr_t(),
+               get_mpz_t(p), MPFR_RNDN);
     q = 84147098480789650_z;
     REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
     q = 84147098480789651_z;
     REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
 
-    mpfr_mul_z(a.get_mpfr_t(),
-               static_cast<const RealMPFR &>(*r2).i.get_mpfr_t(), get_mpz_t(p),
-               MPFR_RNDN);
+    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r2).i.get_mpfr_t(),
+               get_mpz_t(p), MPFR_RNDN);
     q = -41614683654714239_z;
     REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
     q = -41614683654714238_z;
@@ -2757,9 +2756,8 @@ TEST_CASE("MPFR and MPC: functions", "[functions]")
     mpfr_set_ui(a.get_mpfr_t(), 3, MPFR_RNDN);
     r1 = gamma(div(real_mpfr(a), i2));
     REQUIRE(is_a<RealMPFR>(*r1));
-    mpfr_mul_z(a.get_mpfr_t(),
-               static_cast<const RealMPFR &>(*r1).i.get_mpfr_t(), get_mpz_t(p),
-               MPFR_RNDN);
+    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r1).i.get_mpfr_t(),
+               get_mpz_t(p), MPFR_RNDN);
     q = 88622692545275801_z;
     REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
     q = 88622692545275802_z;
@@ -2774,7 +2772,7 @@ TEST_CASE("MPFR and MPC: functions", "[functions]")
     mpfr_set_si(a.get_mpfr_t(), 2, MPFR_RNDN);
     r1 = asin(real_mpfr(a));
     REQUIRE(is_a<ComplexMPC>(*r1));
-    mpc_srcptr b = static_cast<const ComplexMPC &>(*r1).i.get_mpc_t();
+    mpc_srcptr b = down_cast<const ComplexMPC &>(*r1).i.get_mpc_t();
     mpc_real(a.get_mpfr_t(), b, MPFR_RNDN);
     mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
     q = 157079632679489661_z;
@@ -2793,7 +2791,7 @@ TEST_CASE("MPFR and MPC: functions", "[functions]")
     mpc_set_si_si(c.get_mpc_t(), 1, 1, MPFR_RNDN);
     r1 = asin(complex_mpc(c));
     REQUIRE(is_a<ComplexMPC>(*r1));
-    b = static_cast<const ComplexMPC &>(*r1).i.get_mpc_t();
+    b = down_cast<const ComplexMPC &>(*r1).i.get_mpc_t();
     mpc_real(a.get_mpfr_t(), b, MPFR_RNDN);
     mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
     q = 66623943249251525_z;

--- a/symengine/tests/basic/test_number.cpp
+++ b/symengine/tests/basic/test_number.cpp
@@ -26,6 +26,7 @@ using SymEngine::eval_double;
 using SymEngine::integer_class;
 using SymEngine::rational_class;
 using SymEngine::hash_t;
+using SymEngine::down_cast;
 #ifdef HAVE_SYMENGINE_MPFR
 using SymEngine::mpfr_class;
 using SymEngine::real_mpfr;
@@ -288,11 +289,11 @@ TEST_CASE("Test NumberWrapper", "[number]")
         //! true if `this` is equal to `o`.
         virtual bool __eq__(const Basic &o) const
         {
-            return i_ == static_cast<const Long &>(o).i_;
+            return i_ == down_cast<const Long &>(o).i_;
         };
         virtual int compare(const Basic &o) const
         {
-            long j = static_cast<const Long &>(o).i_;
+            long j = down_cast<const Long &>(o).i_;
             if (i_ == j)
                 return 0;
             return i_ > j ? 1 : -1;

--- a/symengine/tests/basic/test_parser.cpp
+++ b/symengine/tests/basic/test_parser.cpp
@@ -38,6 +38,7 @@ using SymEngine::gamma;
 using SymEngine::UIntPoly;
 using SymEngine::from_basic;
 using SymEngine::ParseError;
+using SymEngine::down_cast;
 
 using namespace SymEngine::literals;
 
@@ -325,13 +326,13 @@ TEST_CASE("Parsing: doubles", "[parser]")
     s = "1.324/(2+3)";
     res = parse(s);
     REQUIRE(is_a<RealDouble>(*res));
-    d = static_cast<const RealDouble &>(*res).as_double();
+    d = down_cast<const RealDouble &>(*res).as_double();
     REQUIRE(std::abs(d - 0.2648) < 1e-12);
 
     s = "sqrt(2.0)+5";
     res = parse(s);
     REQUIRE(is_a<RealDouble>(*res));
-    d = static_cast<const RealDouble &>(*res).as_double();
+    d = down_cast<const RealDouble &>(*res).as_double();
     REQUIRE(std::abs(d - (::sqrt(2) + 5)) < 1e-12);
 }
 

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -38,6 +38,7 @@ using SymEngine::integer_class;
 using SymEngine::map_uint_mpz;
 using SymEngine::Infty;
 using SymEngine::infty;
+using SymEngine::down_cast;
 
 using namespace SymEngine::literals;
 
@@ -126,10 +127,10 @@ TEST_CASE("test_printing(): printing", "[printing]")
     rn2 = Rational::from_two_ints(*integer(5), *integer(7));
     rn3 = Rational::from_two_ints(*integer(-5), *integer(7));
 
-    c1 = Complex::from_two_rats(static_cast<const Rational &>(*rn1),
-                                static_cast<const Rational &>(*rn2));
-    c2 = Complex::from_two_rats(static_cast<const Rational &>(*rn1),
-                                static_cast<const Rational &>(*rn3));
+    c1 = Complex::from_two_rats(down_cast<const Rational &>(*rn1),
+                                down_cast<const Rational &>(*rn2));
+    c2 = Complex::from_two_rats(down_cast<const Rational &>(*rn1),
+                                down_cast<const Rational &>(*rn3));
     r1 = mul(c1, x);
     r2 = mul(c2, x);
     REQUIRE(c1->__str__() == "1/2 + 5/7*I");


### PR DESCRIPTION
Some more simple fixes for #1139.
The commits currently cover:
```
cwrapper.cpp
test_basic.cpp
test_parser.cpp
test_functions.cpp
test_printing.cpp
test_number.cpp
```
Additionally, I feel that our use of static_cast() in the following files is essential, as only type conversions are done there, (and no Base-to-Derived or Derived-to-Base pointer changes):
```
basic-inl.h
test_evalf.cpp
```