### PR TITLE
[WIP] More LLVMDoubleVisitor settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ set(WITH_LLVM no
     CACHE BOOL "Build with LLVM")
 
 if (WITH_LLVM)
-    set(SYMENGINE_LLVM_COMPONENTS asmparser core executionengine instcombine mcjit native nativecodegen scalaropts support transformutils)
+    set(SYMENGINE_LLVM_COMPONENTS asmparser core executionengine instcombine mcjit native nativecodegen scalaropts vectorize support transformutils)
     find_package(LLVM REQUIRED ${SYMENGINE_LLVM_COMPONENTS})
     set(LLVM_MINIMUM_REQUIRED_VERSION "3.8")
     if (LLVM_PACKAGE_VERSION LESS ${LLVM_MINIMUM_REQUIRED_VERSION})

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -1572,9 +1572,10 @@ CLLVMDoubleVisitor *llvm_double_visitor_new()
 }
 
 void llvm_double_visitor_init(CLLVMDoubleVisitor *self, const CVecBasic *args,
-                              const CVecBasic *exprs, int perform_cse)
+                              const CVecBasic *exprs, int perform_cse,
+                              int opt_level)
 {
-    self->m.init(args->m, exprs->m, perform_cse);
+    self->m.init(args->m, exprs->m, perform_cse, opt_level);
 }
 
 void llvm_double_visitor_call(CLLVMDoubleVisitor *self, double *const outs,

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -10,7 +10,6 @@
 #include <symengine/lambda_double.h>
 #ifdef HAVE_SYMENGINE_LLVM
 #include <symengine/llvm_double.h>
-using SymEngine::LLVMOptimizationSettings;
 using SymEngine::LLVMDoubleVisitor;
 #endif
 
@@ -1563,59 +1562,6 @@ void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self)
 }
 
 #ifdef HAVE_SYMENGINE_LLVM
-struct CLLVMOptimizationSettings {
-    LLVMOptimizationSettings m;
-};
-
-CLLVMOptimizationSettings *llvm_optimization_settings_new()
-{
-    return new CLLVMOptimizationSettings();
-}
-CWRAPPER_OUTPUT_TYPE
-llvm_optimization_settings_set(CLLVMOptimizationSettings *self,
-                               const char *name, int value)
-{
-    std::string n(name);
-    if (n == "symbolic_cse") {
-        self->m.symbolic_cse = value;
-    } else if (n == "instruction_combining") {
-        self->m.instruction_combining = value;
-    } else if (n == "dead_inst_elimination") {
-        self->m.dead_inst_elimination = value;
-    } else if (n == "promote_memory_to_register") {
-        self->m.promote_memory_to_register = value;
-    } else if (n == "reassociate") {
-        self->m.reassociate = value;
-    } else if (n == "gvn") {
-        self->m.gvn = value;
-    } else if (n == "cfg_simplification") {
-        self->m.cfg_simplification = value;
-    } else if (n == "partially_inline_lib_calls") {
-        self->m.partially_inline_lib_calls = value;
-    } else if (n == "instruction_simplifier") {
-        self->m.instruction_simplifier = value;
-    } else if (n == "memcpy_opt") {
-        self->m.memcpy_opt = value;
-    } else if (n == "sroa") {
-        self->m.sroa = value;
-    } else if (n == "merged_load_store_motion") {
-        self->m.merged_load_store_motion = value;
-    } else if (n == "bit_tracking_dce") {
-        self->m.bit_tracking_dce = value;
-    } else if (n == "aggressive_dce") {
-        self->m.aggressive_dce = value;
-    } else if (n == "slp_vectorize") {
-        self->m.slp_vectorize = value;
-    } else {
-        return SYMENGINE_RUNTIME_ERROR;
-    }
-    return SYMENGINE_NO_EXCEPTION;
-}
-
-void llvm_optimization_settings_free(CLLVMOptimizationSettings *self)
-{
-    delete self;
-}
 struct CLLVMDoubleVisitor {
     SymEngine::LLVMDoubleVisitor m;
 };
