### PR TITLE
New C wrappers for real and imaginary part of complex numbers

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -335,7 +335,7 @@ int real_mpfr_is_zero(const basic s)
 CWRAPPER_OUTPUT_TYPE complex_base_real_part(basic s, const basic com)
 {
     CWRAPPER_BEGIN
-    SYMENGINE_ASSERT(is_a<ComplexBase>(*(com->m)));
+    SYMENGINE_ASSERT(SymEngine::is_a_Complex(*(com->m)));
     s->m = (down_cast<const ComplexBase &>(*(com->m))).real_part();
     CWRAPPER_END
 }
@@ -343,7 +343,7 @@ CWRAPPER_OUTPUT_TYPE complex_base_real_part(basic s, const basic com)
 CWRAPPER_OUTPUT_TYPE complex_base_imaginary_part(basic s, const basic com)
 {
     CWRAPPER_BEGIN
-    SYMENGINE_ASSERT(is_a<ComplexBase>(*(com->m)));
+    SYMENGINE_ASSERT(SymEngine::is_a_Complex(*(com->m)));
     s->m = (down_cast<const ComplexBase &>(*(com->m))).imaginary_part();
     CWRAPPER_END
 }

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -331,7 +331,7 @@ int real_mpfr_is_zero(const basic s)
 }
 
 #endif // HAVE_SYMENGINE_MPFR
-        
+
 CWRAPPER_OUTPUT_TYPE complex_base_real_part(basic s, const basic com)
 {
     CWRAPPER_BEGIN

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -22,6 +22,7 @@ using SymEngine::Integer;
 using SymEngine::integer_class;
 using SymEngine::rational_class;
 using SymEngine::Number;
+using SymEngine::ComplexBase;
 using SymEngine::Complex;
 using SymEngine::ComplexDouble;
 using SymEngine::RealDouble;
@@ -329,6 +330,22 @@ int real_mpfr_is_zero(const basic s)
     return (int)((down_cast<const RealMPFR &>(*(s->m))).is_zero());
 }
 
+CWRAPPER_OUTPUT_TYPE complex_base_real_part(basic s, const basic com)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(is_a<ComplexBase>(*(com->m)));
+    s->m = (down_cast<const ComplexBase &>(*(com->m))).real_part();
+    CWRAPPER_END
+}
+
+CWRAPPER_OUTPUT_TYPE complex_base_imaginary_part(basic s, const basic com)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(is_a<ComplexBase>(*(com->m)));
+    s->m = (down_cast<const ComplexBase &>(*(com->m))).imaginary_part();
+    CWRAPPER_END
+}
+
 #endif // HAVE_SYMENGINE_MPFR
 #ifdef HAVE_SYMENGINE_MPC
 int complex_mpc_is_zero(const basic s)
@@ -336,23 +353,6 @@ int complex_mpc_is_zero(const basic s)
     SYMENGINE_ASSERT(is_a<ComplexMPC>(*(s->m)));
     return (int)((down_cast<const ComplexMPC &>(*(s->m))).is_zero());
 }
-
-CWRAPPER_OUTPUT_TYPE complex_mpc_real_part(basic s, const basic com)
-{
-    CWRAPPER_BEGIN
-    SYMENGINE_ASSERT(is_a<ComplexMPC>(*(com->m)));
-    s->m = (down_cast<const ComplexMPC &>(*(com->m))).real_part();
-    CWRAPPER_END
-}
-
-CWRAPPER_OUTPUT_TYPE complex_mpc_imaginary_part(basic s, const basic com)
-{
-    CWRAPPER_BEGIN
-    SYMENGINE_ASSERT(is_a<ComplexMPC>(*(com->m)));
-    s->m = (down_cast<const ComplexMPC &>(*(com->m))).imaginary_part();
-    CWRAPPER_END
-}
-
 #endif // HAVE_SYMENGINE_MPC
 signed long integer_get_si(const basic s)
 {
@@ -446,38 +446,6 @@ CWRAPPER_OUTPUT_TYPE complex_set_mpq(basic s, const mpq_t re, const mpq_t im)
     CWRAPPER_END
 }
 #endif
