### PR TITLE
Fix for #1154

### DIFF
--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -17,7 +17,7 @@ bool Pow::is_canonical(const Basic &base, const Basic &exp) const
 {
     // e.g. 0**x
     if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_zero())
-        return false;
+        return true;
     // e.g. 1**x
     if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_one())
         return false;
@@ -89,8 +89,19 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
     }
     if (eq(*b, *one))
         return a;
-    if (eq(*a, *zero))
-        return zero;
+
+    if (eq(*a, *zero)) {
+        if (is_a_Number(*b)
+            and rcp_static_cast<const Number>(b)->is_positive()) {
+            return zero;
+        } else if (is_a_Number(*b)
+                   and rcp_static_cast<const Number>(b)->is_negative()) {
+            return ComplexInf;
+        } else {
+            return make_rcp<const Pow>(a, b);
+        }
+    }
+
     if (eq(*a, *one))
         return one;
     if (eq(*a, *minus_one)) {

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -17,11 +17,11 @@ bool Pow::is_canonical(const Basic &base, const Basic &exp) const
 {
     // e.g. 0**x
     if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_zero()) {
-      if (is_a_Number(exp)) {
-        return false;
-      } else {
-        return true;
-      }
+        if (is_a_Number(exp)) {
+            return false;
+        } else {
+            return true;
+        }
     }
     // e.g. 1**x
     if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_one())

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -16,8 +16,13 @@ Pow::Pow(const RCP<const Basic> &base, const RCP<const Basic> &exp)
 bool Pow::is_canonical(const Basic &base, const Basic &exp) const
 {
     // e.g. 0**x
-    if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_zero())
+    if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_zero()) {
+      if (is_a_Number(exp)) {
+        return false;
+      } else {
         return true;
+      }
+    }
     // e.g. 1**x
     if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_one())
         return false;

--- a/symengine/tests/basic/test_arit.cpp
+++ b/symengine/tests/basic/test_arit.cpp
@@ -559,6 +559,15 @@ TEST_CASE("Pow: arit", "[arit]")
     r2 = zero;
     REQUIRE(eq(*r1, *r2));
 
+    r1 = pow(zero, zero);
+    REQUIRE(eq(*r1, *one));
+
+    r1 = pow(zero, i2);
+    REQUIRE(eq(*r1, *zero));
+
+    r1 = pow(zero, im1);
+    REQUIRE(r1->__str__() == "zoo");
+
     /* Test (x*y)**2 -> x**2*y**2 type of simplifications */
 
     r1 = pow(mul(x, y), i2);

--- a/symengine/tests/basic/test_arit.cpp
+++ b/symengine/tests/basic/test_arit.cpp
@@ -45,6 +45,7 @@ using SymEngine::rational_class;
 using SymEngine::is_a;
 using SymEngine::set_basic;
 using SymEngine::SymEngineException;
+using SymEngine::ComplexInf;
 
 TEST_CASE("Add: arit", "[arit]")
 {
@@ -566,7 +567,7 @@ TEST_CASE("Pow: arit", "[arit]")
     REQUIRE(eq(*r1, *zero));
 
     r1 = pow(zero, im1);
-    REQUIRE(r1->__str__() == "zoo");
+    REQUIRE(eq(*r1,*ComplexInf));
 
     /* Test (x*y)**2 -> x**2*y**2 type of simplifications */
 

--- a/symengine/tests/basic/test_subs.cpp
+++ b/symengine/tests/basic/test_subs.cpp
@@ -157,6 +157,16 @@ TEST_CASE("Mul: subs", "[subs]")
     r1 = div(one, x);
     d[x] = zero;
     REQUIRE((*r1->subs(d)).__str__() == "zoo");
+
+    d.clear();
+    r1 = div(i2, x);
+    d[x] = zero;
+    REQUIRE((*r1->subs(d)).__str__() == "zoo");
+
+    d.clear();
+    r1 = div(one, mul(x, y));
+    d[x] = zero;
+    REQUIRE((*r1->subs(d)).__str__() == "zoo/y");
 }
 
 TEST_CASE("Pow: subs", "[subs]")

