### PR TITLE
add evaluate class for nan

### DIFF
--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1950,6 +1950,13 @@ RCP<const Basic> acsch(const RCP<const Basic> &arg)
     if (eq(*arg, *minus_one))
         return log(sub(sq2, one));
 
+    if (is_a_Number(*arg)) {
+        RCP<const Number> _arg = rcp_static_cast<const Number>(arg);
+        if (not _arg->is_exact()) {
+            return _arg->get_eval().acsch(*_arg);
+        }
+    }
+
     RCP<const Basic> d;
     bool b = handle_minus(arg, outArg(d));
     if (b) {

--- a/symengine/nan.cpp
+++ b/symengine/nan.cpp
@@ -1,4 +1,5 @@
 #include <symengine/nan.h>
+#include <symengine/constants.h>
 
 namespace SymEngine
 {
@@ -51,6 +52,156 @@ RCP<const Number> NaN::pow(const Number &other) const
 RCP<const Number> NaN::rpow(const Number &other) const
 {
     return rcp_from_this_cast<Number>();
+}
+
+class EvaluateNaN : public Evaluate
+{
+    virtual RCP<const Basic> sin(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> cos(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> tan(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> cot(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> sec(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> csc(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> asin(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> acos(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> acsc(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> asec(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> atan(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> acot(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> sinh(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> csch(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> cosh(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> sech(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> tanh(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> coth(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> asinh(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> acosh(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> acsch(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> asech(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> atanh(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> acoth(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> abs(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> log(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> gamma(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> exp(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+};
+
+Evaluate &NaN::get_eval() const
+{
+    static EvaluateNaN evaluate_NaN;
+    return evaluate_NaN;
 }
 
 } // SymEngine

--- a/symengine/nan.cpp
+++ b/symengine/nan.cpp
@@ -196,6 +196,16 @@ class EvaluateNaN : public Evaluate
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
+    virtual RCP<const Basic> erf(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
+    virtual RCP<const Basic> erfc(const Basic &x) const override
+    {
+        SYMENGINE_ASSERT(is_a<NaN>(x))
+        return Nan;
+    }
 };
 
 Evaluate &NaN::get_eval() const

--- a/symengine/nan.h
+++ b/symengine/nan.h
@@ -67,6 +67,7 @@ public:
     {
         return false;
     }
+    virtual Evaluate &get_eval() const;
 
     RCP<const Number> add(const Number &other) const;
     RCP<const Number> mul(const Number &other) const;

--- a/symengine/tests/basic/test_nan.cpp
+++ b/symengine/tests/basic/test_nan.cpp
@@ -165,4 +165,8 @@ TEST_CASE("Evaluate Class of NaN", "[NaN]")
     REQUIRE(eq(*n1, *Nan));
     n1 = exp(a);
     REQUIRE(eq(*n1, *Nan));
+    n1 = erf(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = erfc(a);
+    REQUIRE(eq(*n1, *Nan));
 }

--- a/symengine/tests/basic/test_nan.cpp
+++ b/symengine/tests/basic/test_nan.cpp
@@ -4,6 +4,8 @@
 #include <symengine/nan.h>
 #include <symengine/symengine_rcp.h>
 #include <symengine/constants.h>
+#include <symengine/functions.h>
+#include <symengine/pow.h>
 
 using SymEngine::Basic;
 using SymEngine::is_a;
@@ -20,6 +22,7 @@ using SymEngine::Nan;
 using SymEngine::Symbol;
 using SymEngine::symbol;
 using SymEngine::Inf;
+using SymEngine::gamma;
 
 TEST_CASE("Hash Size for NaN", "[NaN]")
 {
@@ -98,5 +101,68 @@ TEST_CASE("Powers to NaN", "[NaN]")
 
     RCP<const Basic> n1;
     n1 = integer(-10)->pow(*a);
+    REQUIRE(eq(*n1, *Nan));
+}
+
+TEST_CASE("Evaluate Class of NaN", "[NaN]")
+{
+    RCP<const NaN> a = Nan;
+    RCP<const Basic> n1;
+
+    n1 = sin(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = cos(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = tan(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = csc(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = sec(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = cot(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = asin(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = acos(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = atan(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = acsc(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = asec(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = acot(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = sinh(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = cosh(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = tanh(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = csch(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = sech(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = coth(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = asinh(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = acosh(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = atanh(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = acsch(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = asech(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = acoth(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = log(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = gamma(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = abs(a);
+    REQUIRE(eq(*n1, *Nan));
+    n1 = exp(a);
     REQUIRE(eq(*n1, *Nan));
 }


### PR DESCRIPTION
like for log(Nan) ..master throws an error message of Not Implemented.
Instead returning Nan is a better way.
TO-DO - 
~~- [ ] for functions not in evaluate class check if arg is Nan and return Nan there itself.~~
- [x] Add tests

@isuruf  please review and suggest changes. 