-
-CWRAPPER_OUTPUT_TYPE complex_real_part(basic s, const basic com)
-{
-    CWRAPPER_BEGIN
-    SYMENGINE_ASSERT(is_a<Complex>(*(com->m)));
-    s->m = (down_cast<const Complex &>(*(com->m))).real_part();
-    CWRAPPER_END
-}
-
-CWRAPPER_OUTPUT_TYPE complex_imaginary_part(basic s, const basic com)
-{
-    CWRAPPER_BEGIN
-    SYMENGINE_ASSERT(is_a<Complex>(*(com->m)));
-    s->m = (down_cast<const Complex &>(*(com->m))).imaginary_part();
-    CWRAPPER_END
-}
-
-CWRAPPER_OUTPUT_TYPE complex_double_real_part(basic s, const basic com)
-{
-    CWRAPPER_BEGIN
-    SYMENGINE_ASSERT(is_a<ComplexDouble>(*(com->m)));
-    s->m = (down_cast<const ComplexDouble &>(*(com->m))).real_part();
-    CWRAPPER_END
-}
-
-CWRAPPER_OUTPUT_TYPE complex_double_imaginary_part(basic s, const basic com)
-{
-    CWRAPPER_BEGIN
-    SYMENGINE_ASSERT(is_a<ComplexDouble>(*(com->m)));
-    s->m = (down_cast<const ComplexDouble &>(*(com->m))).imaginary_part();
-    CWRAPPER_END
-}
 
 dcomplex complex_double_get(const basic s)
 {

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -348,7 +348,6 @@ CWRAPPER_OUTPUT_TYPE complex_base_imaginary_part(basic s, const basic com)
     CWRAPPER_END
 }
 
-#endif // HAVE_SYMENGINE_MPFR
 #ifdef HAVE_SYMENGINE_MPC
 int complex_mpc_is_zero(const basic s)
 {

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -330,6 +330,8 @@ int real_mpfr_is_zero(const basic s)
     return (int)((down_cast<const RealMPFR &>(*(s->m))).is_zero());
 }
 
