### PR TITLE
added type id variable instead of virtual getter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,10 @@ endif()
 set(INTEGER_CLASS "gmp"
     CACHE STRING "Integer class for symengine. Either gmp, gmpxx, flint or piranha")
 
+# Virtual TypeID
+set(WITH_VIRTUAL_TYPEID no CACHE BOOL "Use virtual TypeID getter")
+set(USE_VIRTUAL_TYPEID False)
+
 # Piranha
 set(WITH_PIRANHA no CACHE BOOL "Build with Piranha")
 
@@ -223,6 +227,11 @@ set(HAVE_SYMENGINE_MPFR False)
 set(WITH_MPC no
     CACHE BOOL "Build with MPC")
 set(HAVE_SYMENGINE_MPC False)
+
+# Virtual TypeID
+if (WITH_VIRTUAL_TYPEID)
+    set(USE_VIRTUAL_TYPEID True)
+endif()
 
 if (WITH_FLINT)
     find_package(FLINT REQUIRED)
@@ -674,6 +683,7 @@ if (WITH_TCMALLOC)
 endif()
 
 message("WITH_OPENMP: ${WITH_OPENMP}")
+message("WITH_VIRTUAL_TYPEID: ${WITH_VIRTUAL_TYPEID}")
 
 message("")
 message("--------------------------------------------------------------------------------")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ set(INTEGER_CLASS "gmp"
 
 # Virtual TypeID
 set(WITH_VIRTUAL_TYPEID no CACHE BOOL "Use virtual TypeID getter")
-set(USE_VIRTUAL_TYPEID False)
+set(WITH_SYMENGINE_VIRTUAL_TYPEID False)
 
 # Piranha
 set(WITH_PIRANHA no CACHE BOOL "Build with Piranha")
@@ -230,7 +230,7 @@ set(HAVE_SYMENGINE_MPC False)
 
 # Virtual TypeID
 if (WITH_VIRTUAL_TYPEID)
-    set(USE_VIRTUAL_TYPEID True)
+    set(WITH_SYMENGINE_VIRTUAL_TYPEID True)
 endif()
 
 if (WITH_FLINT)

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -8,6 +8,7 @@ namespace SymEngine
 Add::Add(const RCP<const Number> &coef, umap_basic_num &&dict)
     : coef_{coef}, dict_{std::move(dict)}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(coef, dict_))
 }
 

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -8,7 +8,7 @@ namespace SymEngine
 Add::Add(const RCP<const Number> &coef, umap_basic_num &&dict)
     : coef_{coef}, dict_{std::move(dict)}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(coef, dict_))
 }
 

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -97,7 +97,7 @@ private:
     mutable hash_t hash_; // This holds the hash value
 #endif // WITH_SYMENGINE_THREAD_SAFE
 public:
-#ifdef WITH_VIRTUAL_TYPEID
+#ifdef USE_VIRTUAL_TYPEID
     virtual TypeID get_type_code() const = 0;
 #else
     TypeID type_code_;
@@ -277,7 +277,7 @@ struct hash<SymEngine::Basic>;
 #include "basic-inl.h"
 
 // Macro to define the type_code_id variable and its getter method
-#ifdef WITH_VIRTUAL_TYPEID
+#ifdef USE_VIRTUAL_TYPEID
 #define IMPLEMENT_TYPEID(ID)                                                   \
     /*! Type_code_id shared by all instances */                                \
     const static TypeID type_code_id = ID;                                     \
@@ -294,7 +294,7 @@ struct hash<SymEngine::Basic>;
     SYMENGINE_INCLUDE_METHODS(;)
 #endif
 
-#ifdef WITH_VIRTUAL_TYPEID
+#ifdef USE_VIRTUAL_TYPEID
 #define ASSIGN_TYPEID()
 #else
 #define ASSIGN_TYPEID() this->type_code_ = type_code_id;

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -97,7 +97,15 @@ private:
     mutable hash_t hash_; // This holds the hash value
 #endif // WITH_SYMENGINE_THREAD_SAFE
 public:
+#ifdef WITH_VIRTUAL_TYPEID
     virtual TypeID get_type_code() const = 0;
+#else
+    TypeID type_code_;
+    inline TypeID get_type_code() const
+    {
+        return type_code_;
+    };
+#endif
     //! Constructor
     Basic() : hash_{0}
     {
@@ -269,6 +277,7 @@ struct hash<SymEngine::Basic>;
 #include "basic-inl.h"
 
 // Macro to define the type_code_id variable and its getter method
+#ifdef WITH_VIRTUAL_TYPEID
 #define IMPLEMENT_TYPEID(ID)                                                   \
     /*! Type_code_id shared by all instances */                                \
     const static TypeID type_code_id = ID;                                     \
@@ -278,5 +287,17 @@ struct hash<SymEngine::Basic>;
         return type_code_id;                                                   \
     };                                                                         \
     SYMENGINE_INCLUDE_METHODS(;)
+#else
+#define IMPLEMENT_TYPEID(ID)                                                   \
+    /*! Type_code_id shared by all instances */                                \
+    const static TypeID type_code_id = ID;                                     \
+    SYMENGINE_INCLUDE_METHODS(;)
+#endif
+
+#ifdef WITH_VIRTUAL_TYPEID
+#define ASSIGN_TYPEID()
+#else
+#define ASSIGN_TYPEID() this->type_code_ = type_code_id;
+#endif
 
 #endif

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -97,7 +97,7 @@ private:
     mutable hash_t hash_; // This holds the hash value
 #endif // WITH_SYMENGINE_THREAD_SAFE
 public:
-#ifdef USE_VIRTUAL_TYPEID
+#ifdef WITH_SYMENGINE_VIRTUAL_TYPEID
     virtual TypeID get_type_code() const = 0;
 #else
     TypeID type_code_;
@@ -277,7 +277,7 @@ struct hash<SymEngine::Basic>;
 #include "basic-inl.h"
 
 // Macro to define the type_code_id variable and its getter method
