### PR TITLE
Make ccode print acos(-1) for pi

### DIFF
--- a/symengine/codegen.h
+++ b/symengine/codegen.h
@@ -157,7 +157,7 @@ public:
         if (eq(x, *E)) {
             str_ = "exp(1)";
         } else if (eq(x, *pi)) {
-            str_ = "M_PI";
+            str_ = "acos(-1)";
         } else {
             str_ = x.get_name();
         }

--- a/symengine/tests/printing/test_ccode.cpp
+++ b/symengine/tests/printing/test_ccode.cpp
@@ -7,6 +7,7 @@
 
 using SymEngine::Basic;
 using SymEngine::E;
+using SymEngine::pi;
 using SymEngine::Integer;
 using SymEngine::integer;
 using SymEngine::Interval;
@@ -61,6 +62,8 @@ TEST_CASE("C-code printers", "[CodePrinter]")
     REQUIRE(c99.apply(Inf) == "INFINITY");
     REQUIRE(c89.apply(E) == "exp(1)");
     REQUIRE(c99.apply(E) == "exp(1)");
+    REQUIRE(c89.apply(pi) == "acos(-1)");
+    REQUIRE(c99.apply(pi) == "acos(-1)");
 }
 
 TEST_CASE("Arithmetic", "[ccode]")

--- a/symengine/tests/printing/test_ccode.cpp
+++ b/symengine/tests/printing/test_ccode.cpp
@@ -51,6 +51,7 @@ using SymEngine::cbrt;
 using SymEngine::rational;
 using SymEngine::C89CodePrinter;
 using SymEngine::C99CodePrinter;
+using SymEngine::JSCodePrinter;
 using SymEngine::ccode;
 using SymEngine::jscode;
 
@@ -200,4 +201,6 @@ TEST_CASE("JavaScript math functions", "[jscode]")
     REQUIRE(jscode(*p) == "Math.min(x, y, z)");
     p = exp(x);
     REQUIRE(jscode(*p) == "Math.exp(x)");
+    JSCodePrinter JS;
+    REQUIRE(JS.apply(pi) == "Math.PI");
 }


### PR DESCRIPTION
Such cases should be handled at compile-time due to constant folding by compilers
Relevant - #1383 