### PR TITLE
Remove static keyword from LLVM double ONE_ARG_EXTERNAL_FUNCTION macro.

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -387,7 +387,7 @@ void LLVMDoubleVisitor::bvisit(const Log &x)
 #define ONE_ARG_EXTERNAL_FUNCTION(Class, ext)                                  \
     void LLVMDoubleVisitor::bvisit(const Class &x)                             \
     {                                                                          \
-        static llvm::Function *func = get_external_function(#ext);             \
+        llvm::Function *func = get_external_function(#ext);                    \
         auto r = builder->CreateCall(func, {apply(*x.get_arg())});             \
         r->setTailCall(true);                                                  \
         result_ = r;                                                           \


### PR DESCRIPTION
This fixes a segmentation fault that may arise when sequential calls are
made to the functions defined with this macro.