-#ifdef USE_VIRTUAL_TYPEID
+#ifdef WITH_SYMENGINE_VIRTUAL_TYPEID
 #define IMPLEMENT_TYPEID(ID)                                                   \
     /*! Type_code_id shared by all instances */                                \
     const static TypeID type_code_id = ID;                                     \
@@ -294,10 +294,10 @@ struct hash<SymEngine::Basic>;
     SYMENGINE_INCLUDE_METHODS(;)
 #endif
 
-#ifdef USE_VIRTUAL_TYPEID
-#define ASSIGN_TYPEID()
+#ifdef WITH_SYMENGINE_VIRTUAL_TYPEID
+#define SYMENGINE_ASSIGN_TYPEID()
 #else
-#define ASSIGN_TYPEID() this->type_code_ = type_code_id;
+#define SYMENGINE_ASSIGN_TYPEID() this->type_code_ = type_code_id;
 #endif
 
 #endif

--- a/symengine/complex.cpp
+++ b/symengine/complex.cpp
@@ -7,7 +7,7 @@ namespace SymEngine
 Complex::Complex(rational_class real, rational_class imaginary)
     : real_{real}, imaginary_{imaginary}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(this->real_, this->imaginary_))
 }
 

--- a/symengine/complex.cpp
+++ b/symengine/complex.cpp
@@ -7,6 +7,7 @@ namespace SymEngine
 Complex::Complex(rational_class real, rational_class imaginary)
     : real_{real}, imaginary_{imaginary}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(this->real_, this->imaginary_))
 }
 

--- a/symengine/complex_double.cpp
+++ b/symengine/complex_double.cpp
@@ -10,7 +10,7 @@ namespace SymEngine
 
 ComplexDouble::ComplexDouble(std::complex<double> i)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     this->i = i;
 }
 //! Get the real part of the complex number

--- a/symengine/complex_double.cpp
+++ b/symengine/complex_double.cpp
@@ -10,6 +10,7 @@ namespace SymEngine
 
 ComplexDouble::ComplexDouble(std::complex<double> i)
 {
+    ASSIGN_TYPEID()
     this->i = i;
 }
 //! Get the real part of the complex number

--- a/symengine/complex_mpc.cpp
+++ b/symengine/complex_mpc.cpp
@@ -12,7 +12,7 @@ namespace SymEngine
 
 ComplexMPC::ComplexMPC(mpc_class i) : i{std::move(i)}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t ComplexMPC::__hash__() const

--- a/symengine/complex_mpc.cpp
+++ b/symengine/complex_mpc.cpp
@@ -12,6 +12,7 @@ namespace SymEngine
 
 ComplexMPC::ComplexMPC(mpc_class i) : i{std::move(i)}
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t ComplexMPC::__hash__() const

--- a/symengine/constants.cpp
+++ b/symengine/constants.cpp
@@ -8,6 +8,7 @@ namespace SymEngine
 
 Constant::Constant(const std::string &name) : name_{name}
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t Constant::__hash__() const

--- a/symengine/constants.cpp
+++ b/symengine/constants.cpp
@@ -8,7 +8,7 @@ namespace SymEngine
 
 Constant::Constant(const std::string &name) : name_{name}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t Constant::__hash__() const

--- a/symengine/fields.cpp
+++ b/symengine/fields.cpp
@@ -10,7 +10,7 @@ namespace SymEngine
 GaloisField::GaloisField(const RCP<const Basic> &var, GaloisFieldDict &&dict)
     : UIntPolyBase(var, std::move(dict))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 

--- a/symengine/fields.cpp
+++ b/symengine/fields.cpp
@@ -10,6 +10,7 @@ namespace SymEngine
 GaloisField::GaloisField(const RCP<const Basic> &var, GaloisFieldDict &&dict)
     : UIntPolyBase(var, std::move(dict))
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -326,7 +326,7 @@ bool inverse_lookup(umap_basic_basic &d, const RCP<const Basic> &t,
 
 Sin::Sin(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -394,7 +394,7 @@ RCP<const Basic> sin(const RCP<const Basic> &arg)
 
 Cos::Cos(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -460,7 +460,7 @@ RCP<const Basic> cos(const RCP<const Basic> &arg)
 
 Tan::Tan(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -527,7 +527,7 @@ RCP<const Basic> tan(const RCP<const Basic> &arg)
 
 Cot::Cot(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -592,7 +592,7 @@ RCP<const Basic> cot(const RCP<const Basic> &arg)
 
 Csc::Csc(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -657,7 +657,7 @@ RCP<const Basic> csc(const RCP<const Basic> &arg)
 
 Sec::Sec(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -817,7 +817,7 @@ RCP<const Basic> trig_to_sqrt(const RCP<const Basic> &arg)
 /* ---------------------------- */
 ASin::ASin(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -860,7 +860,7 @@ RCP<const Basic> asin(const RCP<const Basic> &arg)
 
 ACos::ACos(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -903,7 +903,7 @@ RCP<const Basic> acos(const RCP<const Basic> &arg)
 
 ASec::ASec(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -944,7 +944,7 @@ RCP<const Basic> asec(const RCP<const Basic> &arg)
 
 ACsc::ACsc(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -985,7 +985,7 @@ RCP<const Basic> acsc(const RCP<const Basic> &arg)
 
 ATan::ATan(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1028,7 +1028,7 @@ RCP<const Basic> atan(const RCP<const Basic> &arg)
 
 ACot::ACot(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1072,7 +1072,7 @@ RCP<const Basic> acot(const RCP<const Basic> &arg)
 ATan2::ATan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
     : TwoArgFunction(num, den)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(num, den))
 }
 
@@ -1222,7 +1222,7 @@ RCP<const Basic> ACsc::create(const RCP<const Basic> &arg) const
 /* ---------------------------- */
 LambertW::LambertW(const RCP<const Basic> &arg) : OneArgFunction{arg}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1260,14 +1260,14 @@ RCP<const Basic> lambertw(const RCP<const Basic> &arg)
 FunctionSymbol::FunctionSymbol(std::string name, const RCP<const Basic> &arg)
     : name_{name}, arg_{{arg}}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg_))
 }
 
 FunctionSymbol::FunctionSymbol(std::string name, const vec_basic &arg)
     : name_{name}, arg_{arg}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg_))
 }
 
@@ -1322,13 +1322,13 @@ RCP<const Basic> function_symbol(std::string name, const RCP<const Basic> &arg)
 FunctionWrapper::FunctionWrapper(std::string name, const RCP<const Basic> &arg)
     : FunctionSymbol(name, arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 FunctionWrapper::FunctionWrapper(std::string name, const vec_basic &vec)
     : FunctionSymbol(name, vec)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 /* ---------------------------- */
@@ -1336,7 +1336,7 @@ FunctionWrapper::FunctionWrapper(std::string name, const vec_basic &vec)
 Derivative::Derivative(const RCP<const Basic> &arg, const multiset_basic &x)
     : arg_{arg}, x_{x}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg, x))
 }
 
@@ -1434,7 +1434,7 @@ int Derivative::compare(const Basic &o) const
 Subs::Subs(const RCP<const Basic> &arg, const map_basic_basic &dict)
     : arg_{arg}, dict_{dict}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg, dict))
 }
 
