### PR TITLE
DenseMatrix(vec_basic), CSRMatrix::jacobian(vec_basic, vec_sym)

### DIFF
--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -30,6 +30,12 @@ DenseMatrix::DenseMatrix(unsigned row, unsigned col, const vec_basic &l)
     SYMENGINE_ASSERT(m_.size() == row * col)
 }
 
+DenseMatrix::DenseMatrix(const vec_basic &column_elements)
+    : m_(column_elements), row_(static_cast<unsigned>(column_elements.size())),
+      col_(1)
+{
+}
+
 // Resize the Matrix
 void DenseMatrix::resize(unsigned row, unsigned col)
 {

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -86,6 +86,7 @@ public:
     DenseMatrix(const DenseMatrix &);
     DenseMatrix(unsigned row, unsigned col);
     DenseMatrix(unsigned row, unsigned col, const vec_basic &l);
+    DenseMatrix(const vec_basic &column_elements);
     // Resize
     void resize(unsigned i, unsigned j);
 
@@ -371,6 +372,7 @@ public:
                               const std::vector<unsigned> &i,
                               const std::vector<unsigned> &j,
                               const vec_basic &x);
+    static CSRMatrix jacobian(const vec_basic &exprs, const vec_sym &x);
     static CSRMatrix jacobian(const DenseMatrix &A, const DenseMatrix &x);
 
     friend void csr_matmat_pass1(const CSRMatrix &A, const CSRMatrix &B,

--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -422,27 +422,19 @@ CSRMatrix CSRMatrix::from_coo(unsigned row, unsigned col,
     return B;
 }
 
-CSRMatrix CSRMatrix::jacobian(const DenseMatrix &A, const DenseMatrix &x)
+CSRMatrix CSRMatrix::jacobian(const vec_basic &exprs, const vec_sym &x)
 {
-    SYMENGINE_ASSERT(A.col_ == 1);
-    SYMENGINE_ASSERT(x.col_ == 1);
-    unsigned nrows = A.row_, ncols = x.row_;
+    const unsigned nrows = static_cast<unsigned>(exprs.size());
+    const unsigned ncols = static_cast<unsigned>(x.size());
     std::vector<unsigned> p(1, 0), j;
     vec_basic elems;
     p.reserve(nrows + 1);
     j.reserve(nrows);
     elems.reserve(nrows);
-    for (const auto &dx : x.m_) {
-        if (!is_a<Symbol>(*dx)) {
-            throw SymEngineException("'x' must contain Symbols only");
-        }
-    }
     for (unsigned ri = 0; ri < nrows; ++ri) {
         p.push_back(p.back());
         for (unsigned ci = 0; ci < ncols; ++ci) {
-            const RCP<const Symbol> dx
-                = rcp_static_cast<const Symbol>(x.m_[ci]);
-            auto elem = A.m_[ri]->diff(dx);
+            auto elem = exprs[ri]->diff(x[ci]);
             if (neq(*elem, *zero)) {
                 p.back()++;
                 j.push_back(ci);
@@ -452,6 +444,21 @@ CSRMatrix CSRMatrix::jacobian(const DenseMatrix &A, const DenseMatrix &x)
     }
     return CSRMatrix(nrows, ncols, std::move(p), std::move(j),
                      std::move(elems));
+}
+
+CSRMatrix CSRMatrix::jacobian(const DenseMatrix &A, const DenseMatrix &x)
+{
+    SYMENGINE_ASSERT(A.col_ == 1);
+    SYMENGINE_ASSERT(x.col_ == 1);
+    vec_sym syms;
+    syms.reserve(x.row_);
+    for (const auto &dx : x.m_) {
+        if (!is_a<Symbol>(*dx)) {
+            throw SymEngineException("'x' must contain Symbols only");
+        }
+        syms.push_back(rcp_static_cast<const Symbol>(dx));
+    }
+    return CSRMatrix::jacobian(A.m_, syms);
 }
 
 void csr_matmat_pass1(const CSRMatrix &A, const CSRMatrix &B, CSRMatrix &C)

--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -201,7 +201,7 @@ void CSRMatrix::transpose(MatrixBase &result) const
 {
     if (is_a<CSRMatrix>(result)) {
         auto &r = down_cast<CSRMatrix &>(result);
-        r = std::move(this->transpose());
+        r = this->transpose();
     } else {
         throw NotImplementedError("Not Implemented");
     }

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -277,6 +277,7 @@ TEST_CASE("test_transpose_dense(): matrices", "[matrices]")
     transpose_dense(A, B);
 
     REQUIRE(B == DenseMatrix(3, 1, {x, y, z}));
+    REQUIRE(B == DenseMatrix({x, y, z}));
 }
 
 TEST_CASE("test_submatrix_dense(): matrices", "[matrices]")
@@ -1674,8 +1675,9 @@ TEST_CASE("test_ones_zeros(): matrices", "[matrices]")
 TEST_CASE("Test Jacobian", "[matrices]")
 {
     DenseMatrix A, X, J;
-    RCP<const Basic> x = symbol("x"), y = symbol("y"), z = symbol("z"),
-                     t = symbol("t"), f = function_symbol("f", x);
+    RCP<const Symbol> x = symbol("x"), y = symbol("y"), z = symbol("z"),
+                      t = symbol("t");
+    RCP<const Basic> f = function_symbol("f", x);
     A = DenseMatrix(
         4, 1, {add(x, z), mul(y, z), add(mul(z, x), add(y, t)), add(x, y)});
     X = DenseMatrix(4, 1, {x, y, z, t});
@@ -1719,6 +1721,10 @@ TEST_CASE("Test Jacobian", "[matrices]")
     J = DenseMatrix(2, 2);
     sjacobian(A, X, J);
     REQUIRE(J == DenseMatrix(2, 2, {y, f, integer(0), mul(integer(2), y)}));
+
+    REQUIRE(
+        CSRMatrix::jacobian({add(x, mul(integer(-1), y)), mul(x, y)}, {x, y})
+        == DenseMatrix(2, 2, {integer(1), integer(-1), y, x}));
 }
 
 TEST_CASE("Test Diff", "[matrices]")


### PR DESCRIPTION
This is a suggested change to add a constructor to DenseMatrix which accepts vec_basic. I propose that it is interpreted as column vector (I believe it's the convention and e.g. `jacobian` expects column vectors).

I also changed CSRMatrix::jacobian not to strictly require a pair of `DenseMatrix`s, but also accept `vec_basic` and `vec_sym`.

Let me know what you think.