### PR TITLE
increase coverage and minor bug fixes

### DIFF
--- a/symengine/complex_mpc.cpp
+++ b/symengine/complex_mpc.cpp
@@ -676,30 +676,30 @@ class EvaluateMPC : public Evaluate
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
-        mpc_ui_div(t.get_mpc_t(), 1,
-                   down_cast<const ComplexMPC &>(x).as_mpc().get_mpc_t(),
-                   MPFR_RNDN);
-        mpc_tan(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
+        mpc_tan(t.get_mpc_t(),
+                down_cast<const ComplexMPC &>(x).as_mpc().get_mpc_t(),
+                MPFR_RNDN);
+        mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> sec(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
-        mpc_ui_div(t.get_mpc_t(), 1,
-                   down_cast<const ComplexMPC &>(x).as_mpc().get_mpc_t(),
-                   MPFR_RNDN);
-        mpc_cos(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
+        mpc_cos(t.get_mpc_t(),
+                down_cast<const ComplexMPC &>(x).as_mpc().get_mpc_t(),
+                MPFR_RNDN);
+        mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> csc(const Basic &x) const
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
-        mpc_ui_div(t.get_mpc_t(), 1,
-                   down_cast<const ComplexMPC &>(x).as_mpc().get_mpc_t(),
-                   MPFR_RNDN);
-        mpc_sin(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
+        mpc_sin(t.get_mpc_t(),
+                down_cast<const ComplexMPC &>(x).as_mpc().get_mpc_t(),
+                MPFR_RNDN);
+        mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> asin(const Basic &x) const
@@ -810,10 +810,10 @@ class EvaluateMPC : public Evaluate
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
-        mpc_ui_div(t.get_mpc_t(), 1,
-                   down_cast<const ComplexMPC &>(x).as_mpc().get_mpc_t(),
-                   MPFR_RNDN);
-        mpc_tanh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
+        mpc_tanh(t.get_mpc_t(),
+                 down_cast<const ComplexMPC &>(x).as_mpc().get_mpc_t(),
+                 MPFR_RNDN);
+        mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
     virtual RCP<const Basic> asinh(const Basic &x) const

--- a/symengine/complex_mpc.cpp
+++ b/symengine/complex_mpc.cpp
@@ -41,9 +41,13 @@ int ComplexMPC::compare(const Basic &o) const
     const ComplexMPC &s = down_cast<const ComplexMPC &>(o);
     if (get_prec() == s.get_prec()) {
         int cmp = mpc_cmp(this->i.get_mpc_t(), s.i.get_mpc_t());
-        if (cmp == 0)
+        int x = MPC_INEX_RE(cmp), y = MPC_INEX_IM(cmp);
+        if (x == 0) {
+            if (y != 0)
+                return y > 0 ? 1 : -1;
             return 0;
-        return cmp > 0 ? 1 : -1;
+        }
+        return x > 0 ? 1 : -1;
     } else {
         return get_prec() > s.get_prec() ? 1 : -1;
     }

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -2755,7 +2755,7 @@ bool Beta::is_canonical(const RCP<const Basic> &x, const RCP<const Basic> &y)
 RCP<const Basic> Beta::rewrite_as_gamma() const
 {
     return div(mul(gamma(get_arg1()), gamma(get_arg2())),
-               add(get_arg1(), get_arg2()));
+               gamma(add(get_arg1(), get_arg2())));
 }
 
 RCP<const Basic> Beta::create(const RCP<const Basic> &a,

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1216,33 +1216,33 @@ RCP<const Basic> ACsc::create(const RCP<const Basic> &arg) const
 Log::Log(const RCP<const Basic> &arg) : OneArgFunction(arg)
 {
     SYMENGINE_ASSIGN_TYPEID()
-    SYMENGINE_ASSERT(is_canonical(*arg))
+    SYMENGINE_ASSERT(is_canonical(arg))
 }
 
-bool Log::is_canonical(const Basic &arg) const
+bool Log::is_canonical(const RCP<const Basic> &arg) const
 {
     //  log(0)
-    if (is_a<Integer>(arg) and down_cast<const Integer &>(arg).is_zero())
+    if (is_a<Integer>(*arg) and down_cast<const Integer &>(*arg).is_zero())
         return false;
     //  log(1)
-    if (is_a<Integer>(arg) and down_cast<const Integer &>(arg).is_one())
+    if (is_a<Integer>(*arg) and down_cast<const Integer &>(*arg).is_one())
         return false;
     // log(E)
-    if (eq(arg, *E))
+    if (eq(*arg, *E))
         return false;
 
-    if (is_a_Number(arg) and down_cast<const Number &>(arg).is_negative())
+    if (is_a_Number(*arg) and down_cast<const Number &>(*arg).is_negative())
         return false;
 
     // log(Inf) is also handled here.
-    if (is_a_Number(arg) and not down_cast<const Number &>(arg).is_exact())
+    if (is_a_Number(*arg) and not down_cast<const Number &>(*arg).is_exact())
         return false;
 
     // log(3I) should be expanded to log(3) + I*pi/2
-    if (is_a<Complex>(arg) and down_cast<const Complex &>(arg).is_re_zero())
+    if (is_a<Complex>(*arg) and down_cast<const Complex &>(*arg).is_re_zero())
         return false;
     // log(num/den) = log(num) - log(den)
-    if (is_a<Rational>(arg))
+    if (is_a<Rational>(*arg))
         return false;
     return true;
 }

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -440,7 +440,7 @@ public:
     //! Log Constructor
     Log(const RCP<const Basic> &arg);
     //! \return `true` if canonical
-    bool is_canonical(const Basic &arg) const;
+    bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return canonicalized `log`
     virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
 };

--- a/symengine/parser.cpp
+++ b/symengine/parser.cpp
@@ -418,9 +418,6 @@ public:
                 }
                 if (last_char_was_op and operator_error(last_char, x))
                     throw ParseError("Operator inconsistency!");
-                if (last_char_was_op and operator_error(last_char, x)) {
-                    throw SymEngineException("Operator inconsistency!");
-                }
                 last_char_was_op = true;
 
             } else if (s[i] == ' ') {

--- a/symengine/real_double.cpp
+++ b/symengine/real_double.cpp
@@ -278,12 +278,12 @@ class EvaluateComplexDouble : public EvaluateDouble<ComplexDouble>
     virtual RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(1.0 / std::asin(down_cast<const ComplexDouble &>(x).i));
+        return number(std::asin(1.0 / down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
-        return number(1.0 / std::acos(down_cast<const ComplexDouble &>(x).i));
+        return number(std::acos(1.0 / down_cast<const ComplexDouble &>(x).i));
     }
     virtual RCP<const Basic> acosh(const Basic &x) const override
     {

--- a/symengine/real_mpfr.cpp
+++ b/symengine/real_mpfr.cpp
@@ -901,8 +901,8 @@ class EvaluateMPFR : public Evaluate
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         mpfr_class t(mpfr_get_prec(x_));
-        mpfr_ui_div(t.get_mpfr_t(), 1, t.get_mpfr_t(), MPFR_RNDN);
-        mpfr_asinh(t.get_mpfr_t(), x_, MPFR_RNDN);
+        mpfr_ui_div(t.get_mpfr_t(), 1, x_, MPFR_RNDN);
+        mpfr_asinh(t.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
     virtual RCP<const Basic> acosh(const Basic &x) const override
@@ -911,12 +911,12 @@ class EvaluateMPFR : public Evaluate
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) >= 0) {
             mpfr_class t(mpfr_get_prec(x_));
-            mpfr_acosh(t.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
+            mpfr_acosh(t.get_mpfr_t(), x_, MPFR_RNDN);
             return real_mpfr(std::move(t));
         }
 #ifdef HAVE_SYMENGINE_MPC
         mpc_class t(mpfr_get_prec(x_));
-        mpc_set_ui(t.get_mpc_t(), 1, MPFR_RNDN);
+        mpc_set_fr(t.get_mpc_t(), x_, MPFR_RNDN);
         mpc_acosh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
 #else
@@ -949,8 +949,8 @@ class EvaluateMPFR : public Evaluate
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 1) >= 0 or mpfr_cmp_si(x_, -1) <= 0) {
             mpfr_class t(mpfr_get_prec(x_));
-            mpfr_ui_div(t.get_mpfr_t(), 1, t.get_mpfr_t(), MPFR_RNDN);
-            mpfr_atanh(t.get_mpfr_t(), x_, MPFR_RNDN);
+            mpfr_ui_div(t.get_mpfr_t(), 1, x_, MPFR_RNDN);
+            mpfr_atanh(t.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
             return real_mpfr(std::move(t));
         }
 #ifdef HAVE_SYMENGINE_MPC
@@ -970,8 +970,8 @@ class EvaluateMPFR : public Evaluate
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
         if (mpfr_cmp_si(x_, 0) >= 0 and mpfr_cmp_si(x_, 1) <= 0) {
             mpfr_class t(mpfr_get_prec(x_));
-            mpfr_ui_div(t.get_mpfr_t(), 1, t.get_mpfr_t(), MPFR_RNDN);
-            mpfr_acosh(t.get_mpfr_t(), x_, MPFR_RNDN);
+            mpfr_ui_div(t.get_mpfr_t(), 1, x_, MPFR_RNDN);
+            mpfr_acosh(t.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
             return real_mpfr(std::move(t));
         }
 #ifdef HAVE_SYMENGINE_MPC

--- a/symengine/tests/basic/test_arit.cpp
+++ b/symengine/tests/basic/test_arit.cpp
@@ -52,6 +52,7 @@ using SymEngine::down_cast;
 using SymEngine::pi;
 using SymEngine::minus_one;
 using SymEngine::Nan;
+using SymEngine::make_rcp;
 
 TEST_CASE("Add: arit", "[arit]")
 {
@@ -568,9 +569,9 @@ TEST_CASE("Sub: arit", "[arit]")
 
     r1 = real_double(0.1);
     r2 = Rational::from_mpq(rational_class(1, 2));
-    r2 = sub(sub(sub(r1, r2), integer(3)), real_double(0.2));
+    r2 = sub(r1, sub(sub(sub(r1, r2), integer(3)), real_double(0.2)));
     REQUIRE(is_a<RealDouble>(*r2));
-    REQUIRE(std::abs(down_cast<const RealDouble &>(*r2).i + 3.6) < 1e-12);
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r2).i - 3.7) < 1e-12);
 
     r1 = real_double(0.1);
     r2 = Complex::from_two_nums(*Rational::from_mpq(rational_class(1, 2)),
@@ -1064,6 +1065,34 @@ TEST_CASE("Log: arit", "[arit]")
     r1 = r1->subs({{x, E}});
     r2 = one;
     REQUIRE(eq(*r1, *r2));
+
+    r1 = log(real_double(2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.693147180559945)
+            < 1e-12);
+
+    r1 = log(complex_double(std::complex<double>(1, 2)));
+    r2 = log(real_double(-3.0));
+    REQUIRE(is_a<ComplexDouble>(*r1));
+    REQUIRE(is_a<ComplexDouble>(*r2));
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r1).i)
+                     - 1.36870408847499)
+            < 1e-12);
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
+                     - 3.32814563411849)
+            < 1e-12);
+
+    // Test is_canonical()
+    // RCP<const Log> r4 = make_rcp<Log>(i2);
+    // REQUIRE(not (r4->is_canonical(zero)));
+    // REQUIRE(not (r4->is_canonical(one)));
+    // REQUIRE(not (r4->is_canonical(E)));
+    // REQUIRE(not (r4->is_canonical(minus_one)));
+    // REQUIRE(not (r4->is_canonical(im3)));
+    // REQUIRE(not (r4->is_canonical(c1)));
+    // REQUIRE(r4->is_canonical(i2));
+    // REQUIRE(not (r4->is_canonical(real_double(2.0))));
+    // REQUIRE(not (r4->is_canonical(div(one,i2))));
 }
 
 TEST_CASE("Multinomial: arit", "[arit]")

--- a/symengine/tests/basic/test_arit.cpp
+++ b/symengine/tests/basic/test_arit.cpp
@@ -1083,16 +1083,16 @@ TEST_CASE("Log: arit", "[arit]")
             < 1e-12);
 
     // Test is_canonical()
-    // RCP<const Log> r4 = make_rcp<Log>(i2);
-    // REQUIRE(not (r4->is_canonical(zero)));
-    // REQUIRE(not (r4->is_canonical(one)));
-    // REQUIRE(not (r4->is_canonical(E)));
-    // REQUIRE(not (r4->is_canonical(minus_one)));
-    // REQUIRE(not (r4->is_canonical(im3)));
-    // REQUIRE(not (r4->is_canonical(c1)));
-    // REQUIRE(r4->is_canonical(i2));
-    // REQUIRE(not (r4->is_canonical(real_double(2.0))));
-    // REQUIRE(not (r4->is_canonical(div(one,i2))));
+    RCP<const Log> r4 = make_rcp<Log>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(E)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(im3)));
+    REQUIRE(not(r4->is_canonical(c1)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
+    REQUIRE(not(r4->is_canonical(div(one, i2))));
 }
 
 TEST_CASE("Multinomial: arit", "[arit]")

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -48,6 +48,7 @@ using SymEngine::down_cast;
 using SymEngine::NotImplementedError;
 using SymEngine::ComplexInf;
 using SymEngine::Nan;
+using SymEngine::EulerGamma;
 
 using namespace SymEngine::literals;
 
@@ -319,6 +320,8 @@ TEST_CASE("Integer: Basic", "[basic]")
     std::cout << *k << std::endl;
     REQUIRE(eq(*k, *integer(-5)));
     REQUIRE(neq(*k, *integer(12)));
+
+    REQUIRE(not i->is_complex());
 
     i = integer(0);
     j = integer(0);
@@ -647,6 +650,12 @@ TEST_CASE("compare: Basic", "[basic]")
     CHECK(r2->compare(*r1) == 1);
     CHECK(r1->compare(*r1) == 0);
 
+    r1 = real_double(1.0);
+    r2 = real_double(2.0);
+    CHECK(r1->compare(*r2) == -1);
+    CHECK(r2->compare(*r1) == 1);
+    CHECK(r1->compare(*r1) == 0);
+
     // These are specific to the order in the declaration of enum TypeID,
     // so we just make sure that if x < y, then y > x.
     r1 = add(x, z);
@@ -691,6 +700,11 @@ TEST_CASE("compare: Basic", "[basic]")
     CHECK(r1->__cmp__(*r1) == 0);
 
     CHECK_THROWS_AS(r2->expand_as_exp(), NotImplementedError);
+
+    r1 = pi;
+    r2 = EulerGamma;
+    CHECK(r1->__cmp__(*r2) > 0);
+    CHECK(r1->__cmp__(*r1) == 0);
 }
 
 TEST_CASE("Complex: Basic", "[basic]")

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -2596,7 +2596,7 @@ TEST_CASE("Acosh: functions", "[functions]")
             < 1e-12);
     REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
                      - 3.14159265358979)