@@ -1509,7 +1509,7 @@ vec_basic Subs::get_args() const
 
 Sinh::Sinh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1555,7 +1555,7 @@ RCP<const Basic> Sinh::expand_as_exp() const
 
 Csch::Csch(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1605,7 +1605,7 @@ RCP<const Basic> Csch::expand_as_exp() const
 
 Cosh::Cosh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1651,7 +1651,7 @@ RCP<const Basic> Cosh::expand_as_exp() const
 
 Sech::Sech(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1699,7 +1699,7 @@ RCP<const Basic> Sech::expand_as_exp() const
 
 Tanh::Tanh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1747,7 +1747,7 @@ RCP<const Basic> Tanh::expand_as_exp() const
 
 Coth::Coth(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1797,7 +1797,7 @@ RCP<const Basic> Coth::expand_as_exp() const
 
 ASinh::ASinh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1842,7 +1842,7 @@ RCP<const Basic> asinh(const RCP<const Basic> &arg)
 
 ACsch::ACsch(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1877,7 +1877,7 @@ RCP<const Basic> acsch(const RCP<const Basic> &arg)
 
 ACosh::ACosh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1906,7 +1906,7 @@ RCP<const Basic> acosh(const RCP<const Basic> &arg)
 
 ATanh::ATanh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1947,7 +1947,7 @@ RCP<const Basic> atanh(const RCP<const Basic> &arg)
 
 ACoth::ACoth(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1984,7 +1984,7 @@ RCP<const Basic> acoth(const RCP<const Basic> &arg)
 
 ASech::ASech(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -2069,7 +2069,7 @@ KroneckerDelta::KroneckerDelta(const RCP<const Basic> &i,
                                const RCP<const Basic> &j)
     : TwoArgFunction(i, j)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(i, j))
 }
 
@@ -2125,7 +2125,7 @@ bool has_dup(const vec_basic &arg)
 
 LeviCivita::LeviCivita(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 
@@ -2189,13 +2189,13 @@ RCP<const Basic> levi_civita(const vec_basic &arg)
 Zeta::Zeta(const RCP<const Basic> &s, const RCP<const Basic> &a)
     : TwoArgFunction(s, a)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, a))
 }
 
 Zeta::Zeta(const RCP<const Basic> &s) : TwoArgFunction(s, one)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, one))
 }
 
@@ -2259,7 +2259,7 @@ RCP<const Basic> zeta(const RCP<const Basic> &s)
 
 Dirichlet_eta::Dirichlet_eta(const RCP<const Basic> &s) : OneArgFunction(s)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s))
 }
 
@@ -2349,7 +2349,7 @@ RCP<const Basic> erfc(const RCP<const Basic> &arg)
 
 Gamma::Gamma(const RCP<const Basic> &arg) : OneArgFunction{arg}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -2439,7 +2439,7 @@ RCP<const Basic> gamma(const RCP<const Basic> &arg)
 LowerGamma::LowerGamma(const RCP<const Basic> &s, const RCP<const Basic> &x)
     : TwoArgFunction(s, x)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, x))
 }
 
@@ -2497,7 +2497,7 @@ RCP<const Basic> lowergamma(const RCP<const Basic> &s,
 UpperGamma::UpperGamma(const RCP<const Basic> &s, const RCP<const Basic> &x)
     : TwoArgFunction(s, x)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, x))
 }
 
