### PR TITLE
Added vecbasic_{ set, erase } to C wrappers

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -815,6 +815,22 @@ CWRAPPER_OUTPUT_TYPE vecbasic_get(CVecBasic *self, size_t n, basic result)
     CWRAPPER_END
 }
 
+CWRAPPER_OUTPUT_TYPE vecbasic_set(CVecBasic *self, size_t n, const basic s)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(n < self->m.size());
+    self->m[n] = s->m;
+    CWRAPPER_END
+}
+
+CWRAPPER_OUTPUT_TYPE vecbasic_erase(CVecBasic *self, size_t n)
+{
+    CWRAPPER_BEGIN
+    SYMENGINE_ASSERT(n < self->m.size());
+    self->m.erase(self->m.begin() + n);
+    CWRAPPER_END
+}
+
 size_t vecbasic_size(CVecBasic *self)
 {
     return self->m.size();

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -406,6 +406,8 @@ CVecBasic *vecbasic_new();
 void vecbasic_free(CVecBasic *self);
 CWRAPPER_OUTPUT_TYPE vecbasic_push_back(CVecBasic *self, const basic value);
 CWRAPPER_OUTPUT_TYPE vecbasic_get(CVecBasic *self, size_t n, basic result);
+CWRAPPER_OUTPUT_TYPE vecbasic_set(CVecBasic *self, size_t n, const basic s);
+CWRAPPER_OUTPUT_TYPE vecbasic_erase(CVecBasic *self, size_t n);
 size_t vecbasic_size(CVecBasic *self);
 
 //! Assigns to s the max of the provided args.

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -430,9 +430,26 @@ void test_CVecBasic()
 
     SYMENGINE_C_ASSERT(basic_eq(x, y));
 
+    vecbasic_push_back(vec, x);
+
+    SYMENGINE_C_ASSERT(vecbasic_size(vec) == 2);
+
+    vecbasic_erase(vec, 0);
+
+    SYMENGINE_C_ASSERT(vecbasic_size(vec) == 1);
+
+    basic z;
+    basic_new_stack(z);
+    symbol_set(z, "z");
+    vecbasic_set(vec, 0, z);
+    vecbasic_get(vec, 0, y);
+
+    SYMENGINE_C_ASSERT(basic_eq(y, z));
+
     vecbasic_free(vec);
     basic_free_stack(x);
     basic_free_stack(y);
+    basic_free_stack(z);
 }
 
 void test_CSetBasic()


### PR DESCRIPTION
I have added `vecbasic_set` and `vecbasic_erase` to the C wrappers. I am using them, may be they are useful for others as well.