+#endif // HAVE_SYMENGINE_MPFR
+        
 CWRAPPER_OUTPUT_TYPE complex_base_real_part(basic s, const basic com)
 {
     CWRAPPER_BEGIN

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -184,13 +184,14 @@ mpfr_prec_t real_mpfr_get_prec(const basic s);
 int real_mpfr_is_zero(const basic s);
 #endif // HAVE_SYMENGINE_MPFR
 
+//! Assign to s, the real part of com
+CWRAPPER_OUTPUT_TYPE complex_base_real_part(basic s, const basic com);
+//! Assign to s, the imaginary part of com
+CWRAPPER_OUTPUT_TYPE complex_base_imaginary_part(basic s, const basic com);
+
 #ifdef HAVE_SYMENGINE_MPC
 //! Returns 1 if s has value zero; 0 otherwise
 int complex_mpc_is_zero(const basic s);
-//! Assign to s, the real part of com
-CWRAPPER_OUTPUT_TYPE complex_mpc_real_part(basic s, const basic com);
-//! Assign to s, the imaginary part of com
-CWRAPPER_OUTPUT_TYPE complex_mpc_imaginary_part(basic s, const basic com);
 #endif // HAVE_SYMENGINE_MPC
 
 //! Returns signed long value of s.
@@ -223,14 +224,6 @@ CWRAPPER_OUTPUT_TYPE complex_set_rat(basic s, const basic re, const basic im);
 //! Assign to s, a complex re + i*im, where re and im are of type mpq.
 CWRAPPER_OUTPUT_TYPE complex_set_mpq(basic s, const mpq_t re, const mpq_t im);
 #endif
-//! Assign to s, a real where com is a complex
-CWRAPPER_OUTPUT_TYPE complex_real_part(basic s, const basic com);
-//! Assign to s, an imaginary where com is a complex
-CWRAPPER_OUTPUT_TYPE complex_imaginary_part(basic s, const basic com);
-//! Assign to s, a real double where com is a complex double
-CWRAPPER_OUTPUT_TYPE complex_double_real_part(basic s, const basic com);
-//! Assign to s, an imaginary double where com is a complex double
-CWRAPPER_OUTPUT_TYPE complex_double_imaginary_part(basic s, const basic com);
 
 //! Extract the real and imaginary doubles from the std::complex<double> stored
 //! in basic

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -205,7 +205,7 @@ void test_complex()
 
     basic_str_free(s);
 
-    complex_real_part(f, e);
+    complex_base_real_part(f, e);
     s = basic_str(f);
 
     SYMENGINE_C_ASSERT(strcmp(s, "100/47") == 0);
@@ -216,7 +216,7 @@ void test_complex()
 
     basic_str_free(s);
 
-    complex_imaginary_part(f, e);
+    complex_base_imaginary_part(f, e);
     s = basic_str(f);
 
     SYMENGINE_C_ASSERT(strcmp(s, "76/59") == 0);
@@ -260,7 +260,7 @@ void test_complex_double()
     SYMENGINE_C_ASSERT(k.real == 100.47);
     SYMENGINE_C_ASSERT(k.imag == 76.59);
 
-    complex_double_real_part(f, e);
+    complex_base_real_part(f, e);
     s = basic_str(f);
 
     SYMENGINE_C_ASSERT(strcmp(s, "100.47") == 0);
@@ -272,7 +272,7 @@ void test_complex_double()
 
     basic_str_free(s);
 
-    complex_double_imaginary_part(f, e);
+    complex_base_imaginary_part(f, e);
     s = basic_str(f);
 
     SYMENGINE_C_ASSERT(strcmp(s, "76.59") == 0);
@@ -360,10 +360,10 @@ void test_complex_mpc()
     basic r1;
     basic_new_stack(r1);
 
-    complex_mpc_real_part(r1, d2);
+    complex_base_real_part(r1, d2);
     SYMENGINE_C_ASSERT(basic_eq(r1, d));
 
-    complex_mpc_imaginary_part(r1, d2);
+    complex_base_imaginary_part(r1, d2);
     SYMENGINE_C_ASSERT(basic_eq(r1, d1));
 
     basic_free_stack(d);
@@ -1254,9 +1254,9 @@ void test_eval()
     basic_evalf(eval, n1, 53, 0);
     SYMENGINE_C_ASSERT(basic_get_type(eval) == SYMENGINE_COMPLEX_DOUBLE);
     d = -0.780872515;
-    complex_double_real_part(temp, eval);
+    complex_base_real_part(temp, eval);
     d2 = real_double_get_d(temp);
-    complex_double_imaginary_part(temp, eval);
+    complex_base_imaginary_part(temp, eval);
     double d3 = real_double_get_d(temp);
     double d4 = -0.3688890370;
     d = fabs(d - d2);
@@ -1297,9 +1297,9 @@ void test_eval()
 
     // With 53 bit precision, `com1` and `com2` have the same value.
     // Hence value of `r1` was  rounded down to `0.000000000000000`
-    complex_double_real_part(temp, eval3);
+    complex_base_real_part(temp, eval3);
     SYMENGINE_C_ASSERT(real_double_get_d(temp) == 0.0);
-    complex_double_imaginary_part(temp, eval3);
+    complex_base_imaginary_part(temp, eval3);
     SYMENGINE_C_ASSERT(real_double_get_d(temp) == 0.0);
 
     basic_evalf(eval3, r1, 100, 0);


### PR DESCRIPTION
I have replaced these three wrappers

```
CWRAPPER_OUTPUT_TYPE complex_real_part(basic s, const basic com);
CWRAPPER_OUTPUT_TYPE complex_double_real_part(basic s, const basic com);
CWRAPPER_OUTPUT_TYPE complex_mpc_real_part(basic s, const basic com);
```

by just the following one

```
CWRAPPER_OUTPUT_TYPE complex_base_real_part(basic s, const basic com)
{
    CWRAPPER_BEGIN
    SYMENGINE_ASSERT(is_a<ComplexBase>(*(com->m)));
    s->m = (down_cast<const ComplexBase &>(*(com->m))).real_part();
    CWRAPPER_END
}
```

And I did analogue changes regarding the `imaginary_part` wrappers.

So all in all 6 wrappers have been replaced by just 2, without loosing any functionality.

Hope you like it!