@@ -2806,7 +2806,7 @@ RCP<const Basic> polygamma(const RCP<const Basic> &n_,
 
 Abs::Abs(const RCP<const Basic> &arg) : OneArgFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -2864,7 +2864,7 @@ RCP<const Basic> abs(const RCP<const Basic> &arg)
 
 Max::Max(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 
@@ -2968,7 +2968,7 @@ RCP<const Basic> max(const vec_basic &arg)
 
 Min::Min(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -326,6 +326,7 @@ bool inverse_lookup(umap_basic_basic &d, const RCP<const Basic> &t,
 
 Sin::Sin(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -393,6 +394,7 @@ RCP<const Basic> sin(const RCP<const Basic> &arg)
 
 Cos::Cos(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -458,6 +460,7 @@ RCP<const Basic> cos(const RCP<const Basic> &arg)
 
 Tan::Tan(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -524,6 +527,7 @@ RCP<const Basic> tan(const RCP<const Basic> &arg)
 
 Cot::Cot(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -588,6 +592,7 @@ RCP<const Basic> cot(const RCP<const Basic> &arg)
 
 Csc::Csc(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -652,6 +657,7 @@ RCP<const Basic> csc(const RCP<const Basic> &arg)
 
 Sec::Sec(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -811,6 +817,7 @@ RCP<const Basic> trig_to_sqrt(const RCP<const Basic> &arg)
 /* ---------------------------- */
 ASin::ASin(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -853,6 +860,7 @@ RCP<const Basic> asin(const RCP<const Basic> &arg)
 
 ACos::ACos(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -895,6 +903,7 @@ RCP<const Basic> acos(const RCP<const Basic> &arg)
 
 ASec::ASec(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -935,6 +944,7 @@ RCP<const Basic> asec(const RCP<const Basic> &arg)
 
 ACsc::ACsc(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -975,6 +985,7 @@ RCP<const Basic> acsc(const RCP<const Basic> &arg)
 
 ATan::ATan(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1017,6 +1028,7 @@ RCP<const Basic> atan(const RCP<const Basic> &arg)
 
 ACot::ACot(const RCP<const Basic> &arg) : TrigFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1060,6 +1072,7 @@ RCP<const Basic> acot(const RCP<const Basic> &arg)
 ATan2::ATan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
     : TwoArgFunction(num, den)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(num, den))
 }
 
@@ -1209,6 +1222,7 @@ RCP<const Basic> ACsc::create(const RCP<const Basic> &arg) const
 /* ---------------------------- */
 LambertW::LambertW(const RCP<const Basic> &arg) : OneArgFunction{arg}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1246,12 +1260,14 @@ RCP<const Basic> lambertw(const RCP<const Basic> &arg)
 FunctionSymbol::FunctionSymbol(std::string name, const RCP<const Basic> &arg)
     : name_{name}, arg_{{arg}}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg_))
 }
 
 FunctionSymbol::FunctionSymbol(std::string name, const vec_basic &arg)
     : name_{name}, arg_{arg}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg_))
 }
 
@@ -1306,11 +1322,13 @@ RCP<const Basic> function_symbol(std::string name, const RCP<const Basic> &arg)
 FunctionWrapper::FunctionWrapper(std::string name, const RCP<const Basic> &arg)
     : FunctionSymbol(name, arg)
 {
+    ASSIGN_TYPEID()
 }
 
 FunctionWrapper::FunctionWrapper(std::string name, const vec_basic &vec)
     : FunctionSymbol(name, vec)
 {
+    ASSIGN_TYPEID()
 }
 
 /* ---------------------------- */
@@ -1318,6 +1336,7 @@ FunctionWrapper::FunctionWrapper(std::string name, const vec_basic &vec)
 Derivative::Derivative(const RCP<const Basic> &arg, const multiset_basic &x)
     : arg_{arg}, x_{x}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg, x))
 }
 
@@ -1415,6 +1434,7 @@ int Derivative::compare(const Basic &o) const
 Subs::Subs(const RCP<const Basic> &arg, const map_basic_basic &dict)
     : arg_{arg}, dict_{dict}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg, dict))
 }
 
@@ -1489,6 +1509,7 @@ vec_basic Subs::get_args() const
 
 Sinh::Sinh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1534,6 +1555,7 @@ RCP<const Basic> Sinh::expand_as_exp() const
 
 Csch::Csch(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1583,6 +1605,7 @@ RCP<const Basic> Csch::expand_as_exp() const
 
 Cosh::Cosh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1628,6 +1651,7 @@ RCP<const Basic> Cosh::expand_as_exp() const
 
 Sech::Sech(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1675,6 +1699,7 @@ RCP<const Basic> Sech::expand_as_exp() const
 
 Tanh::Tanh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1722,6 +1747,7 @@ RCP<const Basic> Tanh::expand_as_exp() const
 
 Coth::Coth(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1771,6 +1797,7 @@ RCP<const Basic> Coth::expand_as_exp() const
 
 ASinh::ASinh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1815,6 +1842,7 @@ RCP<const Basic> asinh(const RCP<const Basic> &arg)
 
 ACsch::ACsch(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1849,6 +1877,7 @@ RCP<const Basic> acsch(const RCP<const Basic> &arg)
 
 ACosh::ACosh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1877,6 +1906,7 @@ RCP<const Basic> acosh(const RCP<const Basic> &arg)
 
 ATanh::ATanh(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1917,6 +1947,7 @@ RCP<const Basic> atanh(const RCP<const Basic> &arg)
 
 ACoth::ACoth(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -1953,6 +1984,7 @@ RCP<const Basic> acoth(const RCP<const Basic> &arg)
 
 ASech::ASech(const RCP<const Basic> &arg) : HyperbolicFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -2037,6 +2069,7 @@ KroneckerDelta::KroneckerDelta(const RCP<const Basic> &i,
                                const RCP<const Basic> &j)
     : TwoArgFunction(i, j)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(i, j))
 }
 
@@ -2092,6 +2125,7 @@ bool has_dup(const vec_basic &arg)
 
 LeviCivita::LeviCivita(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 
@@ -2155,11 +2189,13 @@ RCP<const Basic> levi_civita(const vec_basic &arg)
 Zeta::Zeta(const RCP<const Basic> &s, const RCP<const Basic> &a)
     : TwoArgFunction(s, a)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, a))
 }
 
 Zeta::Zeta(const RCP<const Basic> &s) : TwoArgFunction(s, one)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, one))
 }
 
@@ -2223,6 +2259,7 @@ RCP<const Basic> zeta(const RCP<const Basic> &s)
 
 Dirichlet_eta::Dirichlet_eta(const RCP<const Basic> &s) : OneArgFunction(s)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s))
 }
 
@@ -2312,6 +2349,7 @@ RCP<const Basic> erfc(const RCP<const Basic> &arg)
 
 Gamma::Gamma(const RCP<const Basic> &arg) : OneArgFunction{arg}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -2401,6 +2439,7 @@ RCP<const Basic> gamma(const RCP<const Basic> &arg)
 LowerGamma::LowerGamma(const RCP<const Basic> &s, const RCP<const Basic> &x)
     : TwoArgFunction(s, x)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, x))
 }
 
@@ -2458,6 +2497,7 @@ RCP<const Basic> lowergamma(const RCP<const Basic> &s,
 UpperGamma::UpperGamma(const RCP<const Basic> &s, const RCP<const Basic> &x)
     : TwoArgFunction(s, x)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, x))
 }
 
@@ -2766,6 +2806,7 @@ RCP<const Basic> polygamma(const RCP<const Basic> &n_,
 
 Abs::Abs(const RCP<const Basic> &arg) : OneArgFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(arg))
 }
 
