### PR TITLE
Look for arb.h instead of fmprb.h

### DIFF
--- a/cmake/FindARB.cmake
+++ b/cmake/FindARB.cmake
@@ -1,6 +1,6 @@
 include(LibFindMacros)
 
-libfind_include(fmprb.h arb)
+libfind_include(arb.h arb)
 libfind_library(arb arb)
 
 set(ARB_LIBRARIES ${ARB_LIBRARY})


### PR DESCRIPTION
fmprb.h is not there in newer versions, but arb.h is in all versions

Fixes https://github.com/symengine/symengine/issues/1423