### PR TITLE
Add to CSRMatrix: jacobian, as_vectors & transpose 

### DIFF
--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -279,6 +279,8 @@ class CSRMatrix : public MatrixBase
 public:
     CSRMatrix();
     CSRMatrix(unsigned row, unsigned col);
+    CSRMatrix(unsigned row, unsigned col, const std::vector<unsigned> &p,
+              const std::vector<unsigned> &j, const vec_basic &x);
     CSRMatrix(unsigned row, unsigned col, std::vector<unsigned> &&p,
               std::vector<unsigned> &&j, vec_basic &&x);
 

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -285,6 +285,9 @@ public:
               std::vector<unsigned> &&j, vec_basic &&x);
     CSRMatrix &operator=(CSRMatrix &&other);
     CSRMatrix(const CSRMatrix &) = default;
+    std::tuple<std::vector<unsigned>, std::vector<unsigned>, vec_basic>
+    as_vectors() const;
+
     bool is_canonical() const;
 
     virtual bool eq(const MatrixBase &other) const;
@@ -382,12 +385,6 @@ public:
         const CSRMatrix &A, const CSRMatrix &B, CSRMatrix &C,
         RCP<const Basic> (&bin_op)(const RCP<const Basic> &,
                                    const RCP<const Basic> &));
-
-    std::tuple<std::vector<unsigned>, std::vector<unsigned>, vec_basic>
-    as_vectors() const
-    {
-        return std::make_tuple(p_, j_, x_);
-    }
 
 private:
     std::vector<unsigned> p_;

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -75,6 +75,8 @@ public:
 
 typedef std::vector<std::pair<int, int>> permutelist;
 
+class CSRMatrix;
+
 // ----------------------------- Dense Matrix --------------------------------//
 class DenseMatrix : public MatrixBase
 {
@@ -261,6 +263,8 @@ public:
     friend void ones(DenseMatrix &A);
     friend void zeros(DenseMatrix &A);
 
+    friend CSRMatrix;
+
 private:
     // Matrix elements are stored in row-major order
     vec_basic m_;
@@ -360,6 +364,7 @@ public:
                               const std::vector<unsigned> &i,
                               const std::vector<unsigned> &j,
                               const vec_basic &x);
+    static CSRMatrix jacobian(const DenseMatrix &A, const DenseMatrix &x);
 
     friend void csr_matmat_pass1(const CSRMatrix &A, const CSRMatrix &B,
                                  CSRMatrix &C);
@@ -373,6 +378,12 @@ public:
         const CSRMatrix &A, const CSRMatrix &B, CSRMatrix &C,
         RCP<const Basic> (&bin_op)(const RCP<const Basic> &,
                                    const RCP<const Basic> &));
+
+    std::tuple<std::vector<unsigned>, std::vector<unsigned>, vec_basic>
+    as_vectors() const
+    {
+        return std::make_tuple(p_, j_, x_);
+    }
 
 private:
     std::vector<unsigned> p_;

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -283,7 +283,8 @@ public:
               const std::vector<unsigned> &j, const vec_basic &x);
     CSRMatrix(unsigned row, unsigned col, std::vector<unsigned> &&p,
               std::vector<unsigned> &&j, vec_basic &&x);
-
+    CSRMatrix &operator=(CSRMatrix &&other);
+    CSRMatrix(const CSRMatrix &) = default;
     bool is_canonical() const;
 
     virtual bool eq(const MatrixBase &other) const;
@@ -320,6 +321,7 @@ public:
 
     // Matrix transpose
     virtual void transpose(MatrixBase &result) const;
+    CSRMatrix transpose() const;
 
     // Extract out a submatrix
     virtual void submatrix(MatrixBase &result, unsigned row_start,

--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -43,6 +43,14 @@ CSRMatrix &CSRMatrix::operator=(CSRMatrix &&other)
     return *this;
 }
 