@@ -2823,6 +2864,7 @@ RCP<const Basic> abs(const RCP<const Basic> &arg)
 
 Max::Max(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 
@@ -2926,6 +2968,7 @@ RCP<const Basic> max(const vec_basic &arg)
 
 Min::Min(const vec_basic &&arg) : MultiArgFunction(std::move(arg))
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(get_vec()))
 }
 

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -913,6 +913,7 @@ public:
     //! Erf Constructor
     Erf(const RCP<const Basic> &arg) : OneArgFunction(arg)
     {
+        ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(arg))
     }
     //! \return `true` if canonical
@@ -937,6 +938,7 @@ public:
     //! Erfc Constructor
     Erfc(const RCP<const Basic> &arg) : OneArgFunction(arg)
     {
+        ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(arg))
     }
     //! \return `true` if canonical
@@ -1022,6 +1024,7 @@ public:
     //! LogGamma Constructor
     LogGamma(const RCP<const Basic> &arg) : OneArgFunction(arg)
     {
+        ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(arg))
     }
     //! \return `true` if canonical
@@ -1048,6 +1051,7 @@ public:
     Beta(const RCP<const Basic> &x, const RCP<const Basic> &y)
         : TwoArgFunction(x, y)
     {
+        ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(x, y))
     }
     //! return `Beta` with ordered arguments
@@ -1082,6 +1086,7 @@ public:
     PolyGamma(const RCP<const Basic> &n, const RCP<const Basic> &x)
         : TwoArgFunction(n, x)
     {
+        ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(n, x))
     }
     bool is_canonical(const RCP<const Basic> &n, const RCP<const Basic> &x);

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -913,7 +913,7 @@ public:
     //! Erf Constructor
     Erf(const RCP<const Basic> &arg) : OneArgFunction(arg)
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(arg))
     }
     //! \return `true` if canonical
@@ -938,7 +938,7 @@ public:
     //! Erfc Constructor
     Erfc(const RCP<const Basic> &arg) : OneArgFunction(arg)
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(arg))
     }
     //! \return `true` if canonical
@@ -1024,7 +1024,7 @@ public:
     //! LogGamma Constructor
     LogGamma(const RCP<const Basic> &arg) : OneArgFunction(arg)
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(arg))
     }
     //! \return `true` if canonical
@@ -1051,7 +1051,7 @@ public:
     Beta(const RCP<const Basic> &x, const RCP<const Basic> &y)
         : TwoArgFunction(x, y)
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(x, y))
     }
     //! return `Beta` with ordered arguments
@@ -1086,7 +1086,7 @@ public:
     PolyGamma(const RCP<const Basic> &n, const RCP<const Basic> &x)
         : TwoArgFunction(n, x)
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
         SYMENGINE_ASSERT(is_canonical(n, x))
     }
     bool is_canonical(const RCP<const Basic> &n, const RCP<const Basic> &x);

--- a/symengine/infinity.cpp
+++ b/symengine/infinity.cpp
@@ -10,12 +10,14 @@ namespace SymEngine
 
 Infty::Infty(const RCP<const Number> &direction)
 {
+    ASSIGN_TYPEID()
     _direction = direction;
     SYMENGINE_ASSERT(is_canonical(_direction));
 }
 
 Infty::Infty(const Infty &inf)
 {
+    ASSIGN_TYPEID()
     _direction = inf.get_direction();
     SYMENGINE_ASSERT(is_canonical(_direction))
 }

--- a/symengine/infinity.cpp
+++ b/symengine/infinity.cpp
@@ -10,14 +10,14 @@ namespace SymEngine
 
 Infty::Infty(const RCP<const Number> &direction)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     _direction = direction;
     SYMENGINE_ASSERT(is_canonical(_direction));
 }
 
 Infty::Infty(const Infty &inf)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     _direction = inf.get_direction();
     SYMENGINE_ASSERT(is_canonical(_direction))
 }

--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -27,9 +27,11 @@ public:
     // explicit Integer(integer_class i);
     Integer(const integer_class &_i) : i(_i)
     {
+        ASSIGN_TYPEID()
     }
     Integer(integer_class &&_i) : i(std::move(_i))
     {
+        ASSIGN_TYPEID()
     }
     //! \return size of the hash
     virtual hash_t __hash__() const;

--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -27,11 +27,11 @@ public:
     // explicit Integer(integer_class i);
     Integer(const integer_class &_i) : i(_i)
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
     Integer(integer_class &&_i) : i(std::move(_i))
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
     //! \return size of the hash
     virtual hash_t __hash__() const;

--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -5,6 +5,7 @@ namespace SymEngine
 
 BooleanAtom::BooleanAtom(bool b) : b_{b}
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t BooleanAtom::__hash__() const
@@ -47,6 +48,7 @@ RCP<const BooleanAtom> boolFalse = make_rcp<BooleanAtom>(false);
 Contains::Contains(const RCP<const Basic> &expr, const RCP<const Set> &set)
     : expr_{expr}, set_{set}
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t Contains::__hash__() const
@@ -104,6 +106,7 @@ RCP<const Boolean> contains(const RCP<const Basic> &expr,
 
 Piecewise::Piecewise(PiecewiseVec &&vec) : vec_(vec)
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t Piecewise::__hash__() const
@@ -146,6 +149,7 @@ int Piecewise::compare(const Basic &o) const
 
 And::And(const set_boolean &s) : container_{s}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s));
 }
 
@@ -197,6 +201,7 @@ const set_boolean &And::get_container() const
 
 Or::Or(const set_boolean &s) : container_{s}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s));
 }
 
@@ -248,6 +253,7 @@ const set_boolean &Or::get_container() const
 
 Not::Not(const RCP<const Boolean> &in) : arg_{in}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(in));
 }
 

--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -5,7 +5,7 @@ namespace SymEngine
 
 BooleanAtom::BooleanAtom(bool b) : b_{b}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t BooleanAtom::__hash__() const
@@ -48,7 +48,7 @@ RCP<const BooleanAtom> boolFalse = make_rcp<BooleanAtom>(false);
 Contains::Contains(const RCP<const Basic> &expr, const RCP<const Set> &set)
     : expr_{expr}, set_{set}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t Contains::__hash__() const
