### PR TITLE
Add LambdaRealDoubleVisitor to cwrapper

### DIFF
--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -18,9 +18,8 @@ export GCOV_EXECUTABLE=gcov
 
 if [[ "${TRAVIS_OS_NAME}" == "osx" ]] && [[ "${CC}" == "gcc" ]]; then
     brew update
-    brew install gcc
-    export CC=gcc
-    export CXX=g++
+    export CC=gcc-4.9
+    export CXX=g++-4.9
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ "${CC}" == "gcc" ]]; then

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -7,6 +7,7 @@
 #include <symengine/matrix.h>
 #include <symengine/eval.h>
 #include <symengine/parser.h>
+#include <symengine/lambda_double.h>
 #define xstr(s) str(s)
 #define str(s) #s
 
@@ -26,6 +27,7 @@ using SymEngine::ComplexBase;
 using SymEngine::Complex;
 using SymEngine::ComplexDouble;
 using SymEngine::RealDouble;
+using SymEngine::LambdaRealDoubleVisitor;
 using SymEngine::down_cast;
 #ifdef HAVE_SYMENGINE_MPFR
 using SymEngine::RealMPFR;
@@ -1515,6 +1517,34 @@ CWRAPPER_OUTPUT_TYPE basic_as_numer_denom(basic numer, basic denom,
     SymEngine::as_numer_denom(x->m, SymEngine::outArg(numer->m),
                               SymEngine::outArg(denom->m));
     CWRAPPER_END
+}
+
+struct CLambdaRealDoubleVisitor {
+    SymEngine::LambdaRealDoubleVisitor m;
+};
+
+CLambdaRealDoubleVisitor *lambda_real_double_visitor_new()
+{
+    return new CLambdaRealDoubleVisitor();
+}
+
+void lambda_real_double_visitor_init(CLambdaRealDoubleVisitor *self,
+                                     const CVecBasic *args,
+                                     const CVecBasic *exprs, int perform_cse)
+{
+    self->m.init(args->m, exprs->m, perform_cse);
+}
+
+void lambda_real_double_visitor_call(CLambdaRealDoubleVisitor *self,
+                                     double *const outs,
+                                     const double *const inps)
+{
+    self->m.call(outs, inps);
+}
+
+void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self)
+{
+    delete self;
 }
 
 //! Print stacktrace on segfault

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -8,6 +8,11 @@
 #include <symengine/eval.h>
 #include <symengine/parser.h>
 #include <symengine/lambda_double.h>
+#ifdef HAVE_SYMENGINE_LLVM
+#include <symengine/llvm_double.h>
+using SymEngine::LLVMDoubleVisitor;
+#endif
+
 #define xstr(s) str(s)
 #define str(s) #s
 
@@ -1547,6 +1552,33 @@ void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self)
     delete self;
 }
 
+#ifdef HAVE_SYMENGINE_LLVM
+struct CLLVMDoubleVisitor {
+    SymEngine::LLVMDoubleVisitor m;
+};
+
+CLLVMDoubleVisitor *llvm_double_visitor_new()
+{
+    return new CLLVMDoubleVisitor();
+}
+
+void llvm_double_visitor_init(CLLVMDoubleVisitor *self, const CVecBasic *args,
+                              const CVecBasic *exprs, int perform_cse)
+{
+    self->m.init(args->m, exprs->m, perform_cse);
+}
+
+void llvm_double_visitor_call(CLLVMDoubleVisitor *self, double *const outs,
+                              const double *const inps)
+{
+    self->m.call(outs, inps);
+}
+
+void llvm_double_visitor_free(CLLVMDoubleVisitor *self)
+{
+    delete self;
+}
+#endif
 //! Print stacktrace on segfault
 void symengine_print_stack_on_segfault()
 {

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -658,6 +658,17 @@ CWRAPPER_OUTPUT_TYPE basic_evalf(basic s, const basic b, unsigned long bits,
 CWRAPPER_OUTPUT_TYPE basic_as_numer_denom(basic numer, basic denom,
                                           const basic x);
 
+//! Wrapper for LambdaRealDoubleVisitor
+typedef struct CLambdaRealDoubleVisitor CLambdaRealDoubleVisitor;
+CLambdaRealDoubleVisitor *lambda_real_double_visitor_new();
+void lambda_real_double_visitor_init(CLambdaRealDoubleVisitor *self,
+                                     const CVecBasic *args,
+                                     const CVecBasic *exprs, int perform_cse);
+void lambda_real_double_visitor_call(CLambdaRealDoubleVisitor *self,
+                                     double *const outs,
+                                     const double *const inps);
+void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self);
+
 //! Print stacktrace on segfault
 void symengine_print_stack_on_segfault();
 

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -669,6 +669,17 @@ void lambda_real_double_visitor_call(CLambdaRealDoubleVisitor *self,
                                      const double *const inps);
 void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self);
 
+//! Wrapper for LambdaRealDoubleVisitor
+#ifdef HAVE_SYMENGINE_LLVM
+typedef struct CLLVMDoubleVisitor CLLVMDoubleVisitor;
+CLLVMDoubleVisitor *llvm_double_visitor_new();
+void llvm_double_visitor_init(CLLVMDoubleVisitor *self, const CVecBasic *args,
+                              const CVecBasic *exprs, int perform_cse);
+void llvm_double_visitor_call(CLLVMDoubleVisitor *self, double *const outs,
+                              const double *const inps);
+void llvm_double_visitor_free(CLLVMDoubleVisitor *self);
+#endif
+
 //! Print stacktrace on segfault
 void symengine_print_stack_on_segfault();
 