+std::tuple<std::vector<unsigned>, std::vector<unsigned>, vec_basic>
+CSRMatrix::as_vectors() const
+{
+    auto p = p_, j = j_;
+    auto x = x_;
+    return std::make_tuple(std::move(p), std::move(j), std::move(x));
+}
+
 bool CSRMatrix::eq(const MatrixBase &other) const
 {
     unsigned row = this->nrows();

--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -100,14 +100,14 @@ RCP<const Basic> CSRMatrix::get(unsigned i, unsigned j) const
         return zero;
     }
 
-    while (row_start <= row_end) {
+    while (row_start < row_end) {
         k = (row_start + row_end) / 2;
         if (j_[k] == j) {
             return x_[k];
         } else if (j_[k] < j) {
             row_start = k + 1;
         } else {
-            row_end = k - 1;
+            row_end = k;
         }
     }
 

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -63,7 +63,7 @@ TEST_CASE("test_get_set(): matrices", "[matrices]")
     vec_basic x1{{integer(1), integer(2), integer(3), integer(4), integer(5),
                   integer(6)}},
         x2;
-    CSRMatrix B = CSRMatrix(3, 3, std::move(p1), std::move(j1), std::move(x1));
+    CSRMatrix B = CSRMatrix(3, 3, p1, j1, x1);
     std::tie(p2, j2, x2) = B.as_vectors();
     REQUIRE(p1 == p2);
     REQUIRE(j1 == j2);

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -70,7 +70,7 @@ TEST_CASE("test_get_set(): matrices", "[matrices]")
     REQUIRE(std::equal(x1.begin(), x1.end(), x2.begin(),
                        [](const RCP<const Basic> &a,
                           const RCP<const Basic> &b) { return eq(*a, *b); }));
-
+    REQUIRE(B == B.transpose().transpose());
     REQUIRE(eq(*B.get(0, 0), *integer(1)));
     REQUIRE(eq(*B.get(1, 2), *integer(3)));
     REQUIRE(eq(*B.get(2, 1), *integer(5)));
@@ -1474,6 +1474,9 @@ TEST_CASE("test_csr_eq(): matrices", "[matrices]")
                              integer(5), integer(6)});
 
     REQUIRE(not(A == C));
+
+    A.transpose(C);
+    REQUIRE(B.transpose() == C);
 }
 
 TEST_CASE("test_from_coo(): matrices", "[matrices]")
@@ -1499,7 +1502,8 @@ TEST_CASE("test_from_coo(): matrices", "[matrices]")
          integer(60), integer(70), integer(80)});
 
     REQUIRE(A == B);
-
+    REQUIRE(A.transpose() == B.transpose());
+    REQUIRE(A.transpose().transpose() == B);
     // Check for duplicate removal
     // Here duplicates are summed to create one element
     A = CSRMatrix(3, 3, {0, 2, 3, 6}, {0, 2, 2, 0, 1, 2},

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -1686,7 +1686,18 @@ TEST_CASE("Test Jacobian", "[matrices]")
                integer(0), z, integer(1), x, integer(1), integer(1), integer(1),
                integer(0), integer(0)});
     REQUIRE(J == ref1);
-    REQUIRE(CSRMatrix::jacobian(A, X) == ref1);
+    CSRMatrix Js = CSRMatrix::jacobian(A, X);
+    std::vector<unsigned> Js_p1, Js_p2{{0, 2, 4, 8, 10}};
+    std::vector<unsigned> Js_j1, Js_j2{{0, 2, 1, 2, 0, 1, 2, 3, 0, 1}};
+    vec_basic Js_x1, Js_x2{{integer(1), integer(1), z, y, z, integer(1), x,
+                            integer(1), integer(1), integer(1)}};
+    std::tie(Js_p1, Js_j1, Js_x1) = Js.as_vectors();
+    REQUIRE(Js_p1 == Js_p2);
+    REQUIRE(Js_j1 == Js_j2);
+    REQUIRE(std::equal(Js_x1.begin(), Js_x1.end(), Js_x2.begin(),
+                       [](const RCP<const Basic> &a,
+                          const RCP<const Basic> &b) { return eq(*a, *b); }));
+    REQUIRE(Js == ref1);
 
     X = DenseMatrix(4, 1, {f, y, z, t});
     CHECK_THROWS_AS(jacobian(A, X, J), SymEngineException);

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -59,9 +59,17 @@ TEST_CASE("test_get_set(): matrices", "[matrices]")
                      2, 2, {integer(0), integer(-2), integer(0), integer(-2)}));
 
     // Test for CSRMatrix