-            < 1e-12);
+            < 1e-7);
 
     RCP<const ACosh> r4 = make_rcp<ACosh>(i2);
     REQUIRE(not(r4->is_canonical(one)));

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -6,6 +6,8 @@
 #include <symengine/functions.h>
 #include <symengine/complex_mpc.h>
 #include <symengine/eval_double.h>
+#include <symengine/eval_mpc.h>
+#include <symengine/eval_mpfr.h>
 #include <symengine/symengine_exception.h>
 
 using SymEngine::Basic;
@@ -34,13 +36,33 @@ using SymEngine::csc;
 using SymEngine::Csc;
 using SymEngine::sec;
 using SymEngine::Sec;
+using SymEngine::ASin;
+using SymEngine::ACos;
+using SymEngine::ASec;
+using SymEngine::ACsc;
+using SymEngine::ATan;
+using SymEngine::ACot;
+using SymEngine::Sinh;
+using SymEngine::Cosh;
+using SymEngine::Sech;
+using SymEngine::Csch;
+using SymEngine::Tanh;
+using SymEngine::Coth;
+using SymEngine::ASinh;
+using SymEngine::ACosh;
+using SymEngine::ASech;
+using SymEngine::ACsch;
+using SymEngine::ATanh;
+using SymEngine::ACoth;
 using SymEngine::asin;
 using SymEngine::acos;
 using SymEngine::asec;
 using SymEngine::acsc;
 using SymEngine::atan;
 using SymEngine::acot;
+using SymEngine::ATan2;
 using SymEngine::atan2;
+using SymEngine::LambertW;
 using SymEngine::lambertw;
 using SymEngine::log;
 using SymEngine::exp;
@@ -68,16 +90,23 @@ using SymEngine::atanh;
 using SymEngine::acoth;
 using SymEngine::asech;
 using SymEngine::kronecker_delta;
+using SymEngine::KroneckerDelta;
 using SymEngine::levi_civita;
+using SymEngine::LeviCivita;
 using SymEngine::zeta;
+using SymEngine::Zeta;
 using SymEngine::dirichlet_eta;
+using SymEngine::Dirichlet_eta;
 using SymEngine::gamma;
+using SymEngine::Gamma;
 using SymEngine::loggamma;
 using SymEngine::LogGamma;
 using SymEngine::polygamma;
 using SymEngine::PolyGamma;
 using SymEngine::lowergamma;
+using SymEngine::LowerGamma;
 using SymEngine::uppergamma;
+using SymEngine::UpperGamma;
 using SymEngine::Beta;
 using SymEngine::beta;
 using SymEngine::abs;
@@ -108,6 +137,8 @@ using SymEngine::ComplexInf;
 using SymEngine::Inf;
 using SymEngine::NegInf;
 using SymEngine::Nan;
+using SymEngine::Erf;
+using SymEngine::Erfc;
 #if SYMENGINE_INTEGER_CLASS != SYMENGINE_BOOSTMP
 using SymEngine::get_mpz_t;
 #endif
@@ -122,12 +153,14 @@ using namespace SymEngine::literals;
 using SymEngine::real_mpfr;
 using SymEngine::RealMPFR;
 using SymEngine::mpfr_class;
+using SymEngine::eval_mpfr;
 #endif
 
 #ifdef HAVE_SYMENGINE_MPC
 using SymEngine::complex_mpc;
 using SymEngine::ComplexMPC;
 using SymEngine::mpc_class;
+using SymEngine::eval_mpc;
 #endif
 
 TEST_CASE("Sin: functions", "[functions]")
@@ -267,6 +300,14 @@ TEST_CASE("Sin: functions", "[functions]")
             < 1e-12);
     REQUIRE(std::abs(down_cast<const RealDouble &>(*r2).i + 0.416146836547142)
             < 1e-12);
+
+    // Test is_canonical()
+    RCP<const Sin> r4 = make_rcp<Sin>(i2); // dummy Sin
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(mul(pi, i2))));
+    REQUIRE(not(r4->is_canonical(add(mul(pi, i2), div(pi, i2)))));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Cos: functions", "[functions]")
@@ -381,6 +422,13 @@ TEST_CASE("Cos: functions", "[functions]")
             < 1e-12);
     REQUIRE(std::abs(down_cast<const RealDouble &>(*r2).i - 0.909297426825682)
             < 1e-12);
+
+    RCP<const Cos> r4 = make_rcp<Cos>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(mul(pi, i2))));
+    REQUIRE(not(r4->is_canonical(add(mul(pi, i2), div(pi, i2)))));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Tan: functions", "[functions]")
@@ -495,6 +543,13 @@ TEST_CASE("Tan: functions", "[functions]")
     REQUIRE(is_a<RealDouble>(*r1));
     REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i + 0.142546543074278)
             < 1e-12);
+
+    RCP<const Tan> r4 = make_rcp<Tan>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(mul(pi, i2))));
+    REQUIRE(not(r4->is_canonical(add(mul(pi, i2), div(pi, i2)))));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Cot: functions", "[functions]")
@@ -605,6 +660,13 @@ TEST_CASE("Cot: functions", "[functions]")
     REQUIRE(is_a<RealDouble>(*r1));
     REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i + 0.457657554360286)
             < 1e-12);
+
+    RCP<const Cot> r4 = make_rcp<Cot>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(mul(pi, i2))));
+    REQUIRE(not(r4->is_canonical(add(mul(pi, i2), div(pi, i2)))));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Csc: functions", "[functions]")
@@ -717,6 +779,13 @@ TEST_CASE("Csc: functions", "[functions]")
     REQUIRE(is_a<RealDouble>(*r1));
     REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 7.08616739573719)
             < 1e-12);
+
+    RCP<const Csc> r4 = make_rcp<Csc>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(mul(pi, i2))));
+    REQUIRE(not(r4->is_canonical(add(mul(pi, i2), div(pi, i2)))));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Sec: functions", "[functions]")
@@ -831,6 +900,13 @@ TEST_CASE("Sec: functions", "[functions]")
     REQUIRE(is_a<RealDouble>(*r1));
     REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i + 1.01010866590799)
             < 1e-12);
+
+    RCP<const Sec> r4 = make_rcp<Sec>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(mul(pi, i2))));
+    REQUIRE(not(r4->is_canonical(add(mul(pi, i2), div(pi, i2)))));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("TrigFunction: trig_to_sqrt", "[functions]")
@@ -900,6 +976,9 @@ TEST_CASE("TrigFunction: trig_to_sqrt", "[functions]")
 
     r1 = sec(atan(x));
     REQUIRE(eq(*trig_to_sqrt(r1), *sqrt(one_p_x2)));
+
+    r1 = sec(acsc(x));
+    REQUIRE(eq(*trig_to_sqrt(r1), *div(one, sqrt(one_m_xm2))));
 
     r1 = sec(acot(x));
     REQUIRE(eq(*trig_to_sqrt(r1), *sqrt(one_p_xm2)));
@@ -1042,7 +1121,6 @@ TEST_CASE("Derivative: functions", "[functions]")
         {{__xi_1, add(_xi_1, x)}});
     REQUIRE(eq(*r1, *r2));
 
-    // Test is_canonical()
     f = function_symbol("f", x);
     RCP<const Derivative> r4 = Derivative::create(f, {x});
     REQUIRE(r4->is_canonical(function_symbol("f", {y, x}), {x}));
@@ -1075,6 +1153,9 @@ TEST_CASE("Derivative: functions", "[functions]")
     REQUIRE(eq(*r2, *r3));
 
     // r1 = Derivative::create(kronecker_delta(x, y), {y});
+
+    r1 = EulerGamma->diff(x);
+    REQUIRE(eq(*r1, *zero));
 }
 
 TEST_CASE("Subs: functions", "[functions]")
@@ -1587,6 +1668,19 @@ TEST_CASE("Asin: functions", "[functions]")
     RCP<const Basic> r1;
     RCP<const Basic> r2;
 
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Symbol> y = symbol("y");
+
+    r1 = asin(x)->diff(x);
+    r2 = div(one, sqrt(sub(one, pow(x, i2))));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = asin(x)->diff(y);
+    REQUIRE(eq(*r1, *zero));
+
+    r1 = asin(zero);
+    REQUIRE(eq(*r1, *zero));
+
     r1 = asin(im1);
     r2 = mul(im1, div(pi, i2));
     REQUIRE(eq(*r1, *r2));
@@ -1626,6 +1720,13 @@ TEST_CASE("Asin: functions", "[functions]")
     REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
                      - 2.0498241882037)
             < 1e-10);
+
+    RCP<const ASin> r4 = make_rcp<ASin>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Acos: functions", "[functions]")
@@ -1639,6 +1740,16 @@ TEST_CASE("Acos: functions", "[functions]")
 
     RCP<const Basic> r1;
     RCP<const Basic> r2;
+
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Symbol> y = symbol("y");
+
+    r1 = acos(x)->diff(x);
+    r2 = div(minus_one, sqrt(sub(one, pow(x, i2))));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = acos(x)->diff(y);
+    REQUIRE(eq(*r1, *zero));
 
     r1 = acos(im1);
     r2 = pi;
@@ -1671,6 +1782,29 @@ TEST_CASE("Acos: functions", "[functions]")
     r1 = acos(div(sub(sqrt(i5), i1), integer(4)));
     r2 = mul(i2, div(pi, i5));
     REQUIRE(eq(*r1, *r2));
+
+    r1 = acos(real_double(0.5));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 1.04719755119660)
+            < 1e-12);
+
+    r1 = acos(complex_double(std::complex<double>(1, 2)));
+    r2 = acos(real_double(4.0));
+    REQUIRE(is_a<ComplexDouble>(*r1));
+    REQUIRE(is_a<ComplexDouble>(*r2));
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r1).i)
+                     - 1.90908861124732)
+            < 1e-12);
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
+                     - 2.06343706889556)
+            < 1e-12);
+
+    RCP<const ACos> r4 = make_rcp<ACos>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Asec: functions", "[functions]")
@@ -1684,6 +1818,16 @@ TEST_CASE("Asec: functions", "[functions]")
 
     RCP<const Basic> r1;
     RCP<const Basic> r2;
+
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Symbol> y = symbol("y");
+
+    r1 = asec(x)->diff(x);
+    r2 = div(one, mul(pow(x, i2), sqrt(sub(one, div(one, pow(x, i2))))));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = asec(x)->diff(y);
+    REQUIRE(eq(*r1, *zero));
 
     r1 = asec(im1);
     r2 = pi;
@@ -1715,6 +1859,28 @@ TEST_CASE("Asec: functions", "[functions]")
     r1 = asec(div(integer(4), sub(sqrt(i5), i1)));
     r2 = mul(i2, div(pi, i5));
     REQUIRE(eq(*r1, *r2));
+
+    r1 = asec(real_double(-2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 2.09439510239320)
+            < 1e-12);
+
+    r1 = asec(complex_double(std::complex<double>(1, 2)));
+    r2 = asec(real_double(0.5));
+    REQUIRE(is_a<ComplexDouble>(*r1));
+    REQUIRE(is_a<ComplexDouble>(*r2));
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r1).i)
+                     - 1.44015500855881)
+            < 1e-12);
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
+                     - 1.31695789692482)
+            < 1e-12);
+
+    RCP<const ASec> r4 = make_rcp<ASec>(i5);
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(r4->is_canonical(i5));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Acsc: functions", "[functions]")
@@ -1728,6 +1894,16 @@ TEST_CASE("Acsc: functions", "[functions]")
 
     RCP<const Basic> r1;
     RCP<const Basic> r2;
+
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Symbol> y = symbol("y");
+
+    r1 = acsc(x)->diff(x);
+    r2 = div(minus_one, mul(pow(x, i2), sqrt(sub(one, div(one, pow(x, i2))))));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = acsc(x)->diff(y);
+    REQUIRE(eq(*r1, *zero));
 
     r1 = acsc(im1);
     r2 = mul(im1, div(pi, i2));
@@ -1752,6 +1928,28 @@ TEST_CASE("Acsc: functions", "[functions]")
     r1 = acsc(mul(div(integer(4), sub(sqrt(i5), i1)), im1));
     r2 = div(pi, mul(im2, i5));
     REQUIRE(eq(*r1, *r2));
+
+    r1 = acsc(real_double(2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.523598775598299)
+            < 1e-12);
+
+    r1 = acsc(complex_double(std::complex<double>(1, 2)));
+    r2 = acsc(real_double(0.4));
+    REQUIRE(is_a<ComplexDouble>(*r1));
+    REQUIRE(is_a<ComplexDouble>(*r2));
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r1).i)
+                     - 0.438156111929239)
+            < 1e-12);
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
+                     - 2.21861690006402)
+            < 1e-12);
+
+    RCP<const ACsc> r4 = make_rcp<ACsc>(i5);
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(r4->is_canonical(i5));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("atan: functions", "[functions]")
@@ -1765,6 +1963,16 @@ TEST_CASE("atan: functions", "[functions]")
 
     RCP<const Basic> r1;
     RCP<const Basic> r2;
+
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Symbol> y = symbol("y");
+
+    r1 = atan(x)->diff(x);
+    r2 = div(one, add(one, pow(x, i2)));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = atan(x)->diff(y);
+    REQUIRE(eq(*r1, *zero));
 
     r1 = atan(i1);
     r2 = div(pi, integer(4));
@@ -1796,6 +2004,18 @@ TEST_CASE("atan: functions", "[functions]")
     r1 = atan(mul(im1, sqrt(add(i5, mul(i2, sqrt(i5))))));
     r2 = div(mul(pi, im2), i5);
     REQUIRE(eq(*r1, *r2));
+
+    r1 = atan(real_double(3.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 1.24904577239825)
+            < 1e-12);
+
+    RCP<const ATan> r4 = make_rcp<ATan>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Acot: functions", "[functions]")
@@ -1809,6 +2029,16 @@ TEST_CASE("Acot: functions", "[functions]")
 
     RCP<const Basic> r1;
     RCP<const Basic> r2;
+
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Symbol> y = symbol("y");
+
+    r1 = acot(x)->diff(x);
+    r2 = div(minus_one, add(one, pow(x, i2)));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = acot(x)->diff(y);
+    REQUIRE(eq(*r1, *zero));
 
     r1 = acot(i1);
     r2 = div(pi, integer(4));