@@ -1626,10 +1572,9 @@ CLLVMDoubleVisitor *llvm_double_visitor_new()
 }
 
 void llvm_double_visitor_init(CLLVMDoubleVisitor *self, const CVecBasic *args,
-                              const CVecBasic *exprs,
-                              const CLLVMOptimizationSettings *settings)
+                              const CVecBasic *exprs, int perform_cse)
 {
-    self->m.init(args->m, exprs->m, settings->m);
+    self->m.init(args->m, exprs->m, perform_cse);
 }
 
 void llvm_double_visitor_call(CLLVMDoubleVisitor *self, double *const outs,

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -10,6 +10,7 @@
 #include <symengine/lambda_double.h>
 #ifdef HAVE_SYMENGINE_LLVM
 #include <symengine/llvm_double.h>
+using SymEngine::LLVMOptimizationSettings;
 using SymEngine::LLVMDoubleVisitor;
 #endif
 
@@ -1562,6 +1563,59 @@ void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self)
 }
 
 #ifdef HAVE_SYMENGINE_LLVM
+struct CLLVMOptimizationSettings {
+    LLVMOptimizationSettings m;
+};
+
+CLLVMOptimizationSettings *llvm_optimization_settings_new()
+{
+    return new CLLVMOptimizationSettings();
+}
+CWRAPPER_OUTPUT_TYPE
+llvm_optimization_settings_set(CLLVMOptimizationSettings *self,
+                               const char *name, int value)
+{
+    std::string n(name);
+    if (n == "symbolic_cse") {
+        self->m.symbolic_cse = value;
+    } else if (n == "instruction_combining") {
+        self->m.instruction_combining = value;
+    } else if (n == "dead_inst_elimination") {
+        self->m.dead_inst_elimination = value;
+    } else if (n == "promote_memory_to_register") {
+        self->m.promote_memory_to_register = value;
+    } else if (n == "reassociate") {
+        self->m.reassociate = value;
+    } else if (n == "gvn") {
+        self->m.gvn = value;
+    } else if (n == "cfg_simplification") {
+        self->m.cfg_simplification = value;
+    } else if (n == "partially_inline_lib_calls") {
+        self->m.partially_inline_lib_calls = value;
+    } else if (n == "instruction_simplifier") {
+        self->m.instruction_simplifier = value;
+    } else if (n == "memcpy_opt") {
+        self->m.memcpy_opt = value;
+    } else if (n == "sroa") {
+        self->m.sroa = value;
+    } else if (n == "merged_load_store_motion") {
+        self->m.merged_load_store_motion = value;
+    } else if (n == "bit_tracking_dce") {
+        self->m.bit_tracking_dce = value;
+    } else if (n == "aggressive_dce") {
+        self->m.aggressive_dce = value;
+    } else if (n == "slp_vectorize") {
+        self->m.slp_vectorize = value;
+    } else {
+        return SYMENGINE_RUNTIME_ERROR;
+    }
+    return SYMENGINE_NO_EXCEPTION;
+}
+
+void llvm_optimization_settings_free(CLLVMOptimizationSettings *self)
+{
+    delete self;
+}
 struct CLLVMDoubleVisitor {
     SymEngine::LLVMDoubleVisitor m;
 };
@@ -1572,9 +1626,10 @@ CLLVMDoubleVisitor *llvm_double_visitor_new()
 }
 
 void llvm_double_visitor_init(CLLVMDoubleVisitor *self, const CVecBasic *args,
-                              const CVecBasic *exprs, int perform_cse)
+                              const CVecBasic *exprs,
+                              const CLLVMOptimizationSettings *settings)
 {
-    self->m.init(args->m, exprs->m, perform_cse);
+    self->m.init(args->m, exprs->m, settings->m);
 }
 
 void llvm_double_visitor_call(CLLVMDoubleVisitor *self, double *const outs,

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -676,18 +676,10 @@ void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self);
 
 //! Wrapper for LambdaRealDoubleVisitor
 #ifdef HAVE_SYMENGINE_LLVM
-typedef struct CLLVMOptimizationSettings CLLVMOptimizationSettings;
-CLLVMOptimizationSettings *llvm_optimization_settings_new();
-CWRAPPER_OUTPUT_TYPE
-llvm_optimization_settings_set(CLLVMOptimizationSettings *self,
-                               const char *name, int value);
-void llvm_optimization_settings_free(CLLVMOptimizationSettings *self);
-
 typedef struct CLLVMDoubleVisitor CLLVMDoubleVisitor;
 CLLVMDoubleVisitor *llvm_double_visitor_new();
 void llvm_double_visitor_init(CLLVMDoubleVisitor *self, const CVecBasic *args,
-                              const CVecBasic *exprs,
-                              const CLLVMOptimizationSettings *settings);
+                              const CVecBasic *exprs, int perform_cse);
 void llvm_double_visitor_call(CLLVMDoubleVisitor *self, double *const outs,
                               const double *const inps);
 void llvm_double_visitor_free(CLLVMDoubleVisitor *self);

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -676,10 +676,18 @@ void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self);
 
 //! Wrapper for LambdaRealDoubleVisitor
 #ifdef HAVE_SYMENGINE_LLVM
