### PR TITLE
Remove CMake keyword to let libcatch build shared library.

### DIFF
--- a/symengine/utilities/catch/CMakeLists.txt
+++ b/symengine/utilities/catch/CMakeLists.txt
@@ -5,4 +5,4 @@ set(SRC
 )
 
 add_library(catch ${SRC})
-target_link_libraries(catch symengine)
+#target_link_libraries(catch symengine)

--- a/symengine/utilities/catch/CMakeLists.txt
+++ b/symengine/utilities/catch/CMakeLists.txt
@@ -4,5 +4,5 @@ set(SRC
     catch.cpp
 )
 
-add_library(catch STATIC ${SRC})
+add_library(catch ${SRC})
 target_link_libraries(catch symengine)


### PR DESCRIPTION
This is required when SymEngine is built as a shared library.