### PR TITLE
use ComplexInf instead of throwing DivisionByZero error

### DIFF
--- a/symengine/complex.h
+++ b/symengine/complex.h
@@ -88,6 +88,7 @@ public:
     {
         return (this->real_ == 0);
     }
+
     /*! Add Complex
      * \param other of type Complex
      * */
@@ -185,17 +186,24 @@ public:
      * */
     inline RCP<const Number> divcomp(const Complex &other) const
     {
-        rational_class modulus_sq
+        rational_class modulus_sq_this
+            = this->real_ * this->real_ + this->imaginary_ * this->imaginary_;
+        rational_class modulus_sq_other
             = other.real_ * other.real_ + other.imaginary_ * other.imaginary_;
-        if (get_num(modulus_sq) == 0) {
-            throw DivisionByZeroError("Divide by zero.");
+
+        if (get_num(modulus_sq_other) == 0) {
+            if (get_num(modulus_sq_this) == 0) {
+                throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+            } else {
+                return ComplexInf;
+            }
         } else {
             return from_mpq((this->real_ * other.real_
                              + this->imaginary_ * other.imaginary_)
-                                / modulus_sq,
+                                / modulus_sq_other,
                             (-this->real_ * other.imaginary_
                              + this->imaginary_ * other.real_)
-                                / modulus_sq);
+                                / modulus_sq_other);
         }
     }
     /*! Divide Complex
@@ -204,7 +212,15 @@ public:
     inline RCP<const Number> divcomp(const Rational &other) const
     {
         if (other.is_zero()) {
-            throw DivisionByZeroError("Division By Zero");
+            rational_class modulus_sq_this
+                = this->real_ * this->real_
+                  + this->imaginary_ * this->imaginary_;
+
+            if (get_num(modulus_sq_this) == 0) {
+                throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+            } else {
+                return ComplexInf;
+            }
         } else {
             return from_mpq(this->real_ / other.i, this->imaginary_ / other.i);
         }
@@ -215,7 +231,15 @@ public:
     inline RCP<const Number> divcomp(const Integer &other) const
     {
         if (other.is_zero()) {
-            throw DivisionByZeroError("Division By Zero");
+            rational_class modulus_sq_this
+                = this->real_ * this->real_
+                  + this->imaginary_ * this->imaginary_;
+
+            if (get_num(modulus_sq_this) == 0) {
+                throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+            } else {
+                return ComplexInf;
+            }
         } else {
             return from_mpq(this->real_ / other.i, this->imaginary_ / other.i);
         }
@@ -225,13 +249,18 @@ public:
      * */
     inline RCP<const Number> rdivcomp(const Integer &other) const
     {
-        rational_class modulus_sq
+        rational_class modulus_sq_this
             = this->real_ * this->real_ + this->imaginary_ * this->imaginary_;
-        if (get_num(modulus_sq) == 0) {
-            throw DivisionByZeroError("Division By Zero");
+
+        if (get_num(modulus_sq_this) == 0) {
+            if (other.is_zero()) {
+                throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+            } else {
+                return ComplexInf;
+            }
         } else {
-            return from_mpq((this->real_ * other.i) / modulus_sq,
-                            (this->imaginary_ * (-other.i)) / modulus_sq);
+            return from_mpq((this->real_ * other.i) / modulus_sq_this,
+                            (this->imaginary_ * (-other.i)) / modulus_sq_this);
         }
     }
     /*! Pow Complex

--- a/symengine/complex.h
+++ b/symengine/complex.h
@@ -186,12 +186,13 @@ public:
      * */
     inline RCP<const Number> divcomp(const Complex &other) const
     {
-        rational_class modulus_sq_this
-            = this->real_ * this->real_ + this->imaginary_ * this->imaginary_;
         rational_class modulus_sq_other
             = other.real_ * other.real_ + other.imaginary_ * other.imaginary_;
 
         if (get_num(modulus_sq_other) == 0) {
+            rational_class modulus_sq_this
+                = this->real_ * this->real_
+                  + this->imaginary_ * this->imaginary_;
             if (get_num(modulus_sq_this) == 0) {
                 throw NotImplementedError("0/0 is NaN. Yet to be implemented");
             } else {

--- a/symengine/integer.cpp
+++ b/symengine/integer.cpp
@@ -44,8 +44,13 @@ signed long int Integer::as_int() const
 
 RCP<const Number> Integer::divint(const Integer &other) const
 {
-    if (other.i == 0)
-        throw DivisionByZeroError("Division By Zero");
+    if (other.is_zero()) {
+        if (this->i == 0) {
+            throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+        } else {
+            return ComplexInf;
+        }
+    }
     rational_class q(this->i, other.i);
 
     // This is potentially slow, but has to be done, since q might not
@@ -59,7 +64,11 @@ RCP<const Number> Integer::rdiv(const Number &other) const
 {
     if (is_a<Integer>(other)) {
         if (this->i == 0) {
-            throw DivisionByZeroError("Division By Zero");
+            if (other.is_zero()) {
+                throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+            } else {
+                return ComplexInf;
+            }
         }
         rational_class q((down_cast<const Integer &>(other)).i, this->i);
 

--- a/symengine/integer.cpp
+++ b/symengine/integer.cpp
@@ -44,7 +44,7 @@ signed long int Integer::as_int() const
 
 RCP<const Number> Integer::divint(const Integer &other) const
 {
-    if (other.is_zero()) {
+    if (other.i == 0) {
         if (this->i == 0) {
             throw NotImplementedError("0/0 is NaN. Yet to be implemented");
         } else {

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -423,8 +423,13 @@ RCP<const Basic> mul(const vec_basic &a)
 
 RCP<const Basic> div(const RCP<const Basic> &a, const RCP<const Basic> &b)
 {
-    if (is_a_Number(*b) and down_cast<const Number &>(*b).is_zero())
-        throw DivisionByZeroError("Division By Zero");
+    if (is_a_Number(*b) and down_cast<const Number &>(*b).is_zero()) {
+        if (is_a_Number(*a) and down_cast<const Number &>(*a).is_zero()) {
+            throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+        } else {
+            return ComplexInf;
+        }
+    }
     return mul(a, pow(b, minus_one));
 }
 

--- a/symengine/rational.cpp
+++ b/symengine/rational.cpp
@@ -43,8 +43,13 @@ RCP<const Number> Rational::from_mpq(rational_class &&i)
 
 RCP<const Number> Rational::from_two_ints(const Integer &n, const Integer &d)
 {
-    if (d.i == 0)
-        throw DivisionByZeroError("Division By Zero");
+    if (d.i == 0) {
+        if (n.i == 0) {
+            throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+        } else {
+            return ComplexInf;
+        }
+    }
     rational_class q(n.i, d.i);
 
     // This is potentially slow, but has to be done, since 'n/d' might not be
@@ -56,8 +61,13 @@ RCP<const Number> Rational::from_two_ints(const Integer &n, const Integer &d)
 
 RCP<const Number> Rational::from_two_ints(long n, long d)
 {
-    if (d == 0)
-        throw DivisionByZeroError("Division By Zero");
+    if (d == 0) {
+        if (n == 0) {
+            throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+        } else {
+            return ComplexInf;
+        }
+    }
     rational_class q(n, d);
 
     // This is potentially slow, but has to be done, since 'n/d' might not be

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -145,7 +145,11 @@ public:
     inline RCP<const Number> divrat(const Rational &other) const
     {
         if (other.i == 0) {
-            throw DivisionByZeroError("Division By Zero");
+            if (this->i == 0) {
+                throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+            } else {
+                return ComplexInf;
+            }
         } else {
             return from_mpq(this->i / other.i);
         }
@@ -156,7 +160,11 @@ public:
     inline RCP<const Number> divrat(const Integer &other) const
     {
         if (other.i == 0) {
-            throw DivisionByZeroError("Division By Zero");
+            if (this->i == 0) {
+                throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+            } else {
+                return ComplexInf;
+            }
         } else {
             return from_mpq(this->i / other.i);
         }
@@ -164,7 +172,11 @@ public:
     inline RCP<const Number> rdivrat(const Integer &other) const
     {
         if (this->i == 0) {
-            throw DivisionByZeroError("Division By Zero");
+            if (other.is_zero()) {
+                throw NotImplementedError("0/0 is NaN. Yet to be implemented");
+            } else {
+                return ComplexInf;
+            }
         } else {
             return from_mpq(other.i / this->i);
         }

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -101,10 +101,10 @@ using SymEngine::Rational;
 using SymEngine::I;
 using SymEngine::integer_class;
 using SymEngine::down_cast;
+using SymEngine::ComplexInf;
 #if SYMENGINE_INTEGER_CLASS != SYMENGINE_BOOSTMP
 using SymEngine::get_mpz_t;
 #endif
-using SymEngine::DivisionByZeroError;
 using SymEngine::NotImplementedError;
 using SymEngine::SymEngineException;
 
@@ -481,7 +481,7 @@ TEST_CASE("Tan: functions", "[functions]")
     r2 = neg(cot(add(div(pi, i6), y)));
     REQUIRE(eq(*r1, *r2));
 
-    CHECK_THROWS_AS(tan(mul(integer(5), div(pi, i2))), DivisionByZeroError);
+    REQUIRE(eq(*tan(mul(integer(5), div(pi, i2))), *ComplexInf));
 
     r1 = tan(real_double(3.0));
     REQUIRE(is_a<RealDouble>(*r1));
@@ -591,7 +591,7 @@ TEST_CASE("Cot: functions", "[functions]")
     r2 = cot(add(div(mul(i2, pi), integer(7)), y));
     REQUIRE(eq(*r1, *r2));
 
-    CHECK_THROWS_AS(cot(mul(integer(7), pi)), DivisionByZeroError);
+    REQUIRE(eq(*cot(mul(integer(7), pi)), *ComplexInf));
 
     r1 = cot(real_double(2.0));
     REQUIRE(is_a<RealDouble>(*r1));
@@ -702,8 +702,8 @@ TEST_CASE("Csc: functions", "[functions]")
     r2 = add(div(pi, i5), y);
     REQUIRE(eq(*r1, *r2));
 
-    CHECK_THROWS_AS(csc(mul(integer(7), pi)), DivisionByZeroError);
-    CHECK_THROWS_AS(csc(integer(0)), DivisionByZeroError);
+    REQUIRE(eq(*csc(mul(integer(7), pi)), *ComplexInf));
+    REQUIRE(eq(*csc(integer(0)), *ComplexInf));
 
     r1 = csc(real_double(3.0));
     REQUIRE(is_a<RealDouble>(*r1));
@@ -817,7 +817,7 @@ TEST_CASE("Sec: functions", "[functions]")
     r2 = add(div(pi, i3), y);
     REQUIRE(eq(*r1, *r2));
 
-    CHECK_THROWS_AS(sec(mul(integer(7), div(pi, i2))), DivisionByZeroError);
+    REQUIRE(eq(*sec(mul(integer(7), div(pi, i2))), *ComplexInf));
 
     r1 = sec(real_double(3.0));
     REQUIRE(is_a<RealDouble>(*r1));


### PR DESCRIPTION
div(2,0) in SymEngine throws DivisionByzeroError. But I think returning ComplexInf instead is a better way.I crosschecked this with SymPy and it does the same (returns ComplexInf for div(2,0)).So I Changed all such possible instances of throwing error to ComplexInf.
@isuruf  @certik  Please review and Suggest changes.