@@ -1841,6 +2071,18 @@ TEST_CASE("Acot: functions", "[functions]")
     r1 = acot(mul(im1, sqrt(add(i5, mul(i2, sqrt(i5))))));
     r2 = div(mul(pi, integer(9)), mul(i5, i2));
     REQUIRE(eq(*r1, *r2));
+
+    r1 = acot(real_double(2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.463647609000806)
+            < 1e-12);
+
+    RCP<const ACot> r4 = make_rcp<ACot>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Atan2: functions", "[functions]")
@@ -1913,9 +2155,6 @@ TEST_CASE("Atan2: functions", "[functions]")
     r1 = atan2(zero, im1);
     REQUIRE(eq(*r1, *pi));
 
-    r1 = atan2(zero, zero);
-    REQUIRE(eq(*r1, *Nan));
-
     r1 = atan2(i2, zero);
     r2 = mul(div(pi, i2), minus_one);
     REQUIRE(eq(*r1, *r2));
@@ -1923,6 +2162,14 @@ TEST_CASE("Atan2: functions", "[functions]")
     r1 = atan2(im2, zero);
     r2 = div(pi, i2);
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const ATan2> r4 = make_rcp<ATan2>(i2, i3);
+    REQUIRE(not(r4->is_canonical(zero, i2)));
+    REQUIRE(not(r4->is_canonical(zero, zero)));
+    REQUIRE(not(r4->is_canonical(i2, i2)));
+    REQUIRE(not(r4->is_canonical(i2, neg(i2))));
+    REQUIRE(r4->is_canonical(i2, i3));
+    REQUIRE(not(r4->is_canonical(one, sqrt(i3))));
 }
 
 TEST_CASE("Lambertw: functions", "[functions]")
@@ -1957,6 +2204,13 @@ TEST_CASE("Lambertw: functions", "[functions]")
     r1 = lambertw(mul(i2, x))->diff(x);
     r2 = div(lambertw(mul(i2, x)), mul(x, add(lambertw(mul(i2, x)), one)));
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const LambertW> r4 = make_rcp<LambertW>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(E)));
+    REQUIRE(not(r4->is_canonical(neg(div(one, E)))));
+    REQUIRE(not(r4->is_canonical(div(log(i2), im2))));
+    REQUIRE(r4->is_canonical(i2));
 }
 
 TEST_CASE("Sinh: functions", "[functions]")
@@ -1986,6 +2240,20 @@ TEST_CASE("Sinh: functions", "[functions]")
     REQUIRE(eq(*r1, *r2));
 
     REQUIRE(eq(*sinh(sub(x, y)), *neg(sinh(sub(y, x)))));
+
+    r1 = sinh(real_double(1.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 1.1752011936438)
+            < 1e-12);
+
+    RCP<const Sinh> r4 = make_rcp<Sinh>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(one));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Csch: functions", "[functions]")
@@ -2012,6 +2280,20 @@ TEST_CASE("Csch: functions", "[functions]")
     r1 = csch(zero);
     REQUIRE(eq(*r1, *ComplexInf));
     REQUIRE(eq(*csch(sub(x, y)), *neg(csch(sub(y, x)))));
+
+    r1 = csch(real_double(1.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.850918128239322)
+            < 1e-12);
+
+    RCP<const Csch> r4 = make_rcp<Csch>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(one));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Cosh: functions", "[functions]")
@@ -2040,6 +2322,20 @@ TEST_CASE("Cosh: functions", "[functions]")
     r2 = mul(im1, sinh(mul(im1, x)));
     REQUIRE(eq(*r1, *r2));
     REQUIRE(eq(*cosh(sub(x, y)), *cosh(sub(y, x))));
+
+    r1 = cosh(real_double(2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 3.76219569108363)
+            < 1e-12);
+
+    RCP<const Cosh> r4 = make_rcp<Cosh>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(one));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Sech: functions", "[functions]")
@@ -2068,6 +2364,20 @@ TEST_CASE("Sech: functions", "[functions]")
     r2 = mul(im1, mul(sech(x), tanh(x)));
     REQUIRE(eq(*r1, *r2));
     REQUIRE(eq(*sech(sub(x, y)), *sech(sub(y, x))));
+
+    r1 = sech(real_double(4.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.0366189934736865)
+            < 1e-12);
+
+    RCP<const Sech> r4 = make_rcp<Sech>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(one));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Tanh: functions", "[functions]")
@@ -2099,12 +2409,27 @@ TEST_CASE("Tanh: functions", "[functions]")
     // REQUIRE(eq(*r1, *r2));
 
     REQUIRE(eq(*tanh(sub(x, y)), *neg(tanh(sub(y, x)))));
+
+    r1 = tanh(real_double(2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.964027580075817)
+            < 1e-12);
+
+    RCP<const Tanh> r4 = make_rcp<Tanh>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(one));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Coth: functions", "[functions]")
 {
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
+    RCP<const Basic> i2 = integer(2);
     RCP<const Basic> im1 = integer(-1);
     RCP<const Basic> im2 = integer(-2);
 
@@ -2127,6 +2452,20 @@ TEST_CASE("Coth: functions", "[functions]")
     REQUIRE(eq(*r1, *ComplexInf));
 
     REQUIRE(eq(*coth(sub(x, y)), *neg(coth(sub(y, x)))));
+
+    r1 = coth(real_double(2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 1.03731472072755)
+            < 1e-12);
+
+    RCP<const Coth> r4 = make_rcp<Coth>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(one));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Asinh: functions", "[functions]")
@@ -2152,6 +2491,10 @@ TEST_CASE("Asinh: functions", "[functions]")
     r2 = log(add(sqrt(i2), im1));
     REQUIRE(eq(*r1, *r2));
 
+    r1 = asinh(neg(i2));
+    r2 = asinh(i2);
+    REQUIRE(eq(*r1, *neg(r2)));
+
     r1 = asinh(mul(im1, x))->diff(x);
     r2 = div(im1, sqrt(add(pow(x, i2), one)));
     REQUIRE(eq(*r1, *r2));
@@ -2161,6 +2504,20 @@ TEST_CASE("Asinh: functions", "[functions]")
     REQUIRE(eq(*r1, *r2));
 
     REQUIRE(eq(*asinh(sub(x, y)), *neg(asinh(sub(y, x)))));
+
+    r1 = asinh(real_double(3.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 1.81844645923207)
+            < 1e-12);
+
+    RCP<const ASinh> r4 = make_rcp<ASinh>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Acsch: functions", "[functions]")
@@ -2187,6 +2544,19 @@ TEST_CASE("Acsch: functions", "[functions]")
     REQUIRE(eq(*r1, *r2));
 
     REQUIRE(eq(*acsch(sub(x, y)), *neg(acsch(sub(y, x)))));
+
+    r1 = acsch(real_double(2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.481211825059603)
+            < 1e-12);
+
+    RCP<const ACsch> r4 = make_rcp<ACsch>(i2);
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Acosh: functions", "[functions]")
@@ -2211,6 +2581,27 @@ TEST_CASE("Acosh: functions", "[functions]")
     r1 = acosh(mul(i2, y))->diff(y);
     r2 = div(i2, sqrt(add(mul(i4, pow(y, i2)), im1)));
     REQUIRE(eq(*r1, *r2));
+
+    r1 = acosh(real_double(2.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 1.31695789692482)
+            < 1e-12);
+
+    r1 = acosh(complex_double(std::complex<double>(1, 2)));
+    r2 = acosh(real_double(-1.0));
+    REQUIRE(is_a<ComplexDouble>(*r1));
+    REQUIRE(is_a<ComplexDouble>(*r2));
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r1).i)
+                     - 1.90908861124732)
+            < 1e-12);
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
+                     - 3.14159265358979)
+            < 1e-12);
+
+    RCP<const ACosh> r4 = make_rcp<ACosh>(i2);
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Atanh: functions", "[functions]")
@@ -2240,6 +2631,10 @@ TEST_CASE("Atanh: functions", "[functions]")
     r2 = mul(im1, atanh(x));
     REQUIRE(eq(*r1, *r2));
 
+    r1 = atanh(neg(i2));
+    r2 = atanh(i2);
+    REQUIRE(eq(*r1, *neg(r2)));
+
     r1 = atanh(real_double(0.5));
     REQUIRE(is_a<RealDouble>(*r1));
     REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.549306144334055)
@@ -2257,6 +2652,13 @@ TEST_CASE("Atanh: functions", "[functions]")
             < 1e-12);
 
     REQUIRE(eq(*atanh(sub(x, y)), *neg(atanh(sub(y, x)))));
+
+    RCP<const ATanh> r4 = make_rcp<ATanh>(i2);
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Acoth: functions", "[functions]")
@@ -2277,7 +2679,33 @@ TEST_CASE("Acoth: functions", "[functions]")
     r2 = mul(im1, acoth(x));
     REQUIRE(eq(*r1, *r2));
 
+    r1 = acoth(neg(i2));
+    r2 = acoth(i2);
+    REQUIRE(eq(*r1, *neg(r2)));
+
     REQUIRE(eq(*acoth(sub(x, y)), *neg(acoth(sub(y, x)))));
+
+    r1 = acoth(real_double(3.0));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 0.346573590279973)
+            < 1e-12);
+
+    r1 = acoth(complex_double(std::complex<double>(1, 2)));
+    r2 = acoth(real_double(0.5));
+    REQUIRE(is_a<ComplexDouble>(*r1));
+    REQUIRE(is_a<ComplexDouble>(*r2));
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r1).i)
+                     - 0.429232899644131)
+            < 1e-12);
+    REQUIRE(std::abs(std::abs(down_cast<const ComplexDouble &>(*r2).i)
+                     - 1.66407281705924)
+            < 1e-12);
+
+    RCP<const ACoth> r4 = make_rcp<ACoth>(i2);
+    REQUIRE(not(r4->is_canonical(neg(i2))));
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Asech: functions", "[functions]")
@@ -2316,6 +2744,12 @@ TEST_CASE("Asech: functions", "[functions]")
     r1 = asech(x)->diff(x);
     r2 = div(im1, mul(sqrt(sub(one, pow(x, i2))), x));
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const ASech> r4 = make_rcp<ASech>(i2);
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Kronecker Delta: functions", "[functions]")
@@ -2373,6 +2807,12 @@ TEST_CASE("Kronecker Delta: functions", "[functions]")
     r1 = kronecker_delta(i, add(i, one));
     r2 = zero;
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const KroneckerDelta> r4 = make_rcp<KroneckerDelta>(i2, i);
+    REQUIRE(not(r4->is_canonical(i2, i2)));
+    REQUIRE(not(r4->is_canonical(i, i)));
+    REQUIRE(not(r4->is_canonical(i2, add(i2, i2))));
+    REQUIRE(r4->is_canonical(i, j));
 }
 
 TEST_CASE("Zeta: functions", "[functions]")
@@ -2424,6 +2864,9 @@ TEST_CASE("Zeta: functions", "[functions]")
     r1 = zeta(x, i2);
     REQUIRE(r1->__str__() == "zeta(x, 2)");
 
+    r2 = zeta(s, x);
+    REQUIRE(r1->compare(*r2) == 1);
+
     r1 = zeta(i1, i2);
     REQUIRE(eq(*r1, *ComplexInf));
 
@@ -2466,6 +2909,12 @@ TEST_CASE("Zeta: functions", "[functions]")
                                               zeta(_xi_1, pow(i2, x)), {_xi_1}),
                                           {{_xi_1, pow(s, i3)}})));
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const Zeta> r4 = make_rcp<Zeta>(i2, x);
+    REQUIRE(not(r4->is_canonical(zero, i2)));
+    REQUIRE(not(r4->is_canonical(one, i2)));
+    REQUIRE(not(r4->is_canonical(i2, add(i2, i2))));
+    REQUIRE(r4->is_canonical(x, y));
 }
 
 TEST_CASE("Levi Civita: functions", "[functions]")
@@ -2516,6 +2965,10 @@ TEST_CASE("Levi Civita: functions", "[functions]")
     r1 = levi_civita({j, j, k})->diff(j);
     REQUIRE(eq(*r1, *zero));
 
+    r1 = levi_civita({i, j, k});
+    r2 = levi_civita({j, k, x});
+    REQUIRE(r1->compare(*r2) == -1);
+
     r1 = levi_civita({pow(x, i2), y})->diff(x);
     r2 = mul(mul(i2, x),
              Subs::create(Derivative::create(levi_civita({_xi_1, y}), {_xi_1}),
@@ -2532,6 +2985,12 @@ TEST_CASE("Levi Civita: functions", "[functions]")
                                  levi_civita({pow(x, i2), _xi_2}), {_xi_2}),
                              {{_xi_2, mul(i2, x)}})));
     REQUIRE(eq(*r1, *r2));
+
+    vec_basic temp = {i2, i};
+    RCP<const LeviCivita> r4 = make_rcp<LeviCivita>(std::move(temp));
+    REQUIRE(not r4->is_canonical({i2, i2}));
+    REQUIRE(not(r4->is_canonical({i2, i, i})));
+    REQUIRE(r4->is_canonical({i2, i}));
 }
 
 TEST_CASE("Dirichlet Eta: functions", "[functions]")
@@ -2541,6 +3000,7 @@ TEST_CASE("Dirichlet Eta: functions", "[functions]")
     RCP<const Symbol> _xi_1 = symbol("_xi_1");
     RCP<const Basic> im1 = integer(-1);
     RCP<const Basic> i2 = integer(2);
+    RCP<const Basic> i3 = integer(3);
 
     RCP<const Basic> r1;
     RCP<const Basic> r2;
@@ -2583,6 +3043,15 @@ TEST_CASE("Dirichlet Eta: functions", "[functions]")
              Subs::create(Derivative::create(dirichlet_eta(_xi_1), {_xi_1}),
                           {{_xi_1, pow(x, x)}}));
     REQUIRE(eq(*r1, *r2));
+
+    r1 = make_rcp<Dirichlet_eta>(i3)->rewrite_as_zeta();
+    r2 = mul(sub(one, pow(i2, sub(one, i3))), zeta(i3));
+    REQUIRE(eq(*r1, *r2));
+
+    RCP<const Dirichlet_eta> r4 = make_rcp<Dirichlet_eta>(i3);
+    REQUIRE(not r4->is_canonical(one));
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(not(r4->is_canonical(i2)));
 }
 
 TEST_CASE("Erf: functions", "[functions]")
@@ -2619,6 +3088,12 @@ TEST_CASE("Erf: functions", "[functions]")
 
     REQUIRE(eq(*erf(neg(x)), *neg(erf(x))));
     REQUIRE(eq(*erf(sub(x, y)), *neg(erf(sub(y, x)))));