-    CSRMatrix B = CSRMatrix(3, 3, {0, 2, 3, 6}, {0, 2, 2, 0, 1, 2},
-                            {integer(1), integer(2), integer(3), integer(4),
-                             integer(5), integer(6)});
+    std::vector<unsigned> p1{{0, 2, 3, 6}}, j1{{0, 2, 2, 0, 1, 2}}, p2, j2;
+    vec_basic x1{{integer(1), integer(2), integer(3), integer(4), integer(5),
+                  integer(6)}},
+        x2;
+    CSRMatrix B = CSRMatrix(3, 3, std::move(p1), std::move(j1), std::move(x1));
+    std::tie(p2, j2, x2) = B.as_vectors();
+    REQUIRE(p1 == p2);
+    REQUIRE(j1 == j2);
+    REQUIRE(std::equal(x1.begin(), x1.end(), x2.begin(),
+                       [](const RCP<const Basic> &a,
+                          const RCP<const Basic> &b) { return eq(*a, *b); }));
 
     REQUIRE(eq(*B.get(0, 0), *integer(1)));
     REQUIRE(eq(*B.get(1, 2), *integer(3)));
@@ -1669,22 +1677,27 @@ TEST_CASE("Test Jacobian", "[matrices]")
     X = DenseMatrix(4, 1, {x, y, z, t});
     J = DenseMatrix(4, 4);
     jacobian(A, X, J);
-    REQUIRE(J == DenseMatrix(4, 4, {integer(1), integer(0), integer(1),
-                                    integer(0), integer(0), z, y, integer(0), z,
-                                    integer(1), x, integer(1), integer(1),
-                                    integer(1), integer(0), integer(0)}));
+    const auto ref1 = DenseMatrix(
+        4, 4, {integer(1), integer(0), integer(1), integer(0), integer(0), z, y,
+               integer(0), z, integer(1), x, integer(1), integer(1), integer(1),
+               integer(0), integer(0)});
+    REQUIRE(J == ref1);
+    REQUIRE(CSRMatrix::jacobian(A, X) == ref1);
 
     X = DenseMatrix(4, 1, {f, y, z, t});
     CHECK_THROWS_AS(jacobian(A, X, J), SymEngineException);
+    CHECK_THROWS_AS(CSRMatrix::jacobian(A, X), SymEngineException);
 
     A = DenseMatrix(
         4, 1, {add(x, z), mul(y, z), add(mul(z, x), add(y, t)), add(x, y)});
     X = DenseMatrix(3, 1, {x, y, z});
     J = DenseMatrix(4, 3);
     jacobian(A, X, J);
-    REQUIRE(J == DenseMatrix(4, 3, {integer(1), integer(0), integer(1),
-                                    integer(0), z, y, z, integer(1), x,
-                                    integer(1), integer(1), integer(0)}));
+    const auto ref2 = DenseMatrix(4, 3, {integer(1), integer(0), integer(1),
+                                         integer(0), z, y, z, integer(1), x,
+                                         integer(1), integer(1), integer(0)});
+    REQUIRE(J == ref2);
+    REQUIRE(CSRMatrix::jacobian(A, X) == ref2);
 
     A = DenseMatrix(2, 1, {mul(f, y), pow(y, integer(2))});
     X = DenseMatrix(2, 1, {f, y});


### PR DESCRIPTION
Just as in the case of `DenseMatrix`, there was no easy way to access the elements of a `CSRMatrix`.
Also, I couldn't find a function for creating a sparse jacobian matrix, so I went ahead and implemented a static method: `CSRMatrix::jacobian`

Let me know what you think.