+typedef struct CLLVMOptimizationSettings CLLVMOptimizationSettings;
+CLLVMOptimizationSettings *llvm_optimization_settings_new();
+CWRAPPER_OUTPUT_TYPE
+llvm_optimization_settings_set(CLLVMOptimizationSettings *self,
+                               const char *name, int value);
+void llvm_optimization_settings_free(CLLVMOptimizationSettings *self);
+
 typedef struct CLLVMDoubleVisitor CLLVMDoubleVisitor;
 CLLVMDoubleVisitor *llvm_double_visitor_new();
 void llvm_double_visitor_init(CLLVMDoubleVisitor *self, const CVecBasic *args,
-                              const CVecBasic *exprs, int perform_cse);
+                              const CVecBasic *exprs,
+                              const CLLVMOptimizationSettings *settings);
 void llvm_double_visitor_call(CLLVMDoubleVisitor *self, double *const outs,
                               const double *const inps);
 void llvm_double_visitor_free(CLLVMDoubleVisitor *self);

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -679,7 +679,8 @@ void lambda_real_double_visitor_free(CLambdaRealDoubleVisitor *self);
 typedef struct CLLVMDoubleVisitor CLLVMDoubleVisitor;
 CLLVMDoubleVisitor *llvm_double_visitor_new();
 void llvm_double_visitor_init(CLLVMDoubleVisitor *self, const CVecBasic *args,
-                              const CVecBasic *exprs, int perform_cse);
+                              const CVecBasic *exprs, int perform_cse,
+                              int opt_level);
 void llvm_double_visitor_call(CLLVMDoubleVisitor *self, double *const outs,
                               const double *const inps);
 void llvm_double_visitor_free(CLLVMDoubleVisitor *self);

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -58,6 +58,13 @@ llvm::Value *LLVMDoubleVisitor::apply(const Basic &b)
 }
 
 void LLVMDoubleVisitor::init(const vec_basic &x, const Basic &b,
+                             bool symbolic_cse, int opt_level)
+{
+    init(x, b, symbolic_cse,
+         LLVMDoubleVisitor::create_default_passes(opt_level));
+}
+
+void LLVMDoubleVisitor::init(const vec_basic &x, const Basic &b,
                              bool symbolic_cse,
                              const std::vector<llvm::Pass *> &passes)
 {
@@ -147,6 +154,13 @@ std::vector<llvm::Pass *> LLVMDoubleVisitor::create_default_passes(int optlevel)
         passes.push_back(llvm::createInstructionSimplifierPass());
     }
     return passes;
