### PR TITLE
[WIP] Add -fsanitize=address to Debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_CXX_FLAGS_DEBUG
-        "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-parameter -ggdb")
+        "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-parameter -ggdb -fsanitize=address")
     set(CMAKE_CXX_FLAGS_RELEASE
         "${CMAKE_CXX_FLAGS_RELEASE} -Wno-unused-parameter")
     if (NOT BUILD_FOR_DISTRIBUTION)


### PR DESCRIPTION
I was getting errors reported by LeakSanitizer when building a 3rd party library and linking against SymEngine. The leaks are from LLVM's jit compiler and the errors look like this:

```
=================================================================
==64==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 237568 byte(s) in 14 object(s) allocated from:
    #0 0x534a18 in operator new(unsigned long) (/drone/src/github.com/bjodah/kinetgine/kinetgine/tests/test_kinetgine+0x534a18)
    #1 0x7f1bf8945ca1 in llvm::DenseMap<unsigned int, std::pair<unsigned short, unsigned short>, llvm::DenseMapInfo<unsigned int>, llvm::detail::DenseMapPair<unsigned int, std::pair<unsigned short, unsigned short> > >::grow(unsigned int) (/drone/symengine/lib/libsymengine.so.0.3+0xcb9ca1)

Indirect leak of 157472 byte(s) in 2 object(s) allocated from:
    #0 0x534a18 in operator new(unsigned long) (/drone/src/github.com/bjodah/kinetgine/kinetgine/tests/test_kinetgine+0x534a18)
    #1 0x7f1bf882dfca in llvm::X86TargetMachine::getSubtargetImpl(llvm::Function const&) const (/drone/symengine/lib/libsymengine.so.0.3+0xba1fca)

Indirect leak of 26624 byte(s) in 26 object(s) allocated from:
    #0 0x534a18 in operator new(unsigned long) (/drone/src/github.com/bjodah/kinetgine/kinetgine/tests/test_kinetgine+0x534a18)
    #1 0x7f1bf895d4f2 in llvm::LegalizerInfo::setAction(llvm::InstrAspect const&, llvm::LegalizerInfo::LegalizeAction) (/drone/symengine/lib/libsymengine.so.0.3+0xcd14f2)
...
``` 

I tried building just SymEngine's test suite with clang's "asan" enabled and got failures for:

- symengine/tests/eval/test_lambda_double
- ./symengine/tests/cwrapper/test_cwrapper

Are these false positives?

The edit to CMakeLists.txt is here to run the tests on the CI servers.
(I know that one can use address sanitizers with CMake without "hardcoding" the option into CMakeLists.txt, I just can't remember what that best-practice looked like right now)
