### PR TITLE
symengine/pow.cpp: Print `exp(1)` instead of `E` to maintain consistency

### DIFF
--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -380,11 +380,8 @@ void StrPrinter::bvisit(const Mul &x)
             o2 << "*";
             den++;
         } else {
-            if (eq(*(p.second), *one)) {
-                if(eq(*(p.first), *E))
-                    _print_pow(o, p.first, p.second);
-                else
-                    o << parenthesizeLT(p.first, PrecedenceEnum::Mul);
+            if (eq(*(p.second), *one) and neq(*(p.first), *E)) {
+                o << parenthesizeLT(p.first, PrecedenceEnum::Mul);
             } else {
                 _print_pow(o, p.first, p.second);
             }
@@ -625,13 +622,11 @@ void StrPrinter::bvisit(const Log &x)
 
 void StrPrinter::bvisit(const Constant &x)
 {
-    /*If the constant is E then it is to
-      be printed as exp(1), this is done
-      to maintain consistency with sympy*/
+    //If the constant is E then it is to
+    //be printed as exp(1), this is done
+    //to maintain consistency
     if(x.get_name() == "E") {
-        std::ostringstream s;
-        s << "exp(1)";
-        str_ = s.str() ;
+        str_ = "exp(1)" ;
     } else {
         str_ = x.get_name();
     }

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -622,11 +622,11 @@ void StrPrinter::bvisit(const Log &x)
 
 void StrPrinter::bvisit(const Constant &x)
 {
-    //If the constant is E then it is to
-    //be printed as exp(1), this is done
-    //to maintain consistency
-    if(x.get_name() == "E") {
-        str_ = "exp(1)" ;
+    // If the constant is E then it is to
+    // be printed as exp(1), this is done
+    // to maintain consistency
+    if (x.get_name() == "E") {
+        str_ = "exp(1)";
     } else {
         str_ = x.get_name();
     }

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -625,7 +625,16 @@ void StrPrinter::bvisit(const Log &x)
 
 void StrPrinter::bvisit(const Constant &x)
 {
-    str_ = x.get_name();
+    /*If the constant is E then it is to
+      be printed as exp(1), this is done
+      to maintain consistency with sympy*/
+    if(x.get_name() == "E") {
+        std::ostringstream s;
+        s << "exp(1)";
+        str_ = s.str() ;
+    } else {
+        str_ = x.get_name();
+    }
 }
 
 std::string StrPrinter::apply(const vec_basic &d)

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -381,7 +381,10 @@ void StrPrinter::bvisit(const Mul &x)
             den++;
         } else {
             if (eq(*(p.second), *one)) {
-                o << parenthesizeLT(p.first, PrecedenceEnum::Mul);
+                if(eq(*(p.first), *E))
+                    _print_pow(o, p.first, p.second);
+                else
+                    o << parenthesizeLT(p.first, PrecedenceEnum::Mul);
             } else {
                 _print_pow(o, p.first, p.second);
             }

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -729,7 +729,7 @@ void test_constants()
     SYMENGINE_C_ASSERT(strcmp(s, "pi") == 0);
     basic_str_free(s);
     s = basic_str(e);
-    SYMENGINE_C_ASSERT(strcmp(s, "E") == 0);
+    SYMENGINE_C_ASSERT(strcmp(s, "exp(1)") == 0);
     basic_str_free(s);
     s = basic_str_julia(e);
     SYMENGINE_C_ASSERT(strcmp(s, "exp(1)") == 0);

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -94,6 +94,8 @@ TEST_CASE("test_printing(): printing", "[printing]")
     REQUIRE(r->__str__() == "exp(-x)");
     r = exp(integer(-1));
     REQUIRE(r->__str__() == "exp(-1)");
+    r = exp(integer(1));
+    REQUIRE(r->__str__() == "exp(1)");
     r = mul(exp(integer(-1)), integer(2));
     REQUIRE(r->__str__() == "2*exp(-1)");
     r = mul(exp(integer(-3)), integer(2));

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -99,7 +99,7 @@ TEST_CASE("test_printing(): printing", "[printing]")
     r = mul(exp(integer(-3)), integer(2));
     REQUIRE(r->__str__() == "2*exp(-3)");
     r = mul(exp(integer(1)), integer(2));
-    REQUIRE(r->__str__() == "2*E");
+    REQUIRE(r->__str__() == "2*exp(1)");
     r = div(exp(integer(-1)), symbol("x"));
     REQUIRE(r->__str__() == "exp(-1)/x");
 


### PR DESCRIPTION
Closes https://github.com/symengine/symengine/issues/1225