+}
+
+void LLVMDoubleVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
+                             const bool symbolic_cse, int opt_level)
+{
+    init(inputs, outputs, symbolic_cse,
+         LLVMDoubleVisitor::create_default_passes(opt_level));
 }
 
 void LLVMDoubleVisitor::init(const vec_basic &inputs, const vec_basic &outputs,

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -22,6 +22,38 @@ namespace SymEngine
 
 class IRBuilder;
 
+struct LLVMOptimizationSettings {
+    bool symbolic_cse{false};
+
+    // LLVM optimization passes:
+    int instruction_combining{2}; // 0: no instcombine, 1: instcombine, 2:
+                                  // instcombine with expensive combines
+    bool dead_inst_elimination{
+        true}; // quickly removes trivially dead instructions
+    bool promote_memory_to_register{
+        true}; // promote memory references to be register references
+    bool reassociate{true}; // reassociates commutative expressions
+    bool gvn{true}; // global value numbering & redundant load elimination
+    bool cfg_simplification{true}; // Simplifies Control Flow Graph (dead code
+                                   // elimination, basic block merging)
+    bool partially_inline_lib_calls{
+        true}; // Tries to inline library calls such as sqrt
+    bool instruction_simplifier{true}; // Remove redundant instructions.
+    bool memcpy_opt{true};             // Combines multiple stores into memset
+    bool sroa{true}; // Replace aggregates or pieces of aggregates with scalar
+                     // SSA values.
+    bool merged_load_store_motion{true}; // merges loads and stores in diamonds
+    bool bit_tracking_dce{true};         // bit-tracking dead code elimination
+    bool aggressive_dce{true}; // aggressive dead code elimination based on
+    bool slp_vectorize{
+        true}; // superword-level paralellism vectorizer, (also run instcombine)
+};
+
+namespace
+{
+const LLVMOptimizationSettings default_settings{};
+}
+
 class LLVMDoubleVisitor : public BaseVisitor<LLVMDoubleVisitor>
 {
 protected:
@@ -41,9 +73,10 @@ protected:
 
 public:
     llvm::Value *apply(const Basic &b);
-    void init(const vec_basic &x, const Basic &b, bool cse = false);
+    void init(const vec_basic &x, const Basic &b,
+              const LLVMOptimizationSettings &settings = default_settings);
     void init(const vec_basic &inputs, const vec_basic &outputs,
-              bool cse = false);
+              const LLVMOptimizationSettings &settings = default_settings);
 
     double call(const std::vector<double> &vec);
     void call(double *outs, const double *inps);

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -23,33 +23,6 @@ namespace SymEngine
 
 class IRBuilder;
 
-struct LLVMOptimizationSettings {
-    bool symbolic_cse{false};
-
-    // LLVM optimization passes:
-    int instruction_combining{2}; // 0: no instcombine, 1: instcombine, 2:
-                                  // instcombine with expensive combines
-    bool dead_inst_elimination{
-        true}; // quickly removes trivially dead instructions
-    bool promote_memory_to_register{
-        true}; // promote memory references to be register references
-    bool reassociate{true}; // reassociates commutative expressions
-    bool gvn{true}; // global value numbering & redundant load elimination
-    bool cfg_simplification{true}; // Simplifies Control Flow Graph (dead code
-                                   // elimination, basic block merging)
-    bool partially_inline_lib_calls{
-        true}; // Tries to inline library calls such as sqrt
-    bool instruction_simplifier{true}; // Remove redundant instructions.
-    bool memcpy_opt{true};             // Combines multiple stores into memset
-    bool sroa{true}; // Replace aggregates or pieces of aggregates with scalar
-                     // SSA values.
-    bool merged_load_store_motion{true}; // merges loads and stores in diamonds
-    bool bit_tracking_dce{true};         // bit-tracking dead code elimination
-    bool aggressive_dce{true}; // aggressive dead code elimination based on
-    bool slp_vectorize{
-        true}; // superword-level paralellism vectorizer, (also run instcombine)
-};
-
 class LLVMDoubleVisitor : public BaseVisitor<LLVMDoubleVisitor>
 {
 protected:
@@ -70,11 +43,13 @@ protected:
 public:
     llvm::Value *apply(const Basic &b);
     void init(const vec_basic &x, const Basic &b,
-              const bool symbolic_cse = false,
-              const std::vector<llvm::Pass *> &passes = {});
+              const bool symbolic_cse = false, int opt_level = 2);
+    void init(const vec_basic &x, const Basic &b, const bool symbolic_cse,
+              const std::vector<llvm::Pass *> &passes);
     void init(const vec_basic &inputs, const vec_basic &outputs,
-              const bool symbolic_cse = false,
-              const std::vector<llvm::Pass *> &passes = {});
+              const bool symbolic_cse = false, int opt_level = 2);
+    void init(const vec_basic &inputs, const vec_basic &outputs,
+              const bool symbolic_cse, const std::vector<llvm::Pass *> &passes);
 
     static std::vector<llvm::Pass *> create_default_passes(int optlevel);
 

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -15,6 +15,7 @@ class Function;
 class ExecutionEngine;
 class MemoryBufferRef;
 class LLVMContext;
+class Pass;
 }
 
 namespace SymEngine
@@ -49,11 +50,6 @@ struct LLVMOptimizationSettings {
         true}; // superword-level paralellism vectorizer, (also run instcombine)
 };
 