+
+    RCP<const Erf> r4 = make_rcp<Erf>(i2);
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Erfc: functions", "[functions]")
@@ -2650,6 +3125,12 @@ TEST_CASE("Erfc: functions", "[functions]")
 
     REQUIRE(eq(*erfc(neg(x)), *sub(i2, erfc(x))));
     REQUIRE(eq(*erfc(sub(y, x)), *sub(i2, erfc(sub(x, y)))));
+
+    RCP<const Erfc> r4 = make_rcp<Erfc>(i2);
+    REQUIRE(not(r4->is_canonical(neg(x))));
+    REQUIRE(not(r4->is_canonical(zero)));
+    REQUIRE(r4->is_canonical(i2));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("Gamma: functions", "[functions]")
@@ -2688,6 +3169,14 @@ TEST_CASE("Gamma: functions", "[functions]")
     r2 = mul(mul(im1, i2), sqrt(pi));
     REQUIRE(eq(*r1, *r2));
 
+    r1 = gamma(real_double(3.7));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 4.17065178379660)
+            < 1e-12);
+
+    CHECK_THROWS_AS(gamma(complex_double(std::complex<double>(1, 1))),
+                    NotImplementedError);
+
     r1 = gamma(div(integer(-15), i2));
     r2 = mul(div(integer(256), integer(2027025)), sqrt(pi));
     REQUIRE(eq(*r1, *r2));
@@ -2716,6 +3205,12 @@ TEST_CASE("Gamma: functions", "[functions]")
     r1 = gamma(add(x, y))->subs({{x, y}});
     r2 = gamma(add(y, y));
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const Gamma> r4 = make_rcp<Gamma>(x);
+    REQUIRE(not(r4->is_canonical(i2)));
+    REQUIRE(r4->is_canonical(y));
+    REQUIRE(not(r4->is_canonical(div(one, i2))));
+    REQUIRE(not(r4->is_canonical(real_double(2.0))));
 }
 
 TEST_CASE("LogGamma: functions", "[functions]")
@@ -2760,6 +3255,12 @@ TEST_CASE("LogGamma: functions", "[functions]")
     r1 = loggamma(add(y, mul(x, y)))->subs({{y, x}});
     r2 = loggamma(add(x, mul(x, x)));
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const LogGamma> r4 = make_rcp<LogGamma>(x);
+    REQUIRE(not(r4->is_canonical(minus_one)));
+    REQUIRE(not(r4->is_canonical(one)));
+    REQUIRE(not(r4->is_canonical(integer(2))));
+    REQUIRE(not(r4->is_canonical(integer(3))));
 }
 
 TEST_CASE("Lowergamma: functions", "[functions]")
@@ -2824,6 +3325,11 @@ TEST_CASE("Lowergamma: functions", "[functions]")
                      Derivative::create(lowergamma(_xi_1, pow(i2, x)), {_xi_1}),
                      {{_xi_1, pow(x, i2)}})));
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const LowerGamma> r4 = make_rcp<LowerGamma>(x, y);
+    REQUIRE(not(r4->is_canonical(one, x)));
+    REQUIRE(not(r4->is_canonical(i2, y)));
+    REQUIRE(not(r4->is_canonical(div(one, i2), i2)));
 }
 
 TEST_CASE("Uppergamma: functions", "[functions]")
@@ -2891,6 +3397,11 @@ TEST_CASE("Uppergamma: functions", "[functions]")
                      Derivative::create(uppergamma(_xi_1, pow(i2, x)), {_xi_1}),
                      {{_xi_1, pow(x, i2)}})));
     REQUIRE(eq(*r1, *r2));
+
+    RCP<const UpperGamma> r4 = make_rcp<UpperGamma>(x, y);
+    REQUIRE(not(r4->is_canonical(one, x)));
+    REQUIRE(not(r4->is_canonical(i2, y)));
+    REQUIRE(not(r4->is_canonical(div(one, i2), i2)));
 }
 
 TEST_CASE("Beta: functions", "[functions]")
@@ -2964,6 +3475,10 @@ TEST_CASE("Beta: functions", "[functions]")
     REQUIRE(eq(*r1, *ComplexInf));
     r1 = beta(one, r5_2);
     r2 = beta(r5_2, one);
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = make_rcp<Beta>(y, x)->rewrite_as_gamma();
+    r2 = div(mul(gamma(y), gamma(x)), gamma(add(x, y)));
     REQUIRE(eq(*r1, *r2));
 }
 
@@ -3146,6 +3661,7 @@ TEST_CASE("Abs: functions", "[functions]")
     REQUIRE(neq(*abs(x)->diff(x), *integer(0)));
     REQUIRE(eq(*abs(x)->diff(y), *integer(0)));
     REQUIRE(eq(*abs(sub(x, y)), *abs(sub(y, x))));
+    REQUIRE(eq(*abs(real_double(-1.0)), *real_double(1.0)));
 }
 
 class MySin : public FunctionWrapper
@@ -3189,6 +3705,20 @@ TEST_CASE("FunctionWrapper: functions", "[functions]")
     REQUIRE(std::fabs(d - 1.84147098480789) < 1e-12);
 
     REQUIRE(e->__str__() == "1 + MySin(x)");
+
+#ifdef HAVE_SYMENGINE_MPFR
+    mpfr_class aa(100);
+    eval_mpfr(aa.get_mpfr_t(), *f, MPFR_RNDN);
+    REQUIRE(mpfr_cmp_d(aa.get_mpfr_t(), 1.8414709848078) == 1);
+    REQUIRE(mpfr_cmp_d(aa.get_mpfr_t(), 1.8414709848079) == -1);
+#ifdef HAVE_SYMENGINE_MPC
+    mpc_class a(100);
+    eval_mpc(a.get_mpc_t(), *f, MPFR_RNDN);
+    mpc_abs(aa.get_mpfr_t(), a.get_mpc_t(), MPFR_RNDN);
+    REQUIRE(mpfr_cmp_d(aa.get_mpfr_t(), 1.8414709848078) == 1);
+    REQUIRE(mpfr_cmp_d(aa.get_mpfr_t(), 1.8414709848079) == -1);
+#endif // HAVE_SYMENGINE_MPC
+#endif // HAVE_SYMENGINE_MPFR
 }
 /* ---------------------------- */
 
@@ -3197,31 +3727,84 @@ TEST_CASE("MPFR and MPC: functions", "[functions]")
 #ifdef HAVE_SYMENGINE_MPFR
     RCP<const Basic> r1, r2;
     RCP<const Basic> i2 = integer(2);
-    integer_class p = 100000000000000000_z;
+    integer_class p = 1000000000000000_z;
     integer_class q;
 
-    mpfr_class a(60);
-    mpfr_set_ui(a.get_mpfr_t(), 1, MPFR_RNDN);
-    r1 = sin(real_mpfr(a));
+    mpfr_class a(60), b1(60), b2(60), b3(60), b4(60), b5(60), b6(60);
+    mpfr_set_ui(b1.get_mpfr_t(), 1, MPFR_RNDN);
+    mpfr_set_ui(b2.get_mpfr_t(), 2, MPFR_RNDN);
+    mpfr_set_ui(b3.get_mpfr_t(), 3, MPFR_RNDN);
+    mpfr_set_d(b4.get_mpfr_t(), 2.2, MPFR_RNDN);
+    mpfr_set_d(b5.get_mpfr_t(), 0.5, MPFR_RNDN);
+    mpfr_set_d(b6.get_mpfr_t(), 0.4, MPFR_RNDN);
 
-    mpfr_set_ui(a.get_mpfr_t(), 2, MPFR_RNDN);
-    r2 = sin(sub(div(pi, i2), real_mpfr(a)));
-    REQUIRE(is_a<RealMPFR>(*r1));
-    REQUIRE(is_a<RealMPFR>(*r2));
+    std::vector<std::tuple<RCP<const Basic>, integer_class, integer_class>>
+        testvec = {
+            std::make_tuple(sin(real_mpfr(b1)), 841470984807896_z,
+                            841470984807897_z),
+            std::make_tuple(sin(sub(div(pi, i2), real_mpfr(b2))),
+                            -416146836547143_z, -416146836547142_z),
+            std::make_tuple(cos(real_mpfr(b1)), 540302305868139_z,
+                            540302305868140_z),
+            std::make_tuple(tan(real_mpfr(b1)), 1557407724654902_z,
+                            1557407724654903_z),
+            std::make_tuple(cot(real_mpfr(b2)), -457657554360286_z,
+                            -457657554360285_z),
+            std::make_tuple(sec(real_mpfr(b3)), -1010108665907994_z,
+                            -1010108665907993_z),
+            std::make_tuple(csc(real_mpfr(b4)), 1236863881243858_z,
+                            1236863881243859_z),
 
-    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r1).i.get_mpfr_t(),
-               get_mpz_t(p), MPFR_RNDN);
-    q = 84147098480789650_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 84147098480789651_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
+            std::make_tuple(asin(real_mpfr(b1)), 1570796326794896_z,
+                            1570796326794897_z),
+            std::make_tuple(acos(real_mpfr(b5)), 1047197551196597_z,
+                            1047197551196598_z),
+            std::make_tuple(atan(real_mpfr(b4)), 1144168833668020_z,
+                            1144168833668021_z),
+            std::make_tuple(acot(real_mpfr(b5)), 1107148717794090_z,
+                            1107148717794091_z),
+            std::make_tuple(asec(real_mpfr(b3)), 1230959417340774_z,
+                            1230959417340775_z),
+            std::make_tuple(acsc(real_mpfr(b3)), 339836909454121_z,
+                            339836909454122_z),
 
-    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r2).i.get_mpfr_t(),
-               get_mpz_t(p), MPFR_RNDN);
-    q = -41614683654714239_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = -41614683654714238_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
+            std::make_tuple(sinh(real_mpfr(b2)), 3626860407847018_z,
+                            3626860407847019_z),
+            std::make_tuple(cosh(real_mpfr(b2)), 3762195691083631_z,
+                            3762195691083632_z),
+            std::make_tuple(tanh(real_mpfr(b1)), 761594155955764_z,
+                            761594155955765_z),
+            std::make_tuple(coth(real_mpfr(b4)), 1024859893164471_z,
+                            1024859893164472_z),
+            std::make_tuple(sech(real_mpfr(b5)), 886818883970073_z,
+                            886818883970074_z),
+            std::make_tuple(csch(real_mpfr(b4)), 224360871403841_z,
+                            2243608714038412_z),
+
+            std::make_tuple(asinh(real_mpfr(b1)), 881373587019543_z,
+                            881373587019544_z),
+            std::make_tuple(acosh(real_mpfr(b2)), 1316957896924816_z,
+                            1316957896924817_z),
+            std::make_tuple(atanh(real_mpfr(b5)), 549306144334054_z,
+                            549306144334055_z),
+            std::make_tuple(acoth(real_mpfr(b4)), 490414626505863_z,
+                            490414626505864_z),
+            std::make_tuple(asech(real_mpfr(b6)), 1566799236972411_z,
+                            1566799236972412_z),
+            std::make_tuple(acsch(real_mpfr(b4)), 440191235352683_z,
+                            440191235352684_z),
+
+            std::make_tuple(log(real_mpfr(b4)), 788457360364270,
+                            788457360364271),
+            std::make_tuple(gamma(div(real_mpfr(b3), i2)), 886226925452758_z,
+                            886226925452759_z),
+            std::make_tuple(exp(real_mpfr(b4)), 9025013499434122_z,
+                            9025013499434123_z),
+            std::make_tuple(erf(real_mpfr(b2)), 995322265018952_z,
+                            995322265018953_z),
+            std::make_tuple(erfc(real_mpfr(b2)), 4677734981047_z,
+                            4677734981048_z),
+        };
 
     mpfr_set_ui(a.get_mpfr_t(), 1, MPFR_RNDN);
     r1 = asech(real_mpfr(a));
@@ -3232,119 +3815,138 @@ TEST_CASE("MPFR and MPC: functions", "[functions]")
     q = 0_z;
     REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) == 0);
 
-    mpfr_set_ui(a.get_mpfr_t(), 3, MPFR_RNDN);
-    r1 = gamma(div(real_mpfr(a), i2));
-    REQUIRE(is_a<RealMPFR>(*r1));
-    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r1).i.get_mpfr_t(),
-               get_mpz_t(p), MPFR_RNDN);
-    q = 88622692545275801_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 88622692545275802_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
+    mpfr_set_si(a.get_mpfr_t(), -22, MPFR_RNDN);
+    r1 = abs(real_mpfr(a));
+    q = 22_z;
+    REQUIRE(mpfr_cmp_z(down_cast<const RealMPFR &>(*r1).i.get_mpfr_t(),
+                       get_mpz_t(q))
+            == 0);
 
-    mpfr_set_si(a.get_mpfr_t(), 0, MPFR_RNDN);
-    r1 = asin(real_mpfr(a));
-    REQUIRE(is_a<RealMPFR>(*r1));
+    mpfr_set_si(a.get_mpfr_t(), -3, MPFR_RNDN);
+    CHECK_THROWS_AS(gamma(real_mpfr(a)), NotImplementedError);
 
-    mpfr_set_ui(a.get_mpfr_t(), 2, MPFR_RNDN);
-    r1 = erf(real_mpfr(a));
-
-    mpfr_set_ui(a.get_mpfr_t(), 2, MPFR_RNDN);
-    r2 = erfc(real_mpfr(a));
-    REQUIRE(is_a<RealMPFR>(*r1));
-    REQUIRE(is_a<RealMPFR>(*r2));
-
-    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r1).i.get_mpfr_t(),
-               get_mpz_t(p), MPFR_RNDN);
-    q = 99532226501895273_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 99532226501895274_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
-
-    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r2).i.get_mpfr_t(),
-               get_mpz_t(p), MPFR_RNDN);
-    q = 467773498104726_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 467773498104727_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
+    for (unsigned i = 0; i < testvec.size(); i++) {
+        r1 = std::get<0>(testvec[i]);
+        REQUIRE(is_a<RealMPFR>(*r1));
+        mpfr_mul_z(a.get_mpfr_t(),
+                   down_cast<const RealMPFR &>(*r1).i.get_mpfr_t(),
+                   get_mpz_t(p), MPFR_RNDN);
+        REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(std::get<1>(testvec[i])))
+                > 0);
+        REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(std::get<2>(testvec[i])))
+                < 0);
+    }
+    testvec.clear();
 
 #ifdef HAVE_SYMENGINE_MPC
