### PR TITLE
Update Travis-CI Linux Distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ compiler:
 os:
   - linux
   - osx
+dist: trusty
 cache:
   directories:
   - $HOME/.ccache


### PR DESCRIPTION
Fixes #1307.
Currently `llvm-toolchain-trusty-3.7` is not white-listed on `Travis`, so this is running `llvm-toolchain-precise-3.7`. Suggestions?