@@ -106,7 +106,7 @@ RCP<const Boolean> contains(const RCP<const Basic> &expr,
 
 Piecewise::Piecewise(PiecewiseVec &&vec) : vec_(vec)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t Piecewise::__hash__() const
@@ -149,7 +149,7 @@ int Piecewise::compare(const Basic &o) const
 
 And::And(const set_boolean &s) : container_{s}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s));
 }
 
@@ -201,7 +201,7 @@ const set_boolean &And::get_container() const
 
 Or::Or(const set_boolean &s) : container_{s}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s));
 }
 
@@ -253,7 +253,7 @@ const set_boolean &Or::get_container() const
 
 Not::Not(const RCP<const Boolean> &in) : arg_{in}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(in));
 }
 

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -9,6 +9,7 @@ namespace SymEngine
 Mul::Mul(const RCP<const Number> &coef, map_basic_basic &&dict)
     : coef_{coef}, dict_{std::move(dict)}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(coef, dict_))
 }
 

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -9,7 +9,7 @@ namespace SymEngine
 Mul::Mul(const RCP<const Number> &coef, map_basic_basic &&dict)
     : coef_{coef}, dict_{std::move(dict)}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(coef, dict_))
 }
 

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -133,6 +133,11 @@ inline bool is_a_Number(const Basic &b)
 class NumberWrapper : public Number
 {
 public:
+    NumberWrapper()
+    {
+        ASSIGN_TYPEID()
+    }
+
     IMPLEMENT_TYPEID(NUMBER_WRAPPER)
     virtual std::string __str__() const
     {

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -135,7 +135,7 @@ class NumberWrapper : public Number
 public:
     NumberWrapper()
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
 
     IMPLEMENT_TYPEID(NUMBER_WRAPPER)

--- a/symengine/polys/msymenginepoly.h
+++ b/symengine/polys/msymenginepoly.h
@@ -455,7 +455,7 @@ public:
     MIntPoly(const set_basic &vars, MIntDict &&dict)
         : MSymEnginePoly(vars, std::move(dict))
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
 
     IMPLEMENT_TYPEID(MINTPOLY);
@@ -472,7 +472,7 @@ public:
     MExprPoly(const set_basic &vars, MExprDict &&dict)
         : MSymEnginePoly(vars, std::move(dict))
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
 
     IMPLEMENT_TYPEID(MEXPRPOLY);

--- a/symengine/polys/msymenginepoly.h
+++ b/symengine/polys/msymenginepoly.h
@@ -455,6 +455,7 @@ public:
     MIntPoly(const set_basic &vars, MIntDict &&dict)
         : MSymEnginePoly(vars, std::move(dict))
     {
+        ASSIGN_TYPEID()
     }
 
     IMPLEMENT_TYPEID(MINTPOLY);
@@ -471,6 +472,7 @@ public:
     MExprPoly(const set_basic &vars, MExprDict &&dict)
         : MSymEnginePoly(vars, std::move(dict))
     {
+        ASSIGN_TYPEID()
     }
 
     IMPLEMENT_TYPEID(MEXPRPOLY);

--- a/symengine/polys/uexprpoly.cpp
+++ b/symengine/polys/uexprpoly.cpp
@@ -6,7 +6,7 @@ namespace SymEngine
 UExprPoly::UExprPoly(const RCP<const Basic> &var, UExprDict &&dict)
     : USymEnginePoly(var, std::move(dict))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 

--- a/symengine/polys/uexprpoly.cpp
+++ b/symengine/polys/uexprpoly.cpp
@@ -6,6 +6,7 @@ namespace SymEngine
 UExprPoly::UExprPoly(const RCP<const Basic> &var, UExprDict &&dict)
     : USymEnginePoly(var, std::move(dict))
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -6,6 +6,7 @@ namespace SymEngine
 UIntPoly::UIntPoly(const RCP<const Basic> &var, UIntDict &&dict)
     : USymEnginePoly(var, std::move(dict))
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -6,7 +6,7 @@ namespace SymEngine
 UIntPoly::UIntPoly(const RCP<const Basic> &var, UIntDict &&dict)
     : USymEnginePoly(var, std::move(dict))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 

--- a/symengine/polys/uintpoly_flint.cpp
+++ b/symengine/polys/uintpoly_flint.cpp
@@ -7,6 +7,7 @@ namespace SymEngine
 UIntPolyFlint::UIntPolyFlint(const RCP<const Basic> &var, fzp_t &&dict)
     : UFlintPoly(var, std::move(dict))
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t UIntPolyFlint::__hash__() const
@@ -22,6 +23,7 @@ hash_t UIntPolyFlint::__hash__() const
 URatPolyFlint::URatPolyFlint(const RCP<const Basic> &var, fqp_t &&dict)
     : UFlintPoly(var, std::move(dict))
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t URatPolyFlint::__hash__() const

--- a/symengine/polys/uintpoly_flint.cpp
+++ b/symengine/polys/uintpoly_flint.cpp
@@ -7,7 +7,7 @@ namespace SymEngine
 UIntPolyFlint::UIntPolyFlint(const RCP<const Basic> &var, fzp_t &&dict)
     : UFlintPoly(var, std::move(dict))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t UIntPolyFlint::__hash__() const
@@ -23,7 +23,7 @@ hash_t UIntPolyFlint::__hash__() const
 URatPolyFlint::URatPolyFlint(const RCP<const Basic> &var, fqp_t &&dict)
     : UFlintPoly(var, std::move(dict))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t URatPolyFlint::__hash__() const

--- a/symengine/polys/uintpoly_piranha.cpp
+++ b/symengine/polys/uintpoly_piranha.cpp
@@ -8,7 +8,7 @@ namespace SymEngine
 UIntPolyPiranha::UIntPolyPiranha(const RCP<const Basic> &var, pintpoly &&dict)
     : UPiranhaPoly(var, std::move(dict))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t UIntPolyPiranha::__hash__() const
@@ -22,7 +22,7 @@ hash_t UIntPolyPiranha::__hash__() const
 URatPolyPiranha::URatPolyPiranha(const RCP<const Basic> &var, pratpoly &&dict)
     : UPiranhaPoly(var, std::move(dict))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t URatPolyPiranha::__hash__() const

--- a/symengine/polys/uintpoly_piranha.cpp
+++ b/symengine/polys/uintpoly_piranha.cpp
@@ -8,6 +8,7 @@ namespace SymEngine
 UIntPolyPiranha::UIntPolyPiranha(const RCP<const Basic> &var, pintpoly &&dict)
     : UPiranhaPoly(var, std::move(dict))
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t UIntPolyPiranha::__hash__() const
@@ -21,6 +22,7 @@ hash_t UIntPolyPiranha::__hash__() const
 URatPolyPiranha::URatPolyPiranha(const RCP<const Basic> &var, pratpoly &&dict)
     : UPiranhaPoly(var, std::move(dict))
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t URatPolyPiranha::__hash__() const

--- a/symengine/polys/uratpoly.cpp
+++ b/symengine/polys/uratpoly.cpp
@@ -6,6 +6,7 @@ namespace SymEngine
 URatPoly::URatPoly(const RCP<const Basic> &var, URatDict &&dict)
     : USymEnginePoly(var, std::move(dict))
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 

--- a/symengine/polys/uratpoly.cpp
+++ b/symengine/polys/uratpoly.cpp
@@ -6,7 +6,7 @@ namespace SymEngine
 URatPoly::URatPoly(const RCP<const Basic> &var, URatDict &&dict)
     : USymEnginePoly(var, std::move(dict))
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(poly_))
 }
 

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -9,6 +9,7 @@ namespace SymEngine
 Pow::Pow(const RCP<const Basic> &base, const RCP<const Basic> &exp)
     : base_{base}, exp_{exp}
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(*base, *exp))
 }
 