--- a/symengine/lambda_double.h
+++ b/symengine/lambda_double.h
@@ -109,7 +109,7 @@ public:
         }
         auto it = cse_intermediate_fns_map.find(x.rcp_from_this());
         if (it != cse_intermediate_fns_map.end()) {
-            unsigned index = it->second;
+            auto index = it->second;
             result_
                 = [=](const T *x) { return cse_intermediate_results[index]; };
             return;

--- a/symengine/lambda_double.h
+++ b/symengine/lambda_double.h
@@ -24,7 +24,7 @@ protected:
     std::vector<fn> results;
     std::vector<T> cse_intermediate_results;
 
-    std::map<RCP<const Basic>, unsigned, RCPBasicKeyLess>
+    std::map<RCP<const Basic>, size_t, RCPBasicKeyLess>
         cse_intermediate_fns_map;
     std::vector<fn> cse_intermediate_fns;
     fn result_;

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1846,6 +1846,14 @@ void test_lambda_double()
         lambda_real_double_visitor_free(vis);
         SYMENGINE_C_ASSERT(fabs(outs[0] - 43.5) < 1e-12);
         SYMENGINE_C_ASSERT(fabs(outs[1] - 45.0) < 1e-12);
+#ifdef HAVE_SYMENGINE_LLVM
+        CLLVMDoubleVisitor *vis2 = llvm_double_visitor_new();
+        llvm_double_visitor_init(vis2, args, exprs, perform_cse);
+        llvm_double_visitor_call(vis2, outs, inps);
+        llvm_double_visitor_free(vis2);
+        SYMENGINE_C_ASSERT(fabs(outs[0] - 43.5) < 1e-12);
+        SYMENGINE_C_ASSERT(fabs(outs[1] - 45.0) < 1e-12);
+#endif
     }
     basic_free_stack(two);
     basic_free_stack(x);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1859,6 +1859,7 @@ void test_lambda_double()
 
 int main(int argc, char *argv[])
 {
+    symengine_print_stack_on_segfault();
     test_version();
     test_cwrapper();
     test_complex();
@@ -1889,7 +1890,6 @@ int main(int argc, char *argv[])
 #ifdef HAVE_SYMENGINE_MPC
     test_complex_mpc();
 #endif // HAVE_SYMENGINE_MPC
-    symengine_print_stack_on_segfault();
     test_matrix();
     test_lambda_double();
     return 0;

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1816,16 +1816,16 @@ void test_lambda_double()
     CVecBasic *args = vecbasic_new();
     CVecBasic *exprs = vecbasic_new();
 
-    vecbasic_push_back(args, x);
-    vecbasic_push_back(args, y);
-    vecbasic_push_back(args, z);
-
     integer_set_si(two, 2);
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
     symbol_set(r, "r");
     symbol_set(s, "s");
+
+    vecbasic_push_back(args, x);
+    vecbasic_push_back(args, y);
+    vecbasic_push_back(args, z);
 
     // r = x + y*z + (y*z)**2
     // s = 2*x + y*z + (y*z)**2

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1805,6 +1805,10 @@ void test_matrix()
 
 void test_lambda_double()
 {
+    int perform_cse;
+    double outs[2];
+    double inps[3] = {1.5, 2.0, 3.0};
+
     basic two, x, y, z, r, s;
     basic_new_stack(two);
     basic_new_stack(x);
@@ -1837,9 +1841,7 @@ void test_lambda_double()
     vecbasic_push_back(exprs, r);
     vecbasic_push_back(exprs, s);
 
-    double outs[2];
-    double inps[3] = {1.5, 2.0, 3.0};
-    for (int perform_cse = 0; perform_cse <= 1; ++perform_cse) {
+    for (perform_cse = 0; perform_cse <= 1; ++perform_cse) {
         CLambdaRealDoubleVisitor *vis = lambda_real_double_visitor_new();
         lambda_real_double_visitor_init(vis, args, exprs, perform_cse);
         lambda_real_double_visitor_call(vis, outs, inps);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -161,7 +161,6 @@ void test_cwrapper()
     SYMENGINE_C_ASSERT(is_a_Integer(p));
     SYMENGINE_C_ASSERT(integer_get_si(p) == 444);
 
-    basic_new_stack(p);
     basic_parse2(p, str, 1);
     SYMENGINE_C_ASSERT(is_a_Integer(p));
     SYMENGINE_C_ASSERT(integer_get_si(p) == 444);
@@ -1840,7 +1839,7 @@ void test_lambda_double()
 
     double outs[2];
     double inps[3] = {1.5, 2.0, 3.0};
-    for (int perform_cse=0; perform_cse<=1; ++perform_cse) {
+    for (int perform_cse = 0; perform_cse <= 1; ++perform_cse) {
         CLambdaRealDoubleVisitor *vis = lambda_real_double_visitor_new();
         lambda_real_double_visitor_init(vis, args, exprs, perform_cse);
         lambda_real_double_visitor_call(vis, outs, inps);
@@ -1857,7 +1856,6 @@ void test_lambda_double()
     vecbasic_free(args);
     vecbasic_free(exprs);
 }
-
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Work-in-progress. Segfaulting right now:
```
#0  0x00000000005245f2 in SymEngine::Symbol::__eq__(SymEngine::Basic const&) const ()
#1  0x00000000004cfbd9 in SymEngine::LambdaDoubleVisitor<double>::bvisit(SymEngine::Symbol const&) ()
#2  0x00000000004ca9e6 in SymEngine::LambdaDoubleVisitor<double>::bvisit(SymEngine::Add const&) ()
#3  0x00000000004bafcc in lambda_real_double_visitor_init ()
#4  0x00000000004b05e8 in test_lambda_double ()
#5  0x00000000004a7d61 in main ()
```
will try again soon, but thought I should ask and see if it looks reasonable (once the test passes).
As you can see from the branch name my idea is to expose the LLVM visitor as well.