--- a/symengine/tests/basic/test_subs.cpp
+++ b/symengine/tests/basic/test_subs.cpp
@@ -28,6 +28,7 @@ using SymEngine::levi_civita;
 using SymEngine::msubs;
 using SymEngine::function_symbol;
 using SymEngine::gamma;
+using SymEngine::ComplexInf;
 
 TEST_CASE("Symbol: subs", "[subs]")
 {
@@ -156,17 +157,17 @@ TEST_CASE("Mul: subs", "[subs]")
     d.clear();
     r1 = div(one, x);
     d[x] = zero;
-    REQUIRE((*r1->subs(d)).__str__() == "zoo");
+    REQUIRE(eq(*r1->subs(d),*ComplexInf));
 
     d.clear();
     r1 = div(i2, x);
     d[x] = zero;
-    REQUIRE((*r1->subs(d)).__str__() == "zoo");
+    REQUIRE(eq(*r1->subs(d),*ComplexInf));
 
     d.clear();
     r1 = div(one, mul(x, y));
     d[x] = zero;
-    REQUIRE((*r1->subs(d)).__str__() == "zoo/y");
+    REQUIRE(eq(*r1->subs(d),*div(ComplexInf,y)));
 }
 
 TEST_CASE("Pow: subs", "[subs]")

--- a/symengine/tests/basic/test_subs.cpp
+++ b/symengine/tests/basic/test_subs.cpp
@@ -152,6 +152,11 @@ TEST_CASE("Mul: subs", "[subs]")
     r1 = mul(x, y)->subs({{x, real_double(0.0)}});
     r2 = real_double(0.0);
     REQUIRE(eq(*r1, *r2));
+
+    d.clear();
+    r1 = div(one, x);
+    d[x] = zero;
+    REQUIRE((*r1->subs(d)).__str__() == "zoo");
 }
 
 TEST_CASE("Pow: subs", "[subs]")

--- a/symengine/tests/polynomial/test_mexprpoly.cpp
+++ b/symengine/tests/polynomial/test_mexprpoly.cpp
@@ -2,6 +2,7 @@
 #include <chrono>
 
 #include <symengine/printer.h>
+#include <symengine/symengine_exception.h>
 
 using SymEngine::Expression;
 using SymEngine::Symbol;
@@ -27,6 +28,7 @@ using SymEngine::vec_uint;
 using SymEngine::RCPBasicKeyLess;
 using SymEngine::MExprPoly;
 using SymEngine::UExprPoly;
+using SymEngine::SymEngineException;
 
 using namespace SymEngine::literals;
 
@@ -174,7 +176,7 @@ TEST_CASE("Testing MExprPoly::eval", "[MExprPoly]")
         = {{x, Expression(0)}, {y, Expression(0)}, {z, Expression(0)}};
     std::map<RCP<const Basic>, Expression, RCPBasicKeyLess> m2
         = {{x, ex}, {y, why}, {z, zee}};
-    REQUIRE(p->eval(m1) == expr4);
+    CHECK_THROWS_AS(p->eval(m1), SymEngineException);
     REQUIRE(p->eval(m2)
             == expr1 * pow_ex(ex, 2) + expr2 * pow_ex(why, 2)
                    + expr3 * pow_ex(zee, 2) + expr4 * ex * why * zee


### PR DESCRIPTION
When i tried to port SymEngine's pow function to the way SymPy does it ,i found that there is a complementary bug in test_mexprpoly.cpp where x^-1 is evaluated for x as 0.
Until now , It didn't raised (0*Inf) error as 1/0 was evaluated to 0.So I changed that part as well in the same commit.Please review this bug fix and suggest changes. 

Fixes #1154