### PR TITLE
Make dumps const (e.g. C++ lib cereal require const save methods)

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -557,7 +557,7 @@ void LLVMDoubleVisitor::bvisit(const Basic &)
     throw std::runtime_error("Not implemented.");
 }
 
-const std::string &LLVMDoubleVisitor::dumps()
+const std::string &LLVMDoubleVisitor::dumps() const
 {
     return membuffer;
 };

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -85,7 +85,7 @@ public:
     void bvisit(const Erfc &x);
     // Return the compiled function as a binary string which can be loaded using
     // `load`
-    const std::string &dumps();
+    const std::string &dumps() const;
     // Load a previously compiled function from a string
     void loads(const std::string &s);
 };


### PR DESCRIPTION
~~Also I don't think we need to return a const string?~~ (didn't think about it being a reference).

EDIT: Maybe I should elaborate a little and give the underlying motivation:
When using [cereal](https://github.com/USCiLab/cereal) you can add serialization functions to your classes such as this one:
```
template <class Archive>
void save(Archive &ar) const {
    ar(names, param_names, const_cast<se::LLVMDoubleVisitor&>(rhs_llvm).dumps(), ...);
}
```
Note the `const_cast`: it will no longer be needed after this PR.