### PR TITLE
Add support for LLVM5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
     - compiler: clang
     - os: osx
   include:
-    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" WITH_COVERAGE="yes" WITH_MPC="yes"
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LATEST_GCC="yes" WITH_COVERAGE="yes" WITH_MPC="yes" WITH_LLVM="5.0"
       compiler: gcc
       os: linux
       addons:
@@ -114,7 +114,7 @@ matrix:
           packages:
           - binutils-dev
           - g++-4.8
-    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LLVM="yes" WITH_BENCHMARKS_NONIUS="yes"
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_LLVM="3.8" WITH_BENCHMARKS_NONIUS="yes"
       compiler: clang
       os: linux
       addons:
@@ -137,10 +137,10 @@ matrix:
           - clang
           - libstdc++-4.8-dev
           - libgmp-dev
-    - env: BUILD_TYPE="Debug"
+    - env: BUILD_TYPE="Debug" WITH_LLVM="3.8"
       compiler: clang
       os: osx
-    - env: BUILD_TYPE="Release"
+    - env: BUILD_TYPE="Release" WITH_LLVM="5.0"
       compiler: clang
       os: osx
     - env: BUILD_TYPE="Debug"

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -73,7 +73,7 @@ if [[ "${WITH_BENCHMARKS_NONIUS}" == "yes" ]]; then
 fi
 
 if [[ "${WITH_PIRANHA}" == "yes" ]]; then
-    conda_pkgs="$conda_pkgs piranha=0.8 cmake=3.6.2"
+    conda_pkgs="$conda_pkgs piranha=0.8 cmake=3.10.0"
 fi
 
 if [[ "${WITH_PRIMESIEVE}" == "yes" ]]; then
@@ -97,7 +97,7 @@ if [[ "${WITH_ARB}" == "yes" ]]; then
 fi
 
 if [[ ! -z "${WITH_LLVM}" ]]; then
-    conda_pkgs="$conda_pkgs llvmdev=${WITH_LLVM} cmake=3.6.2"
+    conda_pkgs="$conda_pkgs llvmdev=${WITH_LLVM} cmake=3.10.0"
 fi
 
 if [[ "${WITH_ECM}" == "yes" ]]; then

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -96,8 +96,8 @@ if [[ "${WITH_ARB}" == "yes" ]]; then
     conda_pkgs="$conda_pkgs arb=2.8.1"
 fi
 
-if [[ "${WITH_LLVM}" == "yes" ]]; then
-    conda_pkgs="$conda_pkgs llvmdev=3.8 cmake=3.6.2"
+if [[ ! -z "${WITH_LLVM}" ]]; then
+    conda_pkgs="$conda_pkgs llvmdev=${WITH_LLVM} cmake=3.6.2"
 fi
 
 if [[ "${WITH_ECM}" == "yes" ]]; then

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -79,7 +79,7 @@ if [[ "${WITH_COVERAGE}" != "" ]]; then
     cmake_line="$cmake_line -DWITH_COVERAGE=${WITH_COVERAGE}"
 fi
 if [[ "${WITH_LLVM}" != "" ]]; then
-    cmake_line="$cmake_line -DWITH_LLVM=${WITH_LLVM} -DLLVM_DIR=${LLVM_DIR}"
+    cmake_line="$cmake_line -DWITH_LLVM:BOOL=ON -DLLVM_DIR=${LLVM_DIR}"
 fi
 if [[ "${BUILD_DOXYGEN}" != "" ]]; then
     cmake_line="$cmake_line -DBUILD_DOXYGEN=${BUILD_DOXYGEN}"

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -218,8 +218,12 @@ void LLVMDoubleVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
     // Validate the generated code, checking for consistency.
     llvm::verifyFunction(*F);
 
-    // std::cout << "LLVM IR" << std::endl;
-    // module->dump();
+    //     std::cout << "LLVM IR" << std::endl;
+    // #if (LLVM_VERSION_MAJOR < 5)
+    //     module->dump();
+    // #else
+    //     module->print(llvm::errs(), nullptr);
+    // #endif
 
     // Optimize the function.
     fpm->run(*F);

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -139,9 +139,9 @@ void LLVMDoubleVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
         F->setAttributes(llvm::AttributeSet::get(mod->getContext(), attrs));
     }
 #else
-    F->addParamAttr(1, llvm::Attribute::ReadOnly);
+    F->addParamAttr(0, llvm::Attribute::ReadOnly);
+    F->addParamAttr(0, llvm::Attribute::NoCapture);
     F->addParamAttr(1, llvm::Attribute::NoCapture);
-    F->addParamAttr(2, llvm::Attribute::NoCapture);
     F->addFnAttr(llvm::Attribute::NoUnwind);
     F->addFnAttr(llvm::Attribute::UWTable);
 #endif

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -42,9 +42,12 @@
 namespace SymEngine
 {
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-tags"
 class IRBuilder : public llvm::IRBuilder<>
 {
 };
+#pragma clang diagnostic pop
 
 llvm::Value *LLVMDoubleVisitor::apply(const Basic &b)
 {

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -7,12 +7,15 @@
 #ifdef HAVE_SYMENGINE_LLVM
 
 // Forward declare llvm types
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-tags"
 namespace llvm
 {
 struct Module;
 struct Value;
 struct Function;
 }
+#pragma clang diagnostic pop
 
 namespace SymEngine
 {


### PR DESCRIPTION
To fix #1385.
Tests passes locally with LLVM 5.0.
I'm new to the LLVM toolchain so a careful review is probably in place.
Do we want to add LLVM 5 to the CI runs?