-    // Check asin(2.0)
-    mpfr_set_si(a.get_mpfr_t(), 2, MPFR_RNDN);
-    r1 = asin(real_mpfr(a));
-    REQUIRE(is_a<ComplexMPC>(*r1));
-    mpc_srcptr b = down_cast<const ComplexMPC &>(*r1).as_mpc().get_mpc_t();
-    mpc_real(a.get_mpfr_t(), b, MPFR_RNDN);
-    mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
-    q = 157079632679489661_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 157079632679489662_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
-    mpc_imag(a.get_mpfr_t(), b, MPFR_RNDN);
-    mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
-    q = 131695789692481670_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 131695789692481671_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
 
-    // Check asin(1.0 + 1.0*I)
-    mpc_class c(60);
-    mpc_set_si_si(c.get_mpc_t(), 1, 1, MPFR_RNDN);
-    r1 = asin(complex_mpc(c));
-    REQUIRE(is_a<ComplexMPC>(*r1));
-    b = down_cast<const ComplexMPC &>(*r1).as_mpc().get_mpc_t();
-    mpc_real(a.get_mpfr_t(), b, MPFR_RNDN);
-    mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
-    q = 66623943249251525_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 66623943249251526_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
-    mpc_imag(a.get_mpfr_t(), b, MPFR_RNDN);
-    mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
-    q = 106127506190503565_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 106127506190503566_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
+    mpc_srcptr b;
+    mpc_class c(60), d1(60), d2(60), d3(60);
+    mpc_set_si_si(d1.get_mpc_t(), 1, 1, MPFR_RNDN);
+    mpc_set_si_si(d2.get_mpc_t(), 2, 3, MPFR_RNDN);
+    mpc_set_si_si(d3.get_mpc_t(), 4, 5, MPFR_RNDN);
 
-    // Check asech(2)
-    mpfr_set_si(a.get_mpfr_t(), 2, MPFR_RNDN);
-    r1 = asech(real_mpfr(a));
-    REQUIRE(is_a<ComplexMPC>(*r1));
-    b = down_cast<const ComplexMPC &>(*r1).as_mpc().get_mpc_t();
-    mpc_real(a.get_mpfr_t(), b, MPFR_RNDN);
-    mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
-    q = 0_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) == 0);
+    testvec = {
+        std::make_tuple(asin(real_mpfr(b2)), 2049824188203704_z,
+                        2049824188203705_z),
+        std::make_tuple(acos(real_mpfr(b2)), 1316957896924816_z,
+                        1316957896924817_z),
+        std::make_tuple(asec(real_mpfr(b6)), 1566799236972411_z,
+                        1566799236972412_z),
+        std::make_tuple(acsc(real_mpfr(b6)), 2218616900064017_z,
+                        2218616900064018_z),
+        std::make_tuple(acosh(real_mpfr(b5)), 1047197551196597_z,
+                        1047197551196598_z),
+        std::make_tuple(atanh(real_mpfr(b2)), 1664072817059243_z,
+                        1664072817059244_z),
+        std::make_tuple(acoth(real_mpfr(b6)), 1626923328349102_z,
+                        1626923328349103_z),
+        std::make_tuple(asech(real_mpfr(b2)), 1047197551196597_z,
+                        1047197551196598_z),
+        std::make_tuple(log(sub(real_mpfr(b1), real_mpfr(b3))),
+                        3217150511711809_z, 3217150511711810_z),
 
-    mpc_imag(a.get_mpfr_t(), b, MPFR_RNDN);
-    mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
-    q = 104719755119659774_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 104719755119659775_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
+        std::make_tuple(sin(complex_mpc(d2)), 10059057603556098_z,
+                        10059057603556099_z),
+        std::make_tuple(cos(complex_mpc(d2)), 10026514661176940_z,
+                        10026514661176941_z),
+        std::make_tuple(tan(complex_mpc(d2)), 1003245688405081_z,
+                        1003245688405082_z),
+        std::make_tuple(csc(complex_mpc(d2)), 99412891287795_z,
+                        99412891287796_z),
+        std::make_tuple(sec(complex_mpc(d2)), 99735554556364_z,
+                        99735554556365_z),
+        std::make_tuple(cot(complex_mpc(d2)), 996764812007075_z,
+                        996764812007076_z),
 
-    // Check asech(2+2*I)
-    mpc_set_si_si(c.get_mpc_t(), 2, 2, MPFR_RNDN);
-    r1 = asech(complex_mpc(c));
-    REQUIRE(is_a<ComplexMPC>(*r1));
-    b = down_cast<const ComplexMPC &>(*r1).as_mpc().get_mpc_t();
-    mpc_real(a.get_mpfr_t(), b, MPFR_RNDN);
-    mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
-    q = 25489557334055081_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = 25489557334055082_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
+        std::make_tuple(asin(complex_mpc(d2)), 2063848034787096_z,
+                        2063848034787097_z),
+        std::make_tuple(acos(complex_mpc(d3)), 2706069014027540_z,
+                        2706069014027541_z),
+        std::make_tuple(atan(complex_mpc(d2)), 1428408786089582_z,
+                        1428408786089583_z),
+        std::make_tuple(acsc(complex_mpc(d2)), 275919504119167_z,
+                        275919504119168_z),
+        std::make_tuple(asec(complex_mpc(d2)), 1439125555072813_z,
+                        1439125555072814_z),
+        std::make_tuple(acot(complex_mpc(d3)), 156440457398915_z,
+                        156440457398916_z),
 
-    mpc_imag(a.get_mpfr_t(), b, MPFR_RNDN);
-    mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
-    q = -132627416165935648_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) > 0);
-    q = -132627416165935647_z;
-    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(q)) < 0);
+        std::make_tuple(sinh(complex_mpc(d2)), 3629604837263012_z,
+                        3629604837263013_z),
+        std::make_tuple(cosh(complex_mpc(d3)), 27291391405744611_z,
+                        27291391405744612_z),
+        std::make_tuple(tanh(complex_mpc(d2)), 965436479673952_z,
+                        965436479673953_z),
+        std::make_tuple(csch(complex_mpc(d2)), 275512085980707_z,
+                        275512085980708_z),
+        std::make_tuple(sech(complex_mpc(d2)), 265989418396841_z,
+                        265989418396842_z),
+        std::make_tuple(coth(complex_mpc(d3)), 999437204152625_z,
+                        999437204152626_z),
+
+        std::make_tuple(asinh(complex_mpc(d2)), 2192282215636676_z,
+                        2192282215636677_z),
+        std::make_tuple(acosh(complex_mpc(d2)), 2221285937468018_z,
+                        2221285937468019_z),
+        std::make_tuple(atanh(complex_mpc(d3)), 1451512702064822_z,
+                        1451512702064823_z),
+        std::make_tuple(acsch(complex_mpc(d3)), 156308000814648_z,
+                        156308000814649_z),
+        std::make_tuple(acoth(complex_mpc(d3)), 155883315867942_z,
+                        155883315867943_z),
+        std::make_tuple(asech(complex_mpc(d2)), 1439125555072813_z,
+                        1439125555072814_z),
+
+        std::make_tuple(log(complex_mpc(d2)), 1615742802564794_z,
+                        1615742802564795_z),
+        std::make_tuple(exp(complex_mpc(d1)), 2718281828459045_z,
+                        2718281828459046_z),
+    };
+
+    r1 = abs(complex_mpc(d2));
+    REQUIRE(is_a<RealMPFR>(*r1));
+    mpfr_mul_z(a.get_mpfr_t(), down_cast<const RealMPFR &>(*r1).i.get_mpfr_t(),
+               get_mpz_t(p), MPFR_RNDN);
+    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(3605551275463989_z)) == 1);
+    REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(3605551275463990_z)) == -1);
+
+    for (unsigned i = 0; i < testvec.size(); i++) {
+        r1 = std::get<0>(testvec[i]);
+        REQUIRE(is_a<ComplexMPC>(*r1));
+        b = down_cast<const ComplexMPC &>(*r1).as_mpc().get_mpc_t();
+        mpc_abs(a.get_mpfr_t(), b, MPFR_RNDN);
+        mpfr_mul_z(a.get_mpfr_t(), a.get_mpfr_t(), get_mpz_t(p), MPFR_RNDN);
+        REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(std::get<1>(testvec[i])))
+                > 0);
+        REQUIRE(mpfr_cmp_z(a.get_mpfr_t(), get_mpz_t(std::get<2>(testvec[i])))
+                < 0);
+    }
 
     mpc_set_si_si(c.get_mpc_t(), 1, 1, MPFR_RNDN);
     CHECK_THROWS_AS(erf(complex_mpc(c)), NotImplementedError);
     CHECK_THROWS_AS(erfc(complex_mpc(c)), NotImplementedError);
+    CHECK_THROWS_AS(gamma(complex_mpc(c)), NotImplementedError);
 #else
     mpfr_set_si(a.get_mpfr_t(), 2, MPFR_RNDN);
     CHECK_THROWS_AS(asin(real_mpfr(a)), SymEngineException);

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -3794,8 +3794,8 @@ TEST_CASE("MPFR and MPC: functions", "[functions]")
             std::make_tuple(acsch(real_mpfr(b4)), 440191235352683_z,
                             440191235352684_z),
 
-            std::make_tuple(log(real_mpfr(b4)), 788457360364270,
-                            788457360364271),
+            std::make_tuple(log(real_mpfr(b4)), 788457360364270_z,
+                            788457360364271_z),
             std::make_tuple(gamma(div(real_mpfr(b3), i2)), 886226925452758_z,
                             886226925452759_z),
             std::make_tuple(exp(real_mpfr(b4)), 9025013499434122_z,

--- a/symengine/tests/basic/test_infinity.cpp
+++ b/symengine/tests/basic/test_infinity.cpp
@@ -68,6 +68,8 @@ TEST_CASE("Constructors for Infinity", "[Infinity]")
         a->is_canonical(Complex::from_two_nums(*integer(1), *integer(2))),
         NotImplementedError);
 
+    REQUIRE(not(a->is_canonical(integer(2))));
+
     a = infty();
     b = infty(-1);
     c = infty(0);

--- a/symengine/tests/basic/test_infinity.cpp
+++ b/symengine/tests/basic/test_infinity.cpp
@@ -9,6 +9,7 @@
 #include <symengine/symengine_exception.h>
 #include <symengine/functions.h>
 #include <symengine/pow.h>
+#include <symengine/complex_double.h>
 
 using SymEngine::Basic;
 using SymEngine::Number;
@@ -41,6 +42,8 @@ using SymEngine::Nan;
 using SymEngine::erf;
 using SymEngine::erfc;
 using SymEngine::I;