-namespace
-{
-const LLVMOptimizationSettings default_settings{};
-}
-
 class LLVMDoubleVisitor : public BaseVisitor<LLVMDoubleVisitor>
 {
 protected:
@@ -74,9 +70,13 @@ protected:
 public:
     llvm::Value *apply(const Basic &b);
     void init(const vec_basic &x, const Basic &b,
-              const LLVMOptimizationSettings &settings = default_settings);
+              const bool symbolic_cse = false,
+              const std::vector<llvm::Pass *> &passes = {});
     void init(const vec_basic &inputs, const vec_basic &outputs,
-              const LLVMOptimizationSettings &settings = default_settings);
+              const bool symbolic_cse = false,
+              const std::vector<llvm::Pass *> &passes = {});
+
+    static std::vector<llvm::Pass *> create_default_passes(int optlevel);
 
     double call(const std::vector<double> &vec);
     void call(double *outs, const double *inps);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1892,9 +1892,9 @@ void test_lambda_double()
         SYMENGINE_C_ASSERT(fabs(outs[0] - 43.5) < 1e-12);
         SYMENGINE_C_ASSERT(fabs(outs[1] - 45.0) < 1e-12);
 #ifdef HAVE_SYMENGINE_LLVM
-        int symbolic_cse = 1;
+        int symbolic_cse = 1, opt_level = 2;
         CLLVMDoubleVisitor *vis2 = llvm_double_visitor_new();
-        llvm_double_visitor_init(vis2, args, exprs, symbolic_cse);
+        llvm_double_visitor_init(vis2, args, exprs, symbolic_cse, opt_level);
         llvm_double_visitor_call(vis2, outs, inps);
         llvm_double_visitor_free(vis2);
         SYMENGINE_C_ASSERT(fabs(outs[0] - 43.5) < 1e-12);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1892,8 +1892,10 @@ void test_lambda_double()
         SYMENGINE_C_ASSERT(fabs(outs[0] - 43.5) < 1e-12);
         SYMENGINE_C_ASSERT(fabs(outs[1] - 45.0) < 1e-12);
 #ifdef HAVE_SYMENGINE_LLVM
+        CLLVMOptimizationSettings *settings = llvm_optimization_settings_new();
+        llvm_optimization_settings_set(settings, "symbolic_cse", 1);
         CLLVMDoubleVisitor *vis2 = llvm_double_visitor_new();
-        llvm_double_visitor_init(vis2, args, exprs, perform_cse);
+        llvm_double_visitor_init(vis2, args, exprs, settings);
         llvm_double_visitor_call(vis2, outs, inps);
         llvm_double_visitor_free(vis2);
         SYMENGINE_C_ASSERT(fabs(outs[0] - 43.5) < 1e-12);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1892,10 +1892,9 @@ void test_lambda_double()
         SYMENGINE_C_ASSERT(fabs(outs[0] - 43.5) < 1e-12);
         SYMENGINE_C_ASSERT(fabs(outs[1] - 45.0) < 1e-12);
 #ifdef HAVE_SYMENGINE_LLVM
-        CLLVMOptimizationSettings *settings = llvm_optimization_settings_new();
-        llvm_optimization_settings_set(settings, "symbolic_cse", 1);
+        int symbolic_cse = 1;
         CLLVMDoubleVisitor *vis2 = llvm_double_visitor_new();
-        llvm_double_visitor_init(vis2, args, exprs, settings);
+        llvm_double_visitor_init(vis2, args, exprs, symbolic_cse);
         llvm_double_visitor_call(vis2, outs, inps);
         llvm_double_visitor_free(vis2);
         SYMENGINE_C_ASSERT(fabs(outs[0] - 43.5) < 1e-12);

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -232,10 +232,9 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
     v2.init({x, y, z}, *r);
 
     LLVMDoubleVisitor v3;
-    const int opt_level = 2;
-    auto passes = LLVMDoubleVisitor::create_default_passes(opt_level);
     bool symbolic_cse = true;