@@ -260,6 +261,7 @@ RCP<const Basic> exp(const RCP<const Basic> &x)
 
 Log::Log(const RCP<const Basic> &arg) : OneArgFunction(arg)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(*arg))
 }
 

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -9,7 +9,7 @@ namespace SymEngine
 Pow::Pow(const RCP<const Basic> &base, const RCP<const Basic> &exp)
     : base_{base}, exp_{exp}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(*base, *exp))
 }
 
@@ -261,7 +261,7 @@ RCP<const Basic> exp(const RCP<const Basic> &x)
 
 Log::Log(const RCP<const Basic> &arg) : OneArgFunction(arg)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(*arg))
 }
 

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -23,7 +23,7 @@ public:
     //! Constructor of Rational class
     Rational(rational_class &&_i) : i(std::move(_i))
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
     /*! \param `i` must already be in rational_class canonical form
     *   \return Integer or Rational depending on denumerator.

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -23,6 +23,7 @@ public:
     //! Constructor of Rational class
     Rational(rational_class &&_i) : i(std::move(_i))
     {
+        ASSIGN_TYPEID()
     }
     /*! \param `i` must already be in rational_class canonical form
     *   \return Integer or Rational depending on denumerator.

--- a/symengine/real_double.cpp
+++ b/symengine/real_double.cpp
@@ -10,7 +10,7 @@ namespace SymEngine
 
 RealDouble::RealDouble(double i)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     this->i = i;
 }
 

--- a/symengine/real_double.cpp
+++ b/symengine/real_double.cpp
@@ -10,6 +10,7 @@ namespace SymEngine
 
 RealDouble::RealDouble(double i)
 {
+    ASSIGN_TYPEID()
     this->i = i;
 }
 

--- a/symengine/real_mpfr.cpp
+++ b/symengine/real_mpfr.cpp
@@ -12,6 +12,7 @@ namespace SymEngine
 
 RealMPFR::RealMPFR(mpfr_class i) : i{std::move(i)}
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t RealMPFR::__hash__() const

--- a/symengine/real_mpfr.cpp
+++ b/symengine/real_mpfr.cpp
@@ -12,7 +12,7 @@ namespace SymEngine
 
 RealMPFR::RealMPFR(mpfr_class i) : i{std::move(i)}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t RealMPFR::__hash__() const

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -8,6 +8,7 @@ URatPSeriesFlint::URatPSeriesFlint(fqp_t p, const std::string varname,
                                    const unsigned degree)
     : SeriesBase(std::move(p), varname, degree)
 {
+    ASSIGN_TYPEID()
 }
 RCP<const URatPSeriesFlint> URatPSeriesFlint::series(const RCP<const Basic> &t,
                                                      const std::string &x,

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -8,7 +8,7 @@ URatPSeriesFlint::URatPSeriesFlint(fqp_t p, const std::string varname,
                                    const unsigned degree)
     : SeriesBase(std::move(p), varname, degree)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 RCP<const URatPSeriesFlint> URatPSeriesFlint::series(const RCP<const Basic> &t,
                                                      const std::string &x,

--- a/symengine/series_generic.h
+++ b/symengine/series_generic.h
@@ -24,6 +24,7 @@ public:
                      const unsigned degree)
         : SeriesBase(std::move(sp), varname, degree)
     {
+        ASSIGN_TYPEID()
     }
 
     static RCP<const UnivariateSeries> create(const RCP<const Symbol> &var,

--- a/symengine/series_generic.h
+++ b/symengine/series_generic.h
@@ -24,7 +24,7 @@ public:
                      const unsigned degree)
         : SeriesBase(std::move(sp), varname, degree)
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
 
     static RCP<const UnivariateSeries> create(const RCP<const Symbol> &var,

--- a/symengine/series_piranha.cpp
+++ b/symengine/series_piranha.cpp
@@ -7,7 +7,7 @@ URatPSeriesPiranha::URatPSeriesPiranha(pp_t p, const std::string varname,
                                        const unsigned degree)
     : SeriesBase(std::move(p), varname, degree)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 RCP<const URatPSeriesPiranha>
 URatPSeriesPiranha::series(const RCP<const Basic> &t, const std::string &x,
@@ -181,7 +181,7 @@ UPSeriesPiranha::UPSeriesPiranha(p_expr p, const std::string varname,
                                  const unsigned degree)
     : SeriesBase(std::move(p), varname, degree)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 RCP<const UPSeriesPiranha> UPSeriesPiranha::series(const RCP<const Basic> &t,

--- a/symengine/series_piranha.cpp
+++ b/symengine/series_piranha.cpp
@@ -7,6 +7,7 @@ URatPSeriesPiranha::URatPSeriesPiranha(pp_t p, const std::string varname,
                                        const unsigned degree)
     : SeriesBase(std::move(p), varname, degree)
 {
+    ASSIGN_TYPEID()
 }
 RCP<const URatPSeriesPiranha>
 URatPSeriesPiranha::series(const RCP<const Basic> &t, const std::string &x,
@@ -180,6 +181,7 @@ UPSeriesPiranha::UPSeriesPiranha(p_expr p, const std::string varname,
                                  const unsigned degree)
     : SeriesBase(std::move(p), varname, degree)
 {
+    ASSIGN_TYPEID()
 }
 
 RCP<const UPSeriesPiranha> UPSeriesPiranha::series(const RCP<const Basic> &t,

--- a/symengine/sets.cpp
+++ b/symengine/sets.cpp
@@ -9,7 +9,7 @@ Interval::Interval(const RCP<const Number> &start, const RCP<const Number> &end,
                    const bool left_open, const bool right_open)
     : start_(start), end_(end), left_open_(left_open), right_open_(right_open)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(
         Interval::is_canonical(start_, end_, left_open_, right_open_));
 }
@@ -272,7 +272,7 @@ const RCP<const UniversalSet> &UniversalSet::getInstance()
 
 FiniteSet::FiniteSet(const set_basic container) : container_(container)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(FiniteSet::is_canonical(container_));
 }
 
@@ -395,7 +395,7 @@ RCP<const Set> FiniteSet::set_intersection(const RCP<const Set> &o) const
 
 Union::Union(set_set in) : container_(in)
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t Union::__hash__() const

--- a/symengine/sets.cpp
+++ b/symengine/sets.cpp
@@ -9,6 +9,7 @@ Interval::Interval(const RCP<const Number> &start, const RCP<const Number> &end,
                    const bool left_open, const bool right_open)
     : start_(start), end_(end), left_open_(left_open), right_open_(right_open)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(
         Interval::is_canonical(start_, end_, left_open_, right_open_));
 }
@@ -271,6 +272,7 @@ const RCP<const UniversalSet> &UniversalSet::getInstance()
 
 FiniteSet::FiniteSet(const set_basic container) : container_(container)
 {
+    ASSIGN_TYPEID()
     SYMENGINE_ASSERT(FiniteSet::is_canonical(container_));
 }
 
@@ -393,6 +395,7 @@ RCP<const Set> FiniteSet::set_intersection(const RCP<const Set> &o) const
 
 Union::Union(set_set in) : container_(in)
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t Union::__hash__() const

--- a/symengine/sets.h
+++ b/symengine/sets.h
@@ -47,10 +47,12 @@ public:
 
 class EmptySet : public Set
 {
-private:
-    EmptySet(){};
-
 public:
+    EmptySet()
+    {
+        ASSIGN_TYPEID()
+    }
+
     IMPLEMENT_TYPEID(EMPTYSET)
     // EmptySet(EmptySet const&) = delete;
     void operator=(EmptySet const &) = delete;
@@ -76,8 +78,11 @@ public:
 
 class UniversalSet : public Set
 {
-private:
-    UniversalSet(){};
+public:
+    UniversalSet()
+    {
+        ASSIGN_TYPEID()
+    }
 
 public:
     IMPLEMENT_TYPEID(UNIVERSALSET)

--- a/symengine/sets.h
+++ b/symengine/sets.h
@@ -50,7 +50,7 @@ class EmptySet : public Set
 public:
     EmptySet()
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
 
     IMPLEMENT_TYPEID(EMPTYSET)
@@ -81,7 +81,7 @@ class UniversalSet : public Set
 public:
     UniversalSet()
     {
-        ASSIGN_TYPEID()
+        SYMENGINE_ASSIGN_TYPEID()
     }
 
 public:

--- a/symengine/symbol.cpp
+++ b/symengine/symbol.cpp
@@ -6,7 +6,7 @@ namespace SymEngine
 
 Symbol::Symbol(const std::string &name) : name_{name}
 {
-    ASSIGN_TYPEID()
+    SYMENGINE_ASSIGN_TYPEID()
 }
 
 hash_t Symbol::__hash__() const

--- a/symengine/symbol.cpp
+++ b/symengine/symbol.cpp
@@ -6,6 +6,7 @@ namespace SymEngine
 
 Symbol::Symbol(const std::string &name) : name_{name}
 {
+    ASSIGN_TYPEID()
 }
 
 hash_t Symbol::__hash__() const

--- a/symengine/symengine_config.h.in
+++ b/symengine/symengine_config.h.in
@@ -24,6 +24,9 @@
 /* Define if you want to enable PRIMESIEVE support in SymEngine */
 #cmakedefine HAVE_SYMENGINE_PRIMESIEVE
 
+/* Define if you want to use virtual TypeIDs in SymEngine */
+#cmakedefine USE_VIRTUAL_TYPEID
+
 /* Define if you want to enable Flint support in SymEngine */
 #cmakedefine HAVE_SYMENGINE_FLINT
 

--- a/symengine/symengine_config.h.in
+++ b/symengine/symengine_config.h.in
@@ -25,7 +25,7 @@
 #cmakedefine HAVE_SYMENGINE_PRIMESIEVE
 
 /* Define if you want to use virtual TypeIDs in SymEngine */
-#cmakedefine USE_VIRTUAL_TYPEID
+#cmakedefine WITH_SYMENGINE_VIRTUAL_TYPEID
 
 /* Define if you want to enable Flint support in SymEngine */
 #cmakedefine HAVE_SYMENGINE_FLINT


### PR DESCRIPTION
Also added cmake option `WITH_VIRTUAL_TYPEID` for easy switching between the two modes. Still have to benchmark performance in the two modes.