+using SymEngine::make_rcp;
+using SymEngine::complex_double;
 
 TEST_CASE("Constructors for Infinity", "[Infinity]")
 {
@@ -58,6 +61,12 @@ TEST_CASE("Constructors for Infinity", "[Infinity]")
     REQUIRE(eq(*a, *Inf));
     REQUIRE(eq(*b, *NegInf));
     REQUIRE(eq(*c, *ComplexInf));
+
+    CHECK_THROWS_AS(a->is_canonical(complex_double(std::complex<double>(2, 3))),
+                    NotImplementedError);
+    CHECK_THROWS_AS(
+        a->is_canonical(Complex::from_two_nums(*integer(1), *integer(2))),
+        NotImplementedError);
 
     a = infty();
     b = infty(-1);
@@ -354,7 +363,9 @@ TEST_CASE("Evaluate Class of Infinity", "[Infinity]")
     CHECK_THROWS_AS(acosh(ComplexInf), DomainError);
     CHECK_THROWS_AS(atanh(ComplexInf), DomainError);
     CHECK_THROWS_AS(acoth(ComplexInf), DomainError);
+    CHECK_THROWS_AS(acsch(ComplexInf), DomainError);
     CHECK_THROWS_AS(exp(ComplexInf), DomainError);
+    CHECK_THROWS_AS(erf(ComplexInf), DomainError);
 
     r1 = atan(Inf);
     REQUIRE(eq(*r1, *div(pi, integer(2))));
@@ -395,6 +406,9 @@ TEST_CASE("Evaluate Class of Infinity", "[Infinity]")
     r1 = asinh(Inf);
     REQUIRE(eq(*r1, *Inf));
 
+    r1 = acsch(Inf);
+    REQUIRE(eq(*r1, *zero));
+
     r1 = acosh(NegInf);
     REQUIRE(eq(*r1, *Inf));
 
@@ -434,6 +448,9 @@ TEST_CASE("Evaluate Class of Infinity", "[Infinity]")
 
     r1 = erf(NegInf);
     REQUIRE(eq(*r1, *minus_one));
+
+    r1 = erfc(NegInf);
+    REQUIRE(eq(*r1, *integer(2)));
 
     r1 = exp(Inf);
     REQUIRE(eq(*r1, *Inf));

--- a/symengine/tests/basic/test_number.cpp
+++ b/symengine/tests/basic/test_number.cpp
@@ -3,6 +3,8 @@
 #include <symengine/functions.h>
 #include <symengine/add.h>
 #include <symengine/eval_double.h>
+#include <symengine/eval_mpc.h>
+#include <symengine/eval_mpfr.h>
 #include <symengine/symengine_exception.h>
 
 using SymEngine::SymEngineException;
@@ -27,14 +29,19 @@ using SymEngine::integer_class;
 using SymEngine::rational_class;
 using SymEngine::hash_t;
 using SymEngine::down_cast;
+using SymEngine::minus_one;
+using SymEngine::one;
 #ifdef HAVE_SYMENGINE_MPFR
 using SymEngine::mpfr_class;
 using SymEngine::real_mpfr;
+using SymEngine::eval_mpfr;
+using SymEngine::RealMPFR;
 #endif
 #ifdef HAVE_SYMENGINE_MPC
 using SymEngine::mpc_class;
 using SymEngine::complex_mpc;
 using SymEngine::ComplexMPC;
+using SymEngine::eval_mpc;
 #endif
 
 TEST_CASE("RealMPFR: arithmetic", "[number]")
@@ -54,11 +61,33 @@ TEST_CASE("RealMPFR: arithmetic", "[number]")
     RCP<const Number> i2 = integer(2);
     RCP<const Number> half = integer(1)->div(*integer(2));
     RCP<const Number> c1 = Complex::from_two_nums(*i1, *i1);
+    RCP<const Number> rat1 = Rational::from_two_ints(*integer(10), *integer(3));
+    RCP<const Number> rd1 = real_double(10.0);
+    RCP<const Number> cd1 = complex_double(std::complex<double>(1, 2));
+
+    REQUIRE(not r1->is_one());
+    REQUIRE(not r1->is_minus_one());
+    REQUIRE(not r1->is_complex());
 
     REQUIRE(eq(*r2, *addnum(r1, r1)));
+    REQUIRE(is_a<RealMPFR>(*addnum(r1, rat1)));
+    REQUIRE(eq(*r2, *addnum(r1, rd1)));
+    REQUIRE(eq(*r1, *subnum(r1, integer(0))));
+    REQUIRE(is_a<RealMPFR>(*subnum(r2, rat1)));
+    REQUIRE(eq(*r1, *subnum(r2, rd1)));
+    REQUIRE(is_a<RealMPFR>(*subnum(rat1, r2)));
+    REQUIRE(eq(*neg(r1), *subnum(rd1, r2)));
     REQUIRE(eq(*r2, *mulnum(r1, i2)));
     REQUIRE(eq(*r2, *mulnum(i2, r1)));
+    REQUIRE(eq(*r3, *mulnum(r1, rd1)));
+    REQUIRE(is_a<RealMPFR>(*mulnum(rat1, r1)));
+    REQUIRE(eq(*r3, *mulnum(r1, r1)));
     REQUIRE(eq(*r1, *divnum(r2, i2)));
+    REQUIRE(eq(*r1, *divnum(r3, rd1)));
+    REQUIRE(is_a<RealMPFR>(*divnum(r3, rat1)));
+    REQUIRE(eq(*r1, *divnum(r3, r1)));
+    REQUIRE(is_a<RealMPFR>(*divnum(mulnum(rat1, rat1), r1)));
+    REQUIRE(eq(*r1, *divnum(mulnum(rd1, rd1), r1)));
     REQUIRE(eq(*divnum(i1, r1), *divnum(i2, r2)));
     REQUIRE(eq(*r1, *subnum(r2, r1)));
     REQUIRE(eq(*r1, *subnum(integer(20), r1)));
@@ -66,12 +95,45 @@ TEST_CASE("RealMPFR: arithmetic", "[number]")
     REQUIRE(eq(*r3, *pownum(r1, i2)));
     REQUIRE(eq(*r4, *pownum(i2, r1)));
     REQUIRE(eq(*r1, *pownum(r3, half)));
+    REQUIRE(eq(*r3, *pownum(r1, real_double(2.0))));
+    REQUIRE(eq(*r3, *pownum(r1, divnum(r2, r1))));
+    REQUIRE(eq(*r4, *pownum(real_double(2.0), r1)));
+    REQUIRE(is_a<RealMPFR>(*pownum(rat1, r1)));
     REQUIRE(eq(*divnum(i1, r4), *half->pow(*r1)));
+
+    mpfr_class e(100);
+    mpfr_set_ui(e.get_mpfr_t(), 10, MPFR_RNDN);
+    r2 = real_mpfr(std::move(e));
+    REQUIRE(r1->__hash__() == r2->__hash__());
+    REQUIRE(r1->compare(*r2) == 0);
+    REQUIRE(r1->compare(*r3) == -1);
+    REQUIRE(r3->compare(*r2) == 1);
+
 #ifdef HAVE_SYMENGINE_MPC
     REQUIRE(is_a<ComplexMPC>(*addnum(r1, c1)));
+    REQUIRE(is_a<ComplexMPC>(*addnum(r1, cd1)));
+    REQUIRE(is_a<ComplexMPC>(*subnum(r1, c1)));
+    REQUIRE(is_a<ComplexMPC>(*subnum(r1, cd1)));
+    REQUIRE(is_a<ComplexMPC>(*subnum(c1, r1)));
+    REQUIRE(is_a<ComplexMPC>(*subnum(cd1, r1)));
     REQUIRE(is_a<ComplexMPC>(*mulnum(c1, r2)));
+    REQUIRE(is_a<ComplexMPC>(*mulnum(cd1, r2)));
+    REQUIRE(is_a<ComplexMPC>(*divnum(c1, r2)));
+    REQUIRE(is_a<ComplexMPC>(*divnum(cd1, r2)));
+    REQUIRE(is_a<ComplexMPC>(*divnum(r1, c1)));
+    REQUIRE(is_a<ComplexMPC>(*divnum(r1, cd1)));
     REQUIRE(is_a<ComplexMPC>(*pownum(r5, half)));
     REQUIRE(is_a<ComplexMPC>(*pownum(integer(-2), r5)));
+    REQUIRE(is_a<ComplexMPC>(*pownum(r1, c1)));
+    REQUIRE(is_a<ComplexMPC>(*pownum(r5, cd1)));
+    REQUIRE(is_a<ComplexMPC>(*pownum(r5, real_double(-0.2))));
+    REQUIRE(is_a<ComplexMPC>(*pownum(r5, mulnum(minus_one, r1))));
+    REQUIRE(is_a<ComplexMPC>(*pownum(c1, r1)));
+    REQUIRE(is_a<ComplexMPC>(*pownum(cd1, r1)));
+    REQUIRE(is_a<ComplexMPC>(*pownum(mulnum(minus_one, rat1), r1)));
+    REQUIRE(is_a<ComplexMPC>(*pownum(real_double(-0.2), r5)));
+    REQUIRE(is_a<ComplexMPC>(*pownum(mulnum(minus_one, r1), r5)));
+
 #else
     CHECK_THROWS_AS(addnum(r1, c1), SymEngineException);
     CHECK_THROWS_AS(pownum(r5, half), SymEngineException);
@@ -83,34 +145,98 @@ TEST_CASE("RealMPFR: arithmetic", "[number]")
 TEST_CASE("ComplexMPC: arithmetic", "[number]")
 {
 #ifdef HAVE_SYMENGINE_MPC
-    mpc_class a(100), b(100), d(100), c(100);
+    mpc_class a(100), b(100), d(100), c(100), e(100);
     mpc_set_ui_ui(a.get_mpc_t(), 10, 7, MPFR_RNDN);
     mpc_set_ui_ui(b.get_mpc_t(), 20, 14, MPFR_RNDN);
     mpc_pow_ui(c.get_mpc_t(), a.get_mpc_t(), 2, MPFR_RNDN);
     mpc_set_ui(d.get_mpc_t(), 2, MPFR_RNDN);
     mpc_pow(d.get_mpc_t(), d.get_mpc_t(), a.get_mpc_t(), MPFR_RNDN);
+    mpc_set_ui_ui(e.get_mpc_t(), 10, 14, MPFR_RNDN);
 
     RCP<const Number> r1 = complex_mpc(std::move(a));
     RCP<const Number> r2 = complex_mpc(std::move(b));
     RCP<const Number> r3 = complex_mpc(std::move(c));
     RCP<const Number> r4 = complex_mpc(std::move(d));
+    RCP<const Number> r5 = complex_mpc(std::move(e));
     RCP<const Number> i1 = integer(1);
     RCP<const Number> i2 = integer(2);
+    RCP<const Number> i10 = integer(10);
     RCP<const Number> half = integer(1)->div(*integer(2));
     RCP<const Number> c1 = Complex::from_two_nums(*integer(10), *integer(7));
+    RCP<const Number> rat1 = Rational::from_two_ints(*integer(10), *integer(3));
+    RCP<const Number> rd1 = real_double(10.0);
+    RCP<const Number> cd1 = complex_double(std::complex<double>(10, 7));
 
     REQUIRE(eq(*r2, *addnum(c1, r1)));
-    REQUIRE(eq(*r2, *mulnum(r1, i2)));
-    REQUIRE(eq(*r2, *mulnum(i2, r1)));
-    REQUIRE(eq(*r1, *divnum(r2, i2)));
-    REQUIRE(eq(*divnum(i1, r1), *divnum(i2, r2)));
+    REQUIRE(eq(*r2, *addnum(r1, r1)));
+    REQUIRE(eq(*r2, *addnum(r5, i10)));
+    REQUIRE(is_a<ComplexMPC>(*addnum(r5, rat1)));
+    REQUIRE(eq(*r2, *addnum(r5, rd1)));
+    REQUIRE(eq(*r2, *addnum(r1, cd1)));
     REQUIRE(eq(*r1, *subnum(r2, r1)));
     REQUIRE(eq(*r1, *subnum(mulnum(c1, i2), r1)));
+    REQUIRE(is_a<ComplexMPC>(*subnum(r2, rat1)));
+    REQUIRE(eq(*r5, *subnum(r2, rd1)));
+    REQUIRE(eq(*r5, *subnum(r2, i10)));
+    REQUIRE(eq(*r1, *subnum(r2, c1)));
+    REQUIRE(eq(*r1, *subnum(r2, cd1)));
+    REQUIRE(is_a<ComplexMPC>(*subnum(rat1, r2)));
+    REQUIRE(eq(*neg(r5), *subnum(rd1, r2)));
+    REQUIRE(eq(*neg(r5), *subnum(i10, r2)));
+    REQUIRE(eq(*neg(r1), *subnum(c1, r2)));
+    REQUIRE(eq(*neg(r1), *subnum(cd1, r2)));
+    REQUIRE(eq(*r2, *mulnum(r1, i2)));
+    REQUIRE(eq(*r2, *mulnum(i2, r1)));
+    REQUIRE(eq(*mulnum(cd1, r1), *mulnum(c1, r1)));
+    REQUIRE(eq(*r3, *mulnum(r1, r1)));
+    REQUIRE(eq(*mulnum(r1, i10), *mulnum(r1, rd1)));
     REQUIRE(eq(*r1, *mulnum(r2, half)));
+    REQUIRE(eq(*r1, *divnum(r2, i2)));
+    REQUIRE(eq(*r2, *divnum(r1, half)));
+    REQUIRE(eq(*divnum(r2, c1), *divnum(r2, cd1)));
+    REQUIRE(eq(*divnum(i1, r1), *divnum(i2, r2)));
+    REQUIRE(eq(*r1, *divnum(r3, r1)));
+    REQUIRE(eq(*r1, *divnum(r2, real_double(2.0))));
+    REQUIRE(eq(*divnum(one, r1), *divnum(i2, r2)));
+    REQUIRE(eq(*divnum(one, r2), *divnum(half, r1)));
+    REQUIRE(eq(*divnum(c1, r2), *divnum(cd1, r2)));
+    REQUIRE(eq(*divnum(i1, r1), *divnum(i2, r2)));
+    REQUIRE(eq(*divnum(one, r1), *divnum(real_double(2.0), r2)));
     REQUIRE(eq(*r3, *pownum(r1, i2)));
-    REQUIRE(eq(*r4, *pownum(i2, r1)));
+    REQUIRE(eq(*r3, *pownum(r1, real_double(2.0))));
+    REQUIRE(is_a<ComplexMPC>(*pownum(r1, cd1)));
+    REQUIRE(eq(*pownum(r1, r1), *pownum(r1, cd1)));
+    REQUIRE(eq(*pownum(r1, c1), *pownum(r1, cd1)));
+    REQUIRE(eq(*r3, *pownum(r1, real_double(2.0))));
     REQUIRE(eq(*r1, *pownum(r3, half)));
+    REQUIRE(eq(*pownum(c1, r1), *pownum(cd1, r1)));
+    REQUIRE(eq(*r1, *pownum(r3, real_double(0.5))));
+    REQUIRE(eq(*r4, *pownum(i2, r1)));
+    REQUIRE(eq(*r4, *pownum(real_double(2.0), r1)));
     REQUIRE(eq(*divnum(i1, r4), *half->pow(*r1)));
+
+    mpc_class ee(100);
+    mpc_set_ui_ui(ee.get_mpc_t(), 20, 14, MPFR_RNDN);
+    RCP<const Number> r6 = complex_mpc(std::move(ee));
+    REQUIRE(r6->__hash__() == r2->__hash__());
+    REQUIRE(r6->compare(*r2) == 0);
+    REQUIRE(r6->compare(*r3) == 1);
+
+#ifdef HAVE_SYMENGINE_MPFR
+    mpfr_class f(100);
+    mpfr_set_ui(f.get_mpfr_t(), 10, MPFR_RNDN);
+    r6 = real_mpfr(std::move(f));
+
+    REQUIRE(eq(*r2, *addnum(r5, r6)));
+    REQUIRE(eq(*r5, *subnum(r2, r6)));
+    REQUIRE(eq(*neg(r5), *subnum(r6, r2)));
+    REQUIRE(eq(*mulnum(r2, i10), *mulnum(r6, r2)));
+    REQUIRE(is_a<ComplexMPC>(*divnum(r3, r6)));
+    REQUIRE(is_a<ComplexMPC>(*divnum(r6, r3)));
+    REQUIRE(eq(*r3, *pownum(r1, divnum(r6, integer(5)))));
+    REQUIRE(eq(*r1, *pownum(r3, divnum(r6, integer(20)))));
+    REQUIRE(eq(*r4, *pownum(divnum(r6, integer(5)), r1)));
+#endif // HAVE_SYMENGINE_MPFR
 #endif // HAVE_SYMENGINE_MPC
 }
 
@@ -124,6 +250,7 @@ TEST_CASE("Test is_exact", "[number]")
     REQUIRE(n1->is_exact_zero());
     REQUIRE(not n1->is_negative());
     REQUIRE(not n1->is_positive());
+    REQUIRE(not n1->is_complex());
 
     n1 = integer(-1);
     REQUIRE(n1->is_exact());
@@ -131,6 +258,7 @@ TEST_CASE("Test is_exact", "[number]")
     REQUIRE(not n1->is_exact_zero());
     REQUIRE(n1->is_negative());
     REQUIRE(not n1->is_positive());
+    REQUIRE(not n1->is_complex());
 
     n1 = Rational::from_mpq(rational_class(2, 1));
     REQUIRE(n1->is_exact());
@@ -159,6 +287,8 @@ TEST_CASE("Test is_exact", "[number]")
     REQUIRE(not n1->is_exact_zero());
     REQUIRE(not n1->is_negative());
     REQUIRE(n1->is_positive());
+    REQUIRE(not n1->is_complex());
+    REQUIRE(not n1->is_minus_one());
 
     n1 = complex_double(1.0);
     REQUIRE(not n1->is_exact());
@@ -313,8 +443,21 @@ TEST_CASE("Test NumberWrapper", "[number]")
     REQUIRE(eq(*integer(5)->mul(*n), *make_rcp<Long>(50)));
 
     RCP<const Basic> r = add(sqrt(integer(2)), n);
-    double d = eval_double(*r);
-    REQUIRE(std::abs(d - 11.4142135623730951) < 1e-12);
-
+    double d1 = eval_double(*r);
+    REQUIRE(std::abs(d1 - 11.4142135623730951) < 1e-12);
     REQUIRE(n->__str__() == "10");
+
+#ifdef HAVE_SYMENGINE_MPFR
+    mpfr_class aa(100);
+    eval_mpfr(aa.get_mpfr_t(), *r, MPFR_RNDN);
+    REQUIRE(mpfr_cmp_d(aa.get_mpfr_t(), 11.41421356237309) == 1);
+    REQUIRE(mpfr_cmp_d(aa.get_mpfr_t(), 11.41421356237310) == -1);
+#ifdef HAVE_SYMENGINE_MPC
+    mpc_class a(100);
+    eval_mpc(a.get_mpc_t(), *r, MPFR_RNDN);
+    mpc_abs(aa.get_mpfr_t(), a.get_mpc_t(), MPFR_RNDN);
+    REQUIRE(mpfr_cmp_d(aa.get_mpfr_t(), 11.41421356237309) == 1);
+    REQUIRE(mpfr_cmp_d(aa.get_mpfr_t(), 11.41421356237310) == -1);
+#endif // HAVE_SYMENGINE_MPC
+#endif // HAVE_SYMENGINE_MPFR
 }