-    v3.init({x, y, z}, *r, symbolic_cse, passes);
+    int opt_level = 3;
+    v3.init({x, y, z}, *r, symbolic_cse, opt_level);
 
     auto t1 = std::chrono::high_resolution_clock::now();
     for (int i = 0; i < 500; i++) {

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -6,6 +6,7 @@
 
 #ifdef HAVE_SYMENGINE_LLVM
 #include <symengine/llvm_double.h>
+using SymEngine::LLVMOptimizationSettings;
 using SymEngine::LLVMDoubleVisitor;
 #endif
 
@@ -233,7 +234,9 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
     v2.init({x, y, z}, *r);
 
     LLVMDoubleVisitor v3;
-    v3.init({x, y, z}, *r, true);
+    LLVMOptimizationSettings settings{};
+    settings.symbolic_cse = true;
+    v3.init({x, y, z}, *r, settings);
 
     auto t1 = std::chrono::high_resolution_clock::now();
     for (int i = 0; i < 500; i++) {

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -6,7 +6,6 @@
 
 #ifdef HAVE_SYMENGINE_LLVM
 #include <symengine/llvm_double.h>
-using SymEngine::LLVMOptimizationSettings;
 using SymEngine::LLVMDoubleVisitor;
 #endif
 
@@ -205,7 +204,6 @@ TEST_CASE("Evaluate functions", "[lambda_gamma]")
 }
 
 #ifdef HAVE_SYMENGINE_LLVM
-
 TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
 {
     RCP<const Basic> x, y, z, r;
@@ -234,9 +232,10 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
     v2.init({x, y, z}, *r);
 
     LLVMDoubleVisitor v3;
-    LLVMOptimizationSettings settings{};
-    settings.symbolic_cse = true;
-    v3.init({x, y, z}, *r, settings);
+    const int opt_level = 2;
+    auto passes = LLVMDoubleVisitor::create_default_passes(opt_level);
+    bool symbolic_cse = true;
+    v3.init({x, y, z}, *r, symbolic_cse, passes);
 
     auto t1 = std::chrono::high_resolution_clock::now();
     for (int i = 0; i < 500; i++) {
@@ -315,5 +314,39 @@ TEST_CASE("Check llvm save and load", "[llvm_double]")
     d = v.call({0.4, 2.0, 3.0});
     d2 = v2.call({0.4, 2.0, 3.0});
     REQUIRE(::fabs((d - d2) / d) < 1e-12);
+}
+
+TEST_CASE("Check that our default LLVM passes give correct results",
+          "[llvm_double]")
+{
+    RCP<const Basic> x, y, z, r;
+    double d, d2;
+    x = symbol("x");
+    y = symbol("y");
+    z = symbol("z");
+
+    vec_basic vec = {log(x),   abs(x),      tan(x),   sinh(x), cosh(x), tanh(x),
+                     asinh(y), acosh(y),    atanh(x), asin(x), acos(x), atan(x),
+                     gamma(x), loggamma(x), erf(x),   erfc(x)};
+
+    r = mul(add(sin(x), add(mul(pow(y, integer(4)), mul(z, integer(2))),
+                            pow(sin(x), integer(2)))),
+            add(vec));
+    for (int i = 0; i < 4; ++i) {
+        r = mul(add(pow(integer(2), E), add(r, pow(x, pow(E, cos(x))))), r);
+    }
+
+    // r = add(add(x, y), pow(add(x, y), integer(2)));
+
+    LambdaRealDoubleVisitor v;
+    v.init({x, y, z}, *r);
+    for (int opt_level = 0; opt_level < 4; ++opt_level) {
+        LLVMDoubleVisitor v2;
+        v2.init({x, y, z}, *r, false,
+                LLVMDoubleVisitor::create_default_passes(opt_level));
+        d = v.call({0.4, 2.0, 3.0});
+        d2 = v2.call({0.4, 2.0, 3.0});
+        REQUIRE(::fabs((d - d2) / d) < 1e-12);
+    }
 }
 #endif


### PR DESCRIPTION
I am currently working with some large systems of ordinary differential equations (chemical kinetics). I am working with hundreds of species and thousands of reactions. Number of rhs evaluations for a series of simulations is 1e7 (and 1e5 number of jacobian evaluations). The `LLVMDoubleVisitor` allows me to evaluate those expressions fast (~5 minutes), but the compilation of the expression takes 5x as much time. In this tentative PR I'm adding an options struct for turning on and off LLVM optimzation passes. Note also that I added a vectorization pass. I haven't evaluated the performance impact of that yet, will get back with data on that.

But I thought this was still a good point to take in some feedback on the API, what do you think?

EDIT: I glanced over [Julia's optimization passes](https://github.com/JuliaLang/julia/blob/74f5328ae7ab8a666986861df0cd1c26a8222043/src/jitlayers.cpp) when adding a few passes, I still need to benchmark this.