### PR TITLE
Add DenseMatrix::flat (for use with LLVM visitor)

### DIFF
--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -51,6 +51,12 @@ void DenseMatrix::set(unsigned i, unsigned j, const RCP<const Basic> &e)
     m_[i * col_ + j] = e;
 }
 
+// Flat (row major) view of Matrix
+vec_basic DenseMatrix::as_vec_basic() const
+{
+    return m_;
+}
+
 unsigned DenseMatrix::rank() const
 {
     throw NotImplementedError("Not Implemented");

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -93,6 +93,7 @@ public:
     // Get and set elements
     virtual RCP<const Basic> get(unsigned i, unsigned j) const;
     virtual void set(unsigned i, unsigned j, const RCP<const Basic> &e);
+    virtual vec_basic as_vec_basic() const;
 
     virtual unsigned nrows() const
     {

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -35,9 +35,10 @@ using SymEngine::mul;
 TEST_CASE("test_get_set(): matrices", "[matrices]")
 {
     // Test for DenseMatirx
-    DenseMatrix A
-        = DenseMatrix(2, 2, {integer(1), integer(0), integer(-1), integer(-2)});
+    vec_basic elems{integer(1), integer(0), integer(-1), integer(-2)};
+    DenseMatrix A = DenseMatrix(2, 2, elems);
 
+    REQUIRE(unified_eq(elems, A.as_vec_basic()));
     REQUIRE(eq(*A.get(0, 0), *integer(1)));
     REQUIRE(eq(*A.get(1, 1), *integer(-2)));
 


### PR DESCRIPTION
I want LLVMDoubleVisitor to evaluate the elements of a DenseMatrix (in column major order).
Is this a sensible approach (pseudo-code):
```
jacobian(y, x, J)
LLVMDoubleVisitor v;
v.init(x, J.transpose().flat())
```
I didn't see an easy way to access `m_` of the jacobian matrix so I added `DenseMatrix::flat`.
But perhaps there's a better way?