--- a/symengine/tests/basic/test_number.cpp
+++ b/symengine/tests/basic/test_number.cpp
@@ -109,6 +109,12 @@ TEST_CASE("RealMPFR: arithmetic", "[number]")
     REQUIRE(r1->compare(*r3) == -1);
     REQUIRE(r3->compare(*r2) == 1);
 
+    // to increase coverage
+    mpfr_class ee(10);
+    mpfr_set_ui(ee.get_mpfr_t(), 101, MPFR_RNDN);
+    r2 = real_mpfr(std::move(ee));
+    REQUIRE(r1->compare(*r2) == 1); // TO-DO is this is a bug or what ?
+
 #ifdef HAVE_SYMENGINE_MPC
     REQUIRE(is_a<ComplexMPC>(*addnum(r1, c1)));
     REQUIRE(is_a<ComplexMPC>(*addnum(r1, cd1)));
@@ -220,7 +226,13 @@ TEST_CASE("ComplexMPC: arithmetic", "[number]")
     RCP<const Number> r6 = complex_mpc(std::move(ee));
     REQUIRE(r6->__hash__() == r2->__hash__());
     REQUIRE(r6->compare(*r2) == 0);
-    REQUIRE(r6->compare(*r3) == 1);
+    REQUIRE(r6->compare(*r3) == -1);
+    REQUIRE(r3->compare(*r6) == 1);
+    REQUIRE(r2->compare(*r5) == 1);
+
+    mpc_class temp(101);
+    mpc_set_ui_ui(temp.get_mpc_t(), 20, 14, MPFR_RNDN);
+    REQUIRE(complex_mpc(std::move(temp))->compare(*r6) == 1);
 
 #ifdef HAVE_SYMENGINE_MPFR
     mpfr_class f(100);

--- a/symengine/tests/basic/test_sets.cpp
+++ b/symengine/tests/basic/test_sets.cpp
@@ -177,6 +177,7 @@ TEST_CASE("EmptySet : Basic", "[basic]")
     REQUIRE(not r1->__eq__(*r2));
     REQUIRE(r1->compare(*emptyset()) == 0);
     REQUIRE(eq(*r1->contains(zero), *boolFalse));
+    REQUIRE(r1->get_args().empty());
     CHECK_THROWS_AS(r1->diff(symbol("x")), SymEngineException);
 }
 
@@ -212,6 +213,7 @@ TEST_CASE("UniversalSet : Basic", "[basic]")
     REQUIRE(r1->__hash__() == universalset()->__hash__());
     REQUIRE(not r1->__eq__(*r2));
     REQUIRE(r1->compare(*universalset()) == 0);
+    REQUIRE(r1->get_args().empty());
     CHECK_THROWS_AS(r1->diff(symbol("x")), SymEngineException);
 }
 
@@ -230,8 +232,10 @@ TEST_CASE("FiniteSet : Basic", "[basic]")
     REQUIRE(eq(*r3->contains(integer(3)), *boolFalse));
     REQUIRE(r3->is_subset(r2));
     REQUIRE(r3->is_proper_subset(r2));
+    REQUIRE(r1->get_args().empty());
 
     r1 = finiteset({zero, one});
+    REQUIRE(r1->__str__() == "{0, 1}");
     RCP<const Set> r4 = interval(zero, one);
     r3 = r2->set_intersection(r4);
     REQUIRE(eq(*r3->contains(one), *boolTrue));
@@ -294,6 +298,7 @@ TEST_CASE("Union : Basic", "[basic]")
     };
     RCP<const Set> f1 = finiteset({zero, one, symbol("x")});
     RCP<const Set> r1 = set_union({f1, emptyset()});
+    REQUIRE(r1->get_args().empty());
     REQUIRE(eq(*r1, *f1));
     r1 = set_union({emptyset()});
     REQUIRE(eq(*r1, *emptyset()));

--- a/symengine/tests/eval/test_eval_mpc.cpp
+++ b/symengine/tests/eval/test_eval_mpc.cpp
@@ -5,6 +5,7 @@
 #include <symengine/eval_mpfr.h>
 #include <symengine/symengine_exception.h>
 #include <symengine/real_double.h>
+#include <symengine/constants.h>
 
 using SymEngine::SymEngineException;
 using SymEngine::NotImplementedError;
@@ -23,10 +24,34 @@ using SymEngine::one;
 using SymEngine::sub;
 using SymEngine::sin;
 using SymEngine::cos;
+using SymEngine::tan;
+using SymEngine::csc;
+using SymEngine::sec;
+using SymEngine::cot;
+using SymEngine::asin;
+using SymEngine::acos;
+using SymEngine::atan;
+using SymEngine::acsc;
+using SymEngine::asec;
+using SymEngine::acot;
+using SymEngine::sinh;
+using SymEngine::cosh;
+using SymEngine::tanh;
+using SymEngine::csch;
+using SymEngine::sech;
+using SymEngine::coth;
+using SymEngine::asinh;
+using SymEngine::acosh;
+using SymEngine::atanh;
+using SymEngine::acsch;
+using SymEngine::asech;
+using SymEngine::acoth;
 using SymEngine::eval_mpc;
 using SymEngine::print_stack_on_segfault;
-using SymEngine::asech;
 using SymEngine::real_double;
+using SymEngine::constant;
+using SymEngine::gamma;
+using SymEngine::abs;
 
 TEST_CASE("eval: eval_mpc", "[eval_mpc]")
 {
@@ -39,7 +64,8 @@ TEST_CASE("eval: eval_mpc", "[eval_mpc]")
     RCP<const Basic> s = add(one, cos(integer(2)));
     RCP<const Basic> t = sin(integer(2));
     RCP<const Basic> r = add(pow(E, mul(integer(2), I)), one);
-
+    RCP<const Basic> arg1 = add(integer(2), mul(integer(3), I));
+    RCP<const Basic> arg2 = add(integer(4), mul(integer(5), I));
     eval_mpc(a, *r, MPFR_RNDN);
     eval_mpfr(real, *s, MPFR_RNDN);
     eval_mpfr(imag, *t, MPFR_RNDN);
@@ -48,26 +74,42 @@ TEST_CASE("eval: eval_mpc", "[eval_mpc]")
 
     REQUIRE(mpc_cmp(a, b) == 0);
 
-    r = acsc(add(integer(2), mul(integer(3), I)));
-    eval_mpc(a, *r, MPFR_RNDN);
-    mpc_abs(real, a, MPFR_RNDN);
+    std::vector<std::tuple<RCP<const Basic>, double, double>> testvec = {
+        std::make_tuple(sin(arg1), 10.0590576035560, 10.0590576035561),
+        std::make_tuple(cos(arg1), 10.0265146611769, 10.0265146611770),
+        std::make_tuple(tan(arg1), 1.00324568840508, 1.00324568840509),
+        std::make_tuple(csc(arg1), 0.09941289128779, 0.09941289128780),
+        std::make_tuple(sec(arg1), 0.09973555455636, 0.09973555455637),
+        std::make_tuple(cot(arg1), 0.99676481200707, 0.99676481200708),
+        std::make_tuple(asin(arg1), 2.06384803478709, 2.06384803478710),
+        std::make_tuple(acos(arg2), 2.70606901402754, 2.70606901402755),
+        std::make_tuple(atan(arg1), 1.42840878608958, 1.42840878608959),
+        std::make_tuple(acsc(arg1), 0.275919504119167, 0.275919504119168),
+        std::make_tuple(asec(arg1), 1.439125555072813, 1.439125555072814),
+        std::make_tuple(acot(arg2), 0.156440457398915, 0.156440457398916),
+        std::make_tuple(sinh(arg1), 3.629604837263012, 3.629604837263013),
+        std::make_tuple(cosh(arg2), 27.2913914057446, 27.2913914057447),
+        std::make_tuple(tanh(arg1), 0.9654364796739529, 0.9654364796739530),
+        std::make_tuple(csch(arg1), 0.275512085980707, 0.275512085980708),
+        std::make_tuple(sech(arg1), 0.2659894183968419, 0.2659894183968420),
+        std::make_tuple(coth(arg2), 0.999437204152625, 0.999437204152626),
+        std::make_tuple(asinh(arg1), 2.19228221563667, 2.19228221563668),
+        std::make_tuple(acosh(arg1), 2.22128593746801, 2.22128593746802),
+        std::make_tuple(atanh(arg2), 1.45151270206482, 1.45151270206483),
+        std::make_tuple(acsch(arg2), 0.156308000814648, 0.156308000814649),
+        std::make_tuple(acoth(arg2), 0.155883315867942, 0.155883315867943),
+        std::make_tuple(asech(arg1), 1.43912555507281, 1.43912555507282),
+        std::make_tuple(log(arg1), 1.615742802564794, 1.615742802564795),
+        std::make_tuple(abs(mul(arg1, arg2)), 23.086792761230, 23.086792761231),
+        std::make_tuple(abs(arg1), 3.605551275463989, 3.605551275463990),
+    };
 
-    REQUIRE(mpfr_cmp_d(real, 0.27591950411917) == -1);
-    REQUIRE(mpfr_cmp_d(real, 0.27591950411916) == 1);
-
-    r = asec(add(one, mul(integer(3), I)));
-    eval_mpc(a, *r, MPFR_RNDN);
-    mpc_abs(real, a, MPFR_RNDN);
-
-    REQUIRE(mpfr_cmp_d(real, 1.50450934308357) == -1);
-    REQUIRE(mpfr_cmp_d(real, 1.50450934308356) == 1);
-
-    r = asech(add(integer(2), mul(integer(3), I)));
-    eval_mpc(a, *r, MPFR_RNDN);
-    mpc_abs(real, a, MPFR_RNDN);
-
-    REQUIRE(mpfr_cmp_d(real, 1.43912555507282) == -1);
-    REQUIRE(mpfr_cmp_d(real, 1.43912555507281) == 1);
+    for (unsigned i = 0; i < testvec.size(); i++) {
+        eval_mpc(a, *std::get<0>(testvec[i]), MPFR_RNDN);
+        mpc_abs(real, a, MPFR_RNDN);
+        REQUIRE(mpfr_cmp_d(real, std::get<1>(testvec[i])) == 1);
+        REQUIRE(mpfr_cmp_d(real, std::get<2>(testvec[i])) == -1);
+    }
 
     r = add(one, mul(EulerGamma, I));
     s = one;
@@ -116,6 +158,10 @@ TEST_CASE("eval: eval_mpc", "[eval_mpc]")
     mpc_set_fr_fr(b, real, imag, MPFR_RNDN);
 
     REQUIRE(mpc_cmp(a, b) == 0);
+
+    CHECK_THROWS_AS(eval_mpc(a, *constant("dummy_constant"), MPFR_RNDN),
+                    NotImplementedError);
+    CHECK_THROWS_AS(eval_mpc(a, *gamma(arg1), MPFR_RNDN), NotImplementedError);
 
     r = erf(add(one, mul(integer(2), I)));
     CHECK_THROWS_AS(eval_mpc(a, *r, MPFR_RNDN), NotImplementedError);

--- a/symengine/tests/eval/test_eval_mpfr.cpp
+++ b/symengine/tests/eval/test_eval_mpfr.cpp
@@ -5,6 +5,7 @@
 #include <symengine/constants.h>
 #include <symengine/functions.h>
 #include <symengine/symengine_exception.h>
+#include <symengine/pow.h>
 
 using SymEngine::SymEngineException;
 using SymEngine::RCP;
@@ -24,10 +25,40 @@ using SymEngine::max;
 using SymEngine::min;
 using SymEngine::loggamma;
 using SymEngine::one;
+using SymEngine::sin;
+using SymEngine::cos;
+using SymEngine::tan;
+using SymEngine::csc;
+using SymEngine::sec;
+using SymEngine::cot;
+using SymEngine::asin;
+using SymEngine::acos;
+using SymEngine::atan;
+using SymEngine::acsc;
+using SymEngine::asec;
+using SymEngine::acot;
+using SymEngine::sinh;
+using SymEngine::cosh;
+using SymEngine::tanh;
+using SymEngine::csch;
+using SymEngine::sech;
+using SymEngine::coth;
+using SymEngine::asinh;
+using SymEngine::acosh;
+using SymEngine::atanh;
+using SymEngine::acsch;
 using SymEngine::asech;
+using SymEngine::acoth;
 using SymEngine::zero;
 using SymEngine::Catalan;
 using SymEngine::GoldenRatio;
+using SymEngine::pow;
+using SymEngine::gamma;
+using SymEngine::beta;
+using SymEngine::constant;
+using SymEngine::NotImplementedError;
+using SymEngine::abs;
+using SymEngine::lambertw;
 
 TEST_CASE("precision: eval_mpfr", "[eval_mpfr]")
 {
@@ -94,57 +125,71 @@ TEST_CASE("precision: eval_mpfr", "[eval_mpfr]")
     REQUIRE(mpfr_cmp_d(a, 0.00000000874989) == 1);
     REQUIRE(mpfr_cmp_d(a, 0.00000000874990) == -1);
 
-    r = max({integer(3), integer(2)});
+    RCP<const Basic> arg1 = integer(2);
+    RCP<const Basic> arg2 = div(one, integer(4));
 
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 3.00000000000001) == -1);
-    REQUIRE(mpfr_cmp_d(a, 2.99999999999999) == 1);
+    std::vector<std::tuple<RCP<const Basic>, double, double>> testvec = {
+        std::make_tuple(pow(E, integer(2)), 7.3890560989306, 7.38905609893066),
+        std::make_tuple(max({integer(3), integer(2)}), 2.99999999999999,
+                        3.0000000000001),
+        std::make_tuple(max({sqrt(integer(3)), sqrt(integer(2))}),
+                        1.73205080756, 1.73205080758),
+        std::make_tuple(min({sqrt(integer(3)), sqrt(integer(2))}),
+                        1.41421356236, 1.41421356238),
+        std::make_tuple(loggamma(E), 0.44946174181, 0.44946174183),
+        std::make_tuple(loggamma(integer(5)), 3.17805383033, 3.17805383035),
+        std::make_tuple(log(arg1), 0.693147180559945, 0.693147180559946),
+        std::make_tuple(erf(integer(2)), 0.995322265017, 0.995322265019),
+        std::make_tuple(erf(div(E, pi)), 0.778918254986, 0.778918254988),
+        std::make_tuple(erfc(integer(2)), 0.004677734981, 0.004677734983),
+        std::make_tuple(sin(arg1), 0.90929742682568, 0.90929742682569),
+        std::make_tuple(cos(arg1), -0.41614683654715, -0.41614683654714),
+        std::make_tuple(tan(arg1), -2.1850398632616, -2.1850398632615),
+        std::make_tuple(csc(arg1), 1.0997501702946, 1.0997501702947),
+        std::make_tuple(sec(arg1), -2.4029979617224, -2.4029979617223),
+        std::make_tuple(cot(arg1), -0.45765755436029, -0.45765755436028),
+        std::make_tuple(asin(arg2), 0.25268025514207, 0.25268025514208),
+        std::make_tuple(acos(arg2), 1.3181160716528, 1.3181160716529),
+        std::make_tuple(atan(arg1), 1.1071487177940, 1.1071487177941),
+        std::make_tuple(acsc(arg1), 0.52359877559829, 0.5235987755983),
+        std::make_tuple(asec(arg1), 1.04719755119659, 1.04719755119660),
+        std::make_tuple(acot(arg1), 0.4636476090008, 0.46364760900081),
+        std::make_tuple(sinh(arg1), 3.6268604078470, 3.6268604078471),
+        std::make_tuple(cosh(arg2), 1.0314130998795, 1.0314130998796),
+        std::make_tuple(tanh(arg1), 0.96402758007581, 0.96402758007582),
+        std::make_tuple(csch(arg1), 0.27572056477178, 0.27572056477179),
+        std::make_tuple(sech(arg1), 0.2658022288340, 0.2658022288341),
+        std::make_tuple(coth(arg2), 4.082988165073, 4.082988165074),
+        std::make_tuple(asinh(arg1), 1.4436354751788, 1.4436354751789),
+        std::make_tuple(acosh(arg1), 1.3169578969248, 1.3169578969249),
+        std::make_tuple(atanh(arg2), 0.255412811882995, 0.255412811883),
+        std::make_tuple(acsch(arg2), 2.094712547261, 2.094712547262),
+        std::make_tuple(acoth(arg1), 0.54930614433405, 0.54930614433406),
+        std::make_tuple(asech(arg2), 2.0634370688955, 2.0634370688956),
+        std::make_tuple(atan2(arg1, arg2), 1.4464413322481, 1.4464413322482),
+        std::make_tuple(asech(div(one, integer(3))), 1.76274717403908,
+                        1.76274717403909),
+        std::make_tuple(gamma(div(arg1, integer(3))), 1.35411793942640,
+                        1.35411793942641),
+        std::make_tuple(gamma(add(arg1, arg2)), -100, 100),
+        std::make_tuple(gamma(arg1), -100, 100),
+        std::make_tuple(gamma(add(add(arg1, arg2), arg1)), -100, 100),
+        std::make_tuple(beta(add(arg1, arg2), arg1), 0.13675213675213,
+                        0.13675213675214),
+        std::make_tuple(abs((neg(sqrt(add(arg2, arg2))))), 0.70710678118654,
+                        0.70710678118655)};
 
-    r = max({sqrt(integer(3)), sqrt(integer(2))});
+    for (unsigned i = 0; i < testvec.size(); i++) {
+        eval_mpfr(a, *std::get<0>(testvec[i]), MPFR_RNDN);
+        REQUIRE(mpfr_cmp_d(a, std::get<1>(testvec[i])) == 1);
+        REQUIRE(mpfr_cmp_d(a, std::get<2>(testvec[i])) == -1);
+    }
 
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 1.73205080756) == 1);
-    REQUIRE(mpfr_cmp_d(a, 1.73205080758) == -1);
+    CHECK_THROWS_AS(eval_mpfr(a, *constant("dummy_constant"), MPFR_RNDN),
+                    NotImplementedError);
 
-    r = min({sqrt(integer(3)), sqrt(integer(2))});
-
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 1.41421356238) == -1);
-    REQUIRE(mpfr_cmp_d(a, 1.41421356236) == 1);
-
-    r = loggamma(E);
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 0.44946174183) == -1);
-    REQUIRE(mpfr_cmp_d(a, 0.44946174181) == 1);
-
-    r = loggamma(integer(5));
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 3.17805383035) == -1);
-    REQUIRE(mpfr_cmp_d(a, 3.17805383033) == 1);
-
-    r = erf(integer(2));
-
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 0.995322265019) == -1);
-    REQUIRE(mpfr_cmp_d(a, 0.995322265017) == 1);
-
-    r = erf(div(E, pi));
-
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 0.778918254988) == -1);
-    REQUIRE(mpfr_cmp_d(a, 0.778918254986) == 1);
-
-    r = erfc(integer(2));
-
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 0.004677734983) == -1);
-    REQUIRE(mpfr_cmp_d(a, 0.004677734981) == 1);
-
-    r = asech(div(one, integer(3)));
-
-    eval_mpfr(a, *r, MPFR_RNDN);
-    REQUIRE(mpfr_cmp_d(a, 1.76274717403909) == -1);
-    REQUIRE(mpfr_cmp_d(a, 1.76274717403908) == 1);
+    CHECK_THROWS_AS(eval_mpfr(a, *lambertw(arg1), MPFR_RNDN),
+                    NotImplementedError);
 
     mpfr_clear(a);
 }

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -24,7 +24,32 @@ using SymEngine::LambdaComplexDoubleVisitor;
 using SymEngine::max;
 using SymEngine::sin;
 using SymEngine::cos;
+using SymEngine::tan;
+using SymEngine::cot;
+using SymEngine::csc;
+using SymEngine::sec;
+using SymEngine::asin;
+using SymEngine::acos;
+using SymEngine::atan;
+using SymEngine::acot;
+using SymEngine::acsc;
+using SymEngine::asec;
+using SymEngine::sinh;
+using SymEngine::cosh;
+using SymEngine::tanh;
+using SymEngine::coth;
+using SymEngine::csch;
+using SymEngine::sech;
+using SymEngine::asinh;
+using SymEngine::acosh;
+using SymEngine::atanh;
+using SymEngine::acoth;
+using SymEngine::acsch;
+using SymEngine::asech;
+using SymEngine::atan2;
+using SymEngine::log;
 using SymEngine::E;
+using SymEngine::Catalan;
 using SymEngine::gamma;
 using SymEngine::loggamma;
 using SymEngine::min;
@@ -106,31 +131,41 @@ TEST_CASE("Evaluate functions", "[lambda_gamma]")
     double d;
     x = symbol("x");
 
-    r = gamma(x);
-
     LambdaRealDoubleVisitor v;
-    v.init({x}, *r);
 
-    d = v.call({1.1});
-    REQUIRE(::fabs(d - 0.9513507698668) < 1e-12);
+    std::vector<std::tuple<RCP<const Basic>, double, double>> testvec = {
+        std::make_tuple(pow(E, cos(x)), 1.3, 1.30669209920819),
+        std::make_tuple(add(sin(x), cos(x)), 1.2, 1.29439684044390),
+        std::make_tuple(mul(tan(x), sec(x)), 2.2, 2.33444426269917),
+        std::make_tuple(add(csc(x), cot(x)), 0.5, 3.91631736464594),
+        std::make_tuple(asin(x), 0.5, 0.523598775598299),
+        std::make_tuple(acos(x), 0.9, 0.451026811796262),
+        std::make_tuple(add(atan(x), asec(x)), 1.1, 1.26268093282586),
+        std::make_tuple(add(acot(x), acsc(x)), 3, 0.661587463850764),
+        std::make_tuple(add(sinh(x), csch(x)), 2.2, 4.68146604193974),
+        std::make_tuple(mul(tanh(x), cosh(x)), 0.2, 0.201336002541094),
+        std::make_tuple(sech(x), 0.5, 0.886818883970074),
+        std::make_tuple(coth(x), 0.9, 1.39606725303001),
+        std::make_tuple(mul(asinh(x), acosh(x)), 1.2, 0.632303583495024),
+        std::make_tuple(mul(acsch(x), asech(x)), 0.3, 3.59566705273267),
+        std::make_tuple(acoth(x), 3.3, 0.312852949882206),
+        std::make_tuple(atanh(x), 0.7, 0.867300527694053),
+        std::make_tuple(atan2(x, add(x, integer(1))), 2.1, 0.595409875478733),
+        std::make_tuple(log(x), 1.2, 0.182321556793955),
+        std::make_tuple(gamma(x), 1.1, 0.9513507698668),
+        std::make_tuple(add(Catalan, x), 1.1, 2.01596559417722),
+        std::make_tuple(loggamma(x), 1.3, -0.10817480950786047),
+        std::make_tuple(add(gamma(x), loggamma(x)), 1.1, 0.901478328607033459),
+        std::make_tuple(abs(x), -1.112111321, 1.112111321),
+        std::make_tuple(erf(x), 1.1, 0.88020506957408169),
+        std::make_tuple(erfc(x), 2.1, 0.00297946665633298),
+    };
 
-    r = loggamma(x);
-    v.init({x}, *r);
-
-    d = v.call({1.3});
-    REQUIRE(::fabs(d + 0.10817480950786047) < 1e-12);
-
-    r = add(gamma(x), loggamma(x));
-    v.init({x}, *r);
-
-    d = v.call({1.1});
-    REQUIRE(::fabs(d - 0.901478328607033459) < 1e-12);
-
-    r = erf(x);
-    v.init({x}, *r);
-
-    d = v.call({1.1});
-    REQUIRE(::fabs(d - 0.88020506957408169) < 1e-12);
+    for (unsigned i = 0; i < testvec.size(); i++) {
+        v.init({x}, *std::get<0>(testvec[i]));
+        d = v.call({std::get<1>(testvec[i])});
+        REQUIRE(::fabs(d - std::get<2>(testvec[i])) < 1e-12);
+    }
 }
 
 #ifdef HAVE_SYMENGINE_LLVM

--- a/symengine/tests/logic/test_logic.cpp
+++ b/symengine/tests/logic/test_logic.cpp
@@ -97,6 +97,11 @@ TEST_CASE("Piecewise", "[logic]")
                         {y, contains(x, int2)},
                         {add(x, y), contains(x, int3)}});
 
+    vec_basic v = p->get_args();
+    vec_basic u = {x,         contains(x, int1), y, contains(x, int2),
+                   add(x, y), contains(x, int3)};
+    REQUIRE(unified_eq(v, u));
+
     std::string s = "Piecewise((x, Contains(x, (1, 2])), (y, Contains(x, (2, "
                     "5])), (x + y, Contains(x, (5, 10])))";
     REQUIRE(s == p->__str__());
@@ -105,6 +110,7 @@ TEST_CASE("Piecewise", "[logic]")
                         {zero, contains(x, int2)},
                         {one, contains(x, int3)}});
 
+    REQUIRE((p->diff(x))->__hash__() == q->__hash__());
     REQUIRE(eq(*p->diff(x), *q));
 }
 
@@ -136,6 +142,10 @@ TEST_CASE("And, Or : Basic", "[basic]")
     auto s2 = logical_and({c2, c1});
     REQUIRE(s1->__hash__() == s2->__hash__());
     REQUIRE(eq(*s1, *s2));
+    vec_basic v = s2->get_args();
+    vec_basic u = {c2, c1};
+    REQUIRE(unified_eq(v, u));
+
     s1 = logical_or({c1, c2});
     str = s1->__str__();
     REQUIRE(str.find("Or(") == 0);
@@ -144,6 +154,9 @@ TEST_CASE("And, Or : Basic", "[basic]")
     s2 = logical_or({c2, c1});
     REQUIRE(s1->__hash__() == s2->__hash__());
     REQUIRE(eq(*s1, *s2));
+    v = s2->get_args();
+    u = {c2, c1};
+    REQUIRE(unified_eq(v, u));
 
     REQUIRE(eq(*logical_and({c1}), *c1));
     REQUIRE(eq(*logical_or({c1}), *c1));


### PR DESCRIPTION
While writing test cases , i came across several bugs as listed below and these are fixed now.
- [acsc()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-7adabd929d7b40deac32003312d6f910R281) and [asec()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-7adabd929d7b40deac32003312d6f910R286) in real_double.cpp
- [Beta::rewrite_as_gamma()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-ccb9531ddf99a9263a8ca4275bdf438eR2758) in functions.cpp
- [acsch()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-748ec5462b257fcab8881d2d458be573R904), [acoth()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-748ec5462b257fcab8881d2d458be573R953), [asech()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-748ec5462b257fcab8881d2d458be573R973) and [2 bugs in acosh()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-748ec5462b257fcab8881d2d458be573R914) in real_mpfr.cpp
- removed [extra check](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-0c21d17fbbe529072b91e762a5c9760dL421) in parser.cpp
- [cot()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-f9e408919c4b9935fa9a23ee4661686fR679),[csc()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-f9e408919c4b9935fa9a23ee4661686fR699),[sec()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-f9e408919c4b9935fa9a23ee4661686fR689) ,[coth()](https://github.com/symengine/symengine/compare/master...ranjithkumar007:TargetCov100%25?expand=1#diff-f9e408919c4b9935fa9a23ee4661686fR813) in complex_mpc.cpp

Apart from the above bug fixes, vector of tuples is used at many places to facilitate testing and remove code redundancy.

Doubts & further TO-DO's : 
- [x]  In [log](https://github.com/symengine/symengine/blob/master/symengine/functions.cpp#L1222) ```is_canonical()``` , why argument used is of type ```const Basic``` instead of ```const RCP<const Basic>``` ?
- [x]  tests for ```is_canonical``` in hyperbolic functions and increase coverage of ```logic.cpp```
- [x] Fix the bug in comparing two objects of type [ComplexMPC](https://github.com/symengine/symengine/blob/master/symengine/complex_mpc.cpp#L43). the correct way of comparing them is to decompose output of mpc_cmp function into x and y and then check them as mentioned in [docs](http://www.multiprecision.org/index.php?prog=mpc&page=html#index-mpc_005fcmp).