### PR TITLE
WIP: BipartiteGraph and Hopcroft-Karp algorithm in C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,10 @@ endif()
 # Enable C++11 support in all compilers. SymEngine will not compile unless
 # the C++11 support is enabled.
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|Intel")
-    set(CXX11_OPTIONS "-std=c++11")
+    set(CXX11_OPTIONS "-std=c++17")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
     # pgcpp
-    set(CXX11_OPTIONS "--gnu --c++11 -D__GXX_EXPERIMENTAL_CXX0X__")
+    set(CXX11_OPTIONS "--gnu --c++17 -D__GXX_EXPERIMENTAL_CXX0X__")
 endif ()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${CXX11_OPTIONS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${CXX11_OPTIONS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,6 +666,8 @@ if (BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif()
 
+add_subdirectory(matchpygen)
+
 # At the end we print a nice summary
 
 message("--------------------------------------------------------------------------------")

--- a/matchpygen/CMakeLists.txt
+++ b/matchpygen/CMakeLists.txt
@@ -1,0 +1,23 @@
+project(matchpygen)
+
+include_directories(BEFORE ${symengine_SOURCE_DIR})
+include_directories(BEFORE ${symengine_BINARY_DIR})
+include_directories(BEFORE ${teuchos_SOURCE_DIR})
+include_directories(BEFORE ${teuchos_BINARY_DIR})
+
+# find_package(Boost REQUIRED)  # 1.65.1 COMPONENTS coroutine2 context REQUIRED)
+#find_package(Boost COMPONENTS system filesystem coroutine context REQUIRED)
+#include_directories(${Boost_INCLUDE_DIR})
+#link_directories(${Boost_LIBRARY_DIR})
+
+#SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -lboost_context -lboost_coroutine ")
+#set(CMAKE_VERBOSE_MAKEFILE on)
+
+#link_directories(${Boost_LIBRARY_DIRS})
+#include_directories(${Boost_INCLUDE_DIR})
+
+#set(BOOST_PARAMS "-I/usr/include/  -lboost_context -lboost_coroutine")
+#message(WARNING ${BOOST_PARAMS})
+
+add_executable(test_bipartite test_bipartite.cpp)
+target_link_libraries(test_bipartite symengine)

--- a/matchpygen/bipartite.h
+++ b/matchpygen/bipartite.h
@@ -16,7 +16,6 @@
 
 using namespace std;
 
-
 const int LEFT = 0;
 const int RIGHT = 1;
 
@@ -31,9 +30,9 @@ template <typename TLeft, typename TRight, typename TEdgeValue>
 class BipartiteGraph
 {
 public:
-    //typedef std::variant<TLeft, TRight> Node;
-    //typedef vector<Node> NodeList;
-    //typedef set<Node> NodeSet;
+    // typedef std::variant<TLeft, TRight> Node;
+    // typedef vector<Node> NodeList;
+    // typedef set<Node> NodeSet;
     typedef tuple<TLeft, TRight> Edge;
     map<Edge, TEdgeValue> _edges;
     map<TLeft, TRight> _matching;
@@ -41,7 +40,7 @@ public:
     map<int, int> _dfs_parent;
     set<TLeft> _left;
     set<TRight> _right;
-    //map<Node, set<Node>> _graph;
+    // map<Node, set<Node>> _graph;
     map<TLeft, set<TRight>> _graph_left;
     map<TRight, set<TLeft>> _graph_right;
 
@@ -63,16 +62,16 @@ public:
         self._dfs_paths = []
         self._dfs_parent = {}
     */
-    BipartiteGraph(map<Edge, TEdgeValue> edges) {
+    BipartiteGraph(map<Edge, TEdgeValue> edges)
+    {
         _edges = edges;
         for (const pair<Edge, TEdgeValue> &p : edges) {
-           _left.insert(p.first);
-           _right.insert(p.second);
-           _graph_left[p.first].insert(p.second);
-           _graph_right[p.second].insert(p.first);
+            _left.insert(p.first);
+            _right.insert(p.second);
+            _graph_left[p.first].insert(p.second);
+            _graph_right[p.second].insert(p.first);
         }
     }
-
 
     void __setitem__(Edge key, TEdgeValue value)
     {
@@ -85,12 +84,12 @@ public:
         //_graph.setdefault((LEFT, key[0]), set()).add((RIGHT, key[1]));
         TLeft k1 = get<0>(key);
         if (_graph_left.find(k1) == _graph_left.end()) {
-	    _graph_left[k1] = set<TRight>();
+            _graph_left[k1] = set<TRight>();
         }
         _graph_left[k1].insert(get<1>(key));
 
         //_graph.setdefault((RIGHT, key[1]), set()).add((LEFT, key[0]));
-	TRight k2 = get<1>(key);
+        TRight k2 = get<1>(key);
         if (_graph_right.find(k2) == _graph_right.end()) {
             _graph_right[k2] = set<TLeft>();
         }
@@ -195,7 +194,8 @@ template <typename TLeft, typename TRight, typename TEdgeType>
 class HopcroftKarp
 {
 public:
-    HopcroftKarp(BipartiteGraph<TLeft, TRight, TEdgeType> &bipartite) : bipartite(bipartite)
+    HopcroftKarp(BipartiteGraph<TLeft, TRight, TEdgeType> &bipartite)
+        : bipartite(bipartite)
     {
         reference_distance = -1;
     }
@@ -281,8 +281,7 @@ private:
 
     bool _dfs_hopcroft_karp(const TLeft &left)
     {
-        for (const TRight &right :
-             bipartite._graph_left[left]) {
+        for (const TRight &right : bipartite._graph_left[left]) {
             int distance;
 
             if (pair_right.find(right) == pair_right.end()) {
@@ -322,7 +321,8 @@ public:
     map<TLeft, set<TRight>> _map_left;
     map<TRight, set<TLeft>> _map_right;
 
-    _DirectedMatchGraph() {
+    _DirectedMatchGraph()
+    {
     }
 
     _DirectedMatchGraph(BipartiteGraph<TLeft, TRight, TEdgeValue> graph,
@@ -343,11 +343,11 @@ public:
                 // if (RIGHT, head) not in self:
                 //    self[(RIGHT, head)] = set()
                 // self[(RIGHT, head)].add((LEFT, tail))
-                //Node head_node = make_tuple(RIGHT, head);
+                // Node head_node = make_tuple(RIGHT, head);
                 if (_map_right.find(head) == _map_right.end()) {
                     _map_right[head] = set<TLeft>();
                 }
-                //Node tail_node = make_tuple(LEFT, tail);
+                // Node tail_node = make_tuple(LEFT, tail);
                 _map_right[head].insert(tail);
             }
         }
@@ -361,18 +361,19 @@ public:
     //        return cycle
     //    return cast(NodeList, [])
 
-    //typedef vector<any> NodeList;
+    // typedef vector<any> NodeList;
     typedef vector<pair<TLeft, TRight>> NodeList;
 
     NodeList find_cycle()
     {
-        //set<variant<TLeft, TRight>> visited;
+        // set<variant<TLeft, TRight>> visited;
         set<TLeft> visited_left;
         set<TRight> visited_right;
         for (const pair<TLeft, set<TRight>> &n : _map_left) {
             NodeList node_list;
             NodeList cycle;
-            cycle = _find_cycle_left(n.first, node_list, visited_left, visited_right);
+            cycle = _find_cycle_left(n.first, node_list, visited_left,
+                                     visited_right);
             if (cycle.size() > 0) {
                 return cycle;
             }
@@ -380,7 +381,9 @@ public:
         return NodeList();
     }
 
-    NodeList _find_cycle_left(const TLeft &node, NodeList &path, set<TLeft> &visited_left, set<TRight> &visited_right)
+    NodeList _find_cycle_left(const TLeft &node, NodeList &path,
+                              set<TLeft> &visited_left,
+                              set<TRight> &visited_right)
     {
         // if node in visited:
         //    try:
@@ -391,9 +394,11 @@ public:
         if (visited_left.find(node) != visited_left.end()) {
             typename NodeList::iterator found_end;
             found_end = find_if(path.begin(), path.end(),
-				[&node](const pair<TLeft, TRight> &p){ return p.first == node; });
+                                [&node](const pair<TLeft, TRight> &p) {
+                                    return p.first == node;
+                                });
             if (found_end != path.end()) {
-                return NodeList(path.begin(), found_end+1);
+                return NodeList(path.begin(), found_end + 1);
             } else {
                 return NodeList();
             }
@@ -409,18 +414,22 @@ public:
         //    cycle = self._find_cycle(other, path + [node], visited)
         //    if cycle:
         //        return cycle
-	for (const TRight &other : _map_left[node]) {
-		NodeList new_path(path.begin(), path.end());
-		new_path.push_back(make_pair(node, other));
-		NodeList cycle = _find_cycle_right(other, new_path, visited_left, visited_right);
-		if (cycle.size() > 0) {
-			return cycle;
-		}
-	}
-	return NodeList();
-	}
+        for (const TRight &other : _map_left[node]) {
+            NodeList new_path(path.begin(), path.end());
+            new_path.push_back(make_pair(node, other));
+            NodeList cycle = _find_cycle_right(other, new_path, visited_left,
+                                               visited_right);
+            if (cycle.size() > 0) {
+                return cycle;
+            }
+        }
+        return NodeList();
+    }
 
-    NodeList _find_cycle_right(const TRight &node, NodeList &path, set<TLeft> &visited_left, set<TRight> &visited_right) {
+    NodeList _find_cycle_right(const TRight &node, NodeList &path,
+                               set<TLeft> &visited_left,
+                               set<TRight> &visited_right)
+    {
         // if node in visited:
         //    try:
         //        index = path.index(node)
@@ -430,9 +439,11 @@ public:
         if (visited_right.find(node) != visited_right.end()) {
             typename NodeList::iterator found_end;
             found_end = find_if(path.begin(), path.end(),
-				[&node](const pair<TLeft, TRight> &p){ return p.second == node; });
+                                [&node](const pair<TLeft, TRight> &p) {
+                                    return p.second == node;
+                                });
             if (found_end != path.end()) {
-                return NodeList(path.begin(), found_end+1);
+                return NodeList(path.begin(), found_end + 1);
             } else {
                 return NodeList();
             }
@@ -448,13 +459,14 @@ public:
         //    cycle = self._find_cycle(other, path + [node], visited)
         //    if cycle:
         //        return cycle
-	for (const TLeft &other : _map_right[node]) {
-		NodeList new_path(path.begin(), path.end());
-		NodeList cycle = _find_cycle_left(other, new_path, visited_left, visited_right);
-		if (cycle.size() > 0) {
-			return cycle;
-		}
-	}
+        for (const TLeft &other : _map_right[node]) {
+            NodeList new_path(path.begin(), path.end());
+            NodeList cycle = _find_cycle_left(other, new_path, visited_left,
+                                              visited_right);
+            if (cycle.size() > 0) {
+                return cycle;
+            }
+        }
         // return cast(NodeList, [])
         return NodeList();
     }
@@ -469,7 +481,8 @@ public:
  * See http://dx.doi.org/10.1007/3-540-63890-3_11
  */
 template <typename TLeft, typename TRight, typename TEdgeValue>
-class _enum_maximum_matchings_iter : public virtual GeneratorTrick<map<TLeft, TRight>>
+class _enum_maximum_matchings_iter
+    : public virtual GeneratorTrick<map<TLeft, TRight>>
 {
 private:
     BipartiteGraph<TLeft, TRight, TEdgeValue> graph;
@@ -478,7 +491,8 @@ private:
 
 public:
     _enum_maximum_matchings_iter(
-        BipartiteGraph<TLeft, TRight, TEdgeValue> graph, map<TLeft, TRight> matching,
+        BipartiteGraph<TLeft, TRight, TEdgeValue> graph,
+        map<TLeft, TRight> matching,
         _DirectedMatchGraph<TLeft, TRight, TEdgeValue> directed_match_graph)
         : graph(graph), matching(matching),
           directed_match_graph(directed_match_graph)
@@ -654,7 +668,8 @@ private:
         }
         // directed_match_graph_plus = _DirectedMatchGraph(graph_plus, matching)
         directed_match_graph_plus
-            = _DirectedMatchGraph<TLeft, TRight, TEdgeValue>(graph_plus, matching);
+            = _DirectedMatchGraph<TLeft, TRight, TEdgeValue>(graph_plus,
+                                                             matching);
         // yield from _enum_maximum_matchings_iter(graph_plus, matching,
         // directed_match_graph_plus)
         iter_enum = _enum_maximum_matchings_iter<TLeft, TRight, TEdgeValue>(
@@ -762,8 +777,10 @@ private:
         graph_plus = graph.without_nodes(edge);
         graph_minus = graph.without_edge(edge);
 
-        dgm_plus = _DirectedMatchGraph<TLeft, TRight, TEdgeValue>(graph_plus, new_match);
-        dgm_minus = _DirectedMatchGraph<TLeft, TRight, TEdgeValue>(graph_minus, matching);
+        dgm_plus = _DirectedMatchGraph<TLeft, TRight, TEdgeValue>(graph_plus,
+                                                                  new_match);
+        dgm_minus = _DirectedMatchGraph<TLeft, TRight, TEdgeValue>(graph_minus,
+                                                                   matching);
         this->current = bind(&_enum_maximum_matchings_iter::step9, this);
     }
 
@@ -797,7 +814,8 @@ private:
         // dgm_minus)
         iter_enum = _enum_maximum_matchings_iter<TLeft, TRight, TEdgeValue>(
             graph_minus, matching, dgm_minus);
-        this->current = bind(&_enum_maximum_matchings_iter::step10part002, this);
+        this->current
+            = bind(&_enum_maximum_matchings_iter::step10part002, this);
     }
 
     void step10part002()

--- a/matchpygen/bipartite.h
+++ b/matchpygen/bipartite.h
@@ -403,8 +403,8 @@ public:
  * December 17-19, 1997 Proceedings"
  * See http://dx.doi.org/10.1007/3-540-63890-3_11
  */
-template <typename TEdgeValue>
-class _enum_maximum_matchings_iter : public GeneratorTrick<map<TLeft, TRight>>
+template <typename TLeft, typename TRight, typename TEdgeValue>
+class _enum_maximum_matchings_iter : public virtual GeneratorTrick<map<TLeft, TRight>>
 {
 private:
     BipartiteGraph<TEdgeValue> graph;
@@ -433,7 +433,7 @@ private:
 
     BipartiteGraph<TEdgeValue> graph_plus, graph_minus;
     _DirectedMatchGraph<TEdgeValue> dgm_plus, dgm_minus;
-    _enum_maximum_matchings_iter<TEdgeValue> iter_enum;
+    _enum_maximum_matchings_iter<TLeft, TRight, TEdgeValue> iter_enum;
 
     TLeft *left1, *left2;
     TRight *right;
@@ -441,7 +441,7 @@ private:
 
     virtual void start()
     {
-        current = bind(&_enum_maximum_matchings_iter::step1, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step1, this);
     }
 
     void step1()
@@ -450,9 +450,9 @@ private:
         // if len(graph) == 0:
         //    return
         if (graph.empty()) {
-            generator_stop = true;
+            this->generator_stop = true;
         } else {
-            current = bind(&_enum_maximum_matchings_iter::step2, this);
+            this->current = bind(&_enum_maximum_matchings_iter::step2, this);
         }
     }
 
@@ -486,9 +486,9 @@ private:
             } else {
                 cycle = NodeList(raw_cycle.begin() + 1, raw_cycle.end());
             }
-            current = bind(&_enum_maximum_matchings_iter::step3, this);
+            this->current = bind(&_enum_maximum_matchings_iter::step3, this);
         } else {
-            current = bind(&_enum_maximum_matchings_iter::step8, this);
+            this->current = bind(&_enum_maximum_matchings_iter::step8, this);
         }
     }
     void step3()
@@ -496,13 +496,13 @@ private:
         //# Step 3 - TODO: Properly find right edge? (to get complexity bound)
         // edge = cast(Edge, cycle[:2])
         edge = make_tuple(cycle[0], cycle[1]);
-        current = bind(&_enum_maximum_matchings_iter::step4, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step4, this);
     }
     void step4()
     {
         //# Step 4
         //# already done because we are not really finding the optimal edge
-        current = bind(&_enum_maximum_matchings_iter::step5, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step5, this);
     }
     void step5()
     {
@@ -526,7 +526,7 @@ private:
         yield(new_match);
         old_value = graph._graph.at(edge);
         graph.__delitem__(edge);
-        current = bind(&_enum_maximum_matchings_iter::step7, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step7, this);
     }
 
     void step7()
@@ -541,9 +541,9 @@ private:
         // graph[edge] = old_value
         directed_match_graph_minus
             = _DirectedMatchGraph<TEdgeValue>(graph, new_match);
-        iter_enum = _enum_maximum_matchings_iter<TEdgeValue>(
+        iter_enum = _enum_maximum_matchings_iter<TLeft, TRight, TEdgeValue>(
             graph, new_match, directed_match_graph_minus);
-        current = bind(&_enum_maximum_matchings_iter::step7part002, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step7part002, this);
     }
 
     void step7part002()
@@ -556,7 +556,7 @@ private:
             yield(*v);
             return;
         }
-        current = bind(&_enum_maximum_matchings_iter::step6, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step6, this);
     }
 
     void step6()
@@ -589,9 +589,9 @@ private:
             = _DirectedMatchGraph<TEdgeValue>(graph_plus, matching);
         // yield from _enum_maximum_matchings_iter(graph_plus, matching,
         // directed_match_graph_plus)
-        iter_enum = _enum_maximum_matchings_iter<TEdgeValue>(
+        iter_enum = _enum_maximum_matchings_iter<TLeft, TRight, TEdgeValue>(
             graph_plus, matching, directed_match_graph_plus);
-        current = bind(&_enum_maximum_matchings_iter::step6part002, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step6part002, this);
     }
 
     void step6part002()
@@ -604,7 +604,7 @@ private:
             yield(*v);
             return;
         }
-        current = bind(&_enum_maximum_matchings_iter::step6part003, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step6part003, this);
     }
 
     void step6part003()
@@ -615,7 +615,7 @@ private:
             Node node(get<0>(p), get<1>(p));
             graph_plus[node] = get<2>(p);
         }
-        generator_stop = true;
+        this->generator_stop = true;
     }
 
     void step8()
@@ -671,7 +671,7 @@ private:
         // if left2 is None:
         //    return
         if (left2 == nullptr) {
-            generator_stop = true;
+            this->generator_stop = true;
             return;
         }
         //# Construct M'
@@ -696,7 +696,7 @@ private:
 
         dgm_plus = _DirectedMatchGraph<TEdgeValue>(graph_plus, new_match);
         dgm_minus = _DirectedMatchGraph<TEdgeValue>(graph_minus, matching);
-        current = bind(&_enum_maximum_matchings_iter::step9, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step9, this);
     }
 
     void step9()
@@ -704,9 +704,9 @@ private:
         //# Step 9
         // yield from _enum_maximum_matchings_iter(graph_plus, new_match,
         // dgm_plus)
-        iter_enum = _enum_maximum_matchings_iter<TEdgeValue>(
+        iter_enum = _enum_maximum_matchings_iter<TLeft, TRight, TEdgeValue>(
             graph_plus, new_match, dgm_plus);
-        current = bind(&_enum_maximum_matchings_iter::step9part002, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step9part002, this);
     }
 
     void step9part002()
@@ -719,7 +719,7 @@ private:
             yield(*v);
             return;
         }
-        current = bind(&_enum_maximum_matchings_iter::step10, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step10, this);
     }
 
     void step10()
@@ -727,9 +727,9 @@ private:
         //# Step 10
         // yield from _enum_maximum_matchings_iter(graph_minus, matching,
         // dgm_minus)
-        iter_enum = _enum_maximum_matchings_iter<TEdgeValue>(
+        iter_enum = _enum_maximum_matchings_iter<TLeft, TRight, TEdgeValue>(
             graph_minus, matching, dgm_minus);
-        current = bind(&_enum_maximum_matchings_iter::step10part002, this);
+        this->current = bind(&_enum_maximum_matchings_iter::step10part002, this);
     }
 
     void step10part002()
@@ -742,7 +742,7 @@ private:
             yield(*v);
             return;
         }
-        generator_stop = true;
+        this->generator_stop = true;
     }
 };
 

--- a/matchpygen/bipartite.h
+++ b/matchpygen/bipartite.h
@@ -21,16 +21,16 @@ const int RIGHT = 1;
 
 typedef map<tuple<int, int>, tuple<int, int>> Matching;
 
-//(Generic[TLeft, TRight, TEdgeValue], MutableMapping[Tuple[TLeft, TRight], TEdgeValue])
+//(Generic[TLeft, TRight, TEdgeValue], MutableMapping[Tuple[TLeft, TRight],
+//TEdgeValue])
 /*
  * A bipartite graph representation.
  */
-template<typename TEdgeValue>
+template <typename TEdgeValue>
 class BipartiteGraph
 {
 public:
-
-    //Node = Tuple[int, Union[TLeft, TRight]]
+    // Node = Tuple[int, Union[TLeft, TRight]]
     // typedef tuple<int, variant<TLeft, TRight>> Node; ???
     typedef tuple<int, TItem> Node;
     typedef vector<Node> NodeList;
@@ -51,7 +51,7 @@ public:
 
     void __setitem__(Edge key, TEdgeValue value)
     {
-        //if not isinstance(key, tuple) or len(key) != 2:
+        // if not isinstance(key, tuple) or len(key) != 2:
         //    raise TypeError("The edge must be a 2-tuple")
         _edges[key] = value;
         _left.insert(get<0>(key));
@@ -80,7 +80,7 @@ public:
     void __delitem__(Edge key)
     {
         _edges.erase(key);
-        //if all(l != key[0] for (l, _) in self._edges):
+        // if all(l != key[0] for (l, _) in self._edges):
         //    self._left.remove(key[0])
         for (const pair<Edge, TEdgeValue> &p : _edges) {
             TLeft l = get<0>(p.first);
@@ -89,7 +89,7 @@ public:
                 break;
             }
         }
-        //if all(r != key[1] for (_, r) in self._edges):
+        // if all(r != key[1] for (_, r) in self._edges):
         //    self._right.remove(key[1])
         for (const pair<Edge, TEdgeValue> &p : _edges) {
             TRight l = get<1>(p.first);
@@ -98,19 +98,19 @@ public:
                 break;
             }
         }
-        //self._graph[(LEFT, key[0])].remove((RIGHT, key[1]))
+        // self._graph[(LEFT, key[0])].remove((RIGHT, key[1]))
         _graph[make_tuple(LEFT, get<0>(key))].erase(
-                make_tuple(RIGHT, get<1>(key)));
-        //self._graph[(RIGHT, key[1])].remove((LEFT, key[0]))
+            make_tuple(RIGHT, get<1>(key)));
+        // self._graph[(RIGHT, key[1])].remove((LEFT, key[0]))
         _graph[make_tuple(RIGHT, get<1>(key))].erase(
-                make_tuple(LEFT, get<0>(key)));
+            make_tuple(LEFT, get<0>(key)));
     }
 
-    //def edges_with_labels(self):
+    // def edges_with_labels(self):
     //    """Returns a view on the edges with labels."""
     //    return self._edges.items()
 
-    //def edges(self):
+    // def edges(self):
     //    return self._edges.keys()
 
     void clear()
@@ -120,16 +120,13 @@ public:
         _right.clear();
         _graph.clear();
     }
-
 };
 
-template<typename TEdgeType>
+template <typename TEdgeType>
 class HopcroftKarp
 {
 public:
-
-    HopcroftKarp(BipartiteGraph<TEdgeType> &bipartite) :
-            bipartite(bipartite)
+    HopcroftKarp(BipartiteGraph<TEdgeType> &bipartite) : bipartite(bipartite)
     {
         reference_distance = -1;
     }
@@ -146,7 +143,7 @@ public:
                 break;
             for (const TLeft &left : bipartite._left) {
                 if ((pair_left.find(left) == pair_left.end())
-                        && _dfs_hopcroft_karp(left)) {
+                    && _dfs_hopcroft_karp(left)) {
                     matching++;
                 }
             }
@@ -195,8 +192,8 @@ private:
             vertex_queue.pop_front();
             if (dist_left.find(left_vertex) == dist_left.end())
                 continue;
-            for (const tuple<int, TRight> &p : bipartite._graph[make_tuple(LEFT,
-                    left_vertex)]) {
+            for (const tuple<int, TRight> &p :
+                 bipartite._graph[make_tuple(LEFT, left_vertex)]) {
                 if (get<0>(p) == LEFT) {
                     // not a left vertex, continue
                     throw("inconsistent graph");
@@ -213,7 +210,6 @@ private:
                         vertex_queue.push_back(other_left);
                     }
                 }
-
             }
         }
         return reference_distance != -1;
@@ -221,8 +217,8 @@ private:
 
     bool _dfs_hopcroft_karp(const TLeft &left)
     {
-        for (const tuple<int, TRight> &p : bipartite._graph[make_tuple(LEFT,
-                left)]) {
+        for (const tuple<int, TRight> &p :
+             bipartite._graph[make_tuple(LEFT, left)]) {
             const TRight &right = get<1>(p);
             int distance;
 
@@ -241,12 +237,10 @@ private:
                 pair_right[right] = left;
                 return true;
             }
-
         }
         dist_left.erase(left);
         return false;
     }
-
 };
 
 int get0(tuple<int, int> a)

--- a/matchpygen/bipartite.h
+++ b/matchpygen/bipartite.h
@@ -16,26 +16,26 @@ typedef tuple<int, int> TItem; // either TLeft or TRight, use <variant> instead?
 typedef TItem TRight;
 typedef TItem TLeft;
 
-
 const int LEFT = 0;
 const int RIGHT = 1;
 
-typedef map<tuple<int, int>, tuple<int, int> > Matching;
+typedef map<tuple<int, int>, tuple<int, int>> Matching;
 
 //(Generic[TLeft, TRight, TEdgeValue], MutableMapping[Tuple[TLeft, TRight], TEdgeValue])
 /*
  * A bipartite graph representation.
  */
 template<typename TEdgeValue>
-class BipartiteGraph {
+class BipartiteGraph
+{
 public:
 
-	//Node = Tuple[int, Union[TLeft, TRight]]
-	// typedef tuple<int, variant<TLeft, TRight>> Node; ???
-	typedef tuple<int, TItem> Node;
-	typedef vector<Node> NodeList;
-	typedef set<Node> NodeSet;
-	typedef tuple<TLeft, TRight> Edge;
+    //Node = Tuple[int, Union[TLeft, TRight]]
+    // typedef tuple<int, variant<TLeft, TRight>> Node; ???
+    typedef tuple<int, TItem> Node;
+    typedef vector<Node> NodeList;
+    typedef set<Node> NodeSet;
+    typedef tuple<TLeft, TRight> Edge;
 
     map<Edge, TEdgeValue> _edges;
     map<int, int> _matching;
@@ -45,11 +45,14 @@ public:
     set<TRight> _right;
     map<Node, set<Node>> _graph;
 
-    BipartiteGraph() {}
+    BipartiteGraph()
+    {
+    }
 
-    void __setitem__(Edge key, TEdgeValue value) {
-//        if not isinstance(key, tuple) or len(key) != 2:
-//            raise TypeError("The edge must be a 2-tuple")
+    void __setitem__(Edge key, TEdgeValue value)
+    {
+        //if not isinstance(key, tuple) or len(key) != 2:
+        //    raise TypeError("The edge must be a 2-tuple")
         _edges[key] = value;
         _left.insert(get<0>(key));
         _right.insert(get<1>(key));
@@ -69,11 +72,13 @@ public:
         _graph[k2].insert(make_tuple(LEFT, get<0>(key)));
     }
 
-    TEdgeValue &__getitem__(Edge key) {
+    TEdgeValue &__getitem__(Edge key)
+    {
         return _edges[key];
     }
 
-    void __delitem__(Edge key) {
+    void __delitem__(Edge key)
+    {
         _edges.erase(key);
         //if all(l != key[0] for (l, _) in self._edges):
         //    self._left.remove(key[0])
@@ -94,19 +99,22 @@ public:
             }
         }
         //self._graph[(LEFT, key[0])].remove((RIGHT, key[1]))
-        _graph[make_tuple(LEFT, get<0>(key))].erase(make_tuple(RIGHT, get<1>(key)));
+        _graph[make_tuple(LEFT, get<0>(key))].erase(
+                make_tuple(RIGHT, get<1>(key)));
         //self._graph[(RIGHT, key[1])].remove((LEFT, key[0]))
-        _graph[make_tuple(RIGHT, get<1>(key))].erase(make_tuple(LEFT, get<0>(key)));
+        _graph[make_tuple(RIGHT, get<1>(key))].erase(
+                make_tuple(LEFT, get<0>(key)));
     }
 
-//    def edges_with_labels(self):
-//        """Returns a view on the edges with labels."""
-//        return self._edges.items()
+    //def edges_with_labels(self):
+    //    """Returns a view on the edges with labels."""
+    //    return self._edges.items()
 
-//    def edges(self):
-//        return self._edges.keys()
+    //def edges(self):
+    //    return self._edges.keys()
 
-    void clear() {
+    void clear()
+    {
         _edges.clear();
         _left.clear();
         _right.clear();
@@ -115,128 +123,139 @@ public:
 
 };
 
-
 template<typename TEdgeType>
-class HopcroftKarp {
+class HopcroftKarp
+{
 public:
 
-	HopcroftKarp(BipartiteGraph<TEdgeType> &bipartite) : bipartite(bipartite) {
-		reference_distance = -1;
-	}
+    HopcroftKarp(BipartiteGraph<TEdgeType> &bipartite) :
+            bipartite(bipartite)
+    {
+        reference_distance = -1;
+    }
 
-	int hopcroft_karp() {
-		pair_left.clear();
-		pair_right.clear();
-		dist_left.clear();
-		vertex_queue.clear();
-		int matching = 0;
-		while (true) {
-			if (!_bfs_hopcroft_karp())
-				break;
-			for (const TLeft &left : bipartite._left) {
-				if ((pair_left.find(left) == pair_left.end()) && _dfs_hopcroft_karp(left)) {
-					matching++;
-				}
-			}
-		}
-		return matching;
-	}
+    int hopcroft_karp()
+    {
+        pair_left.clear();
+        pair_right.clear();
+        dist_left.clear();
+        vertex_queue.clear();
+        int matching = 0;
+        while (true) {
+            if (!_bfs_hopcroft_karp())
+                break;
+            for (const TLeft &left : bipartite._left) {
+                if ((pair_left.find(left) == pair_left.end())
+                        && _dfs_hopcroft_karp(left)) {
+                    matching++;
+                }
+            }
+        }
+        return matching;
+    }
 
-	void dump_state() {
-		cout << endl;
-		for (const pair<TLeft, TRight> &p : pair_left) {
-			int l = get<1>(p.first);
-			cout << l << " " << get<1>(p.second) << endl;
-		}
-		cout << endl;
-		cout << "Distances:\n";
-		for (const pair<TLeft, int> &p : dist_left) {
-			cout << "Vertex: " << get<1>(p.first) << " " << p.second << endl;
-		}
-		return;
-	}
+    void dump_state()
+    {
+        cout << endl;
+        for (const pair<TLeft, TRight> &p : pair_left) {
+            int l = get<1>(p.first);
+            cout << l << " " << get<1>(p.second) << endl;
+        }
+        cout << endl;
+        cout << "Distances:\n";
+        for (const pair<TLeft, int> &p : dist_left) {
+            cout << "Vertex: " << get<1>(p.first) << " " << p.second << endl;
+        }
+        return;
+    }
 
 private:
-	map<TLeft, TRight> pair_left;
-	map<TRight, TLeft> pair_right;
-	BipartiteGraph<TEdgeType> &bipartite;
-	deque<TLeft> vertex_queue;
-	map<TLeft, int> dist_left;
-	int reference_distance;
+    map<TLeft, TRight> pair_left;
+    map<TRight, TLeft> pair_right;
+    BipartiteGraph<TEdgeType> &bipartite;
+    deque<TLeft> vertex_queue;
+    map<TLeft, int> dist_left;
+    int reference_distance;
 
-	bool _bfs_hopcroft_karp() {
-		for (const TLeft &left_vert : bipartite._left) {
-			if (pair_left.find(left_vert) == pair_left.end()) {
-				vertex_queue.push_back(left_vert);
-				dist_left[left_vert] = 0;
-			} else {
-				dist_left.erase(left_vert);
-			}
-		}
-		reference_distance = -1;
-		while (true) {
-			if (vertex_queue.size() == 0)
-				break;
-			TLeft &left_vertex = vertex_queue.front();
-			vertex_queue.pop_front();
-			if (dist_left.find(left_vertex) == dist_left.end())
-				continue;
-			for (const tuple<int, TRight> &p : bipartite._graph[make_tuple(LEFT, left_vertex)]) {
-				if (get<0>(p) == LEFT) {
-					// not a left vertex, continue
-					throw("inconsistent graph");
-				}
-				const TRight &right_vertex = get<1>(p);
-				if (pair_right.find(right_vertex) == pair_right.end()) {
-					if (reference_distance == -1) {
-						reference_distance = dist_left[left_vertex] + 1;
-					}
-				} else {
-					TLeft &other_left = pair_right.at(right_vertex);
-					if (dist_left.find(other_left) == dist_left.end()) {
-						dist_left[other_left] = dist_left[left_vertex] + 1;
-						vertex_queue.push_back(other_left);
-					}
-				}
+    bool _bfs_hopcroft_karp()
+    {
+        for (const TLeft &left_vert : bipartite._left) {
+            if (pair_left.find(left_vert) == pair_left.end()) {
+                vertex_queue.push_back(left_vert);
+                dist_left[left_vert] = 0;
+            } else {
+                dist_left.erase(left_vert);
+            }
+        }
+        reference_distance = -1;
+        while (true) {
+            if (vertex_queue.size() == 0)
+                break;
+            TLeft &left_vertex = vertex_queue.front();
+            vertex_queue.pop_front();
+            if (dist_left.find(left_vertex) == dist_left.end())
+                continue;
+            for (const tuple<int, TRight> &p : bipartite._graph[make_tuple(LEFT,
+                    left_vertex)]) {
+                if (get<0>(p) == LEFT) {
+                    // not a left vertex, continue
+                    throw("inconsistent graph");
+                }
+                const TRight &right_vertex = get<1>(p);
+                if (pair_right.find(right_vertex) == pair_right.end()) {
+                    if (reference_distance == -1) {
+                        reference_distance = dist_left[left_vertex] + 1;
+                    }
+                } else {
+                    TLeft &other_left = pair_right.at(right_vertex);
+                    if (dist_left.find(other_left) == dist_left.end()) {
+                        dist_left[other_left] = dist_left[left_vertex] + 1;
+                        vertex_queue.push_back(other_left);
+                    }
+                }
 
-			}
-		}
-		return reference_distance != -1;
-	}
+            }
+        }
+        return reference_distance != -1;
+    }
 
-	bool _dfs_hopcroft_karp(const TLeft &left) {
-		for (const tuple<int, TRight> &p : bipartite._graph[make_tuple(LEFT, left)]) {
-			const TRight &right = get<1>(p);
-			int distance;
+    bool _dfs_hopcroft_karp(const TLeft &left)
+    {
+        for (const tuple<int, TRight> &p : bipartite._graph[make_tuple(LEFT,
+                left)]) {
+            const TRight &right = get<1>(p);
+            int distance;
 
-			if (pair_right.find(right) == pair_right.end()) {
-				distance = reference_distance;
-			} else {
-				TLeft &other_left = pair_right.at(right);
-				if (dist_left.find(other_left) == dist_left.end()) {
-					distance = reference_distance;
-				} else {
-					distance = dist_left.at(other_left);
-				}
-			}
-			if (distance == dist_left.at(left) + 1) {
-				pair_left[left] = right;
-				pair_right[right] = left;
-				return true;
-			}
+            if (pair_right.find(right) == pair_right.end()) {
+                distance = reference_distance;
+            } else {
+                TLeft &other_left = pair_right.at(right);
+                if (dist_left.find(other_left) == dist_left.end()) {
+                    distance = reference_distance;
+                } else {
+                    distance = dist_left.at(other_left);
+                }
+            }
+            if (distance == dist_left.at(left) + 1) {
+                pair_left[left] = right;
+                pair_right[right] = left;
+                return true;
+            }
 
-		}
-		dist_left.erase(left);
-		return false;
-	}
+        }
+        dist_left.erase(left);
+        return false;
+    }
 
 };
 
-int get0(tuple<int, int> a) {
-	return get<0>(a);
+int get0(tuple<int, int> a)
+{
+    return get<0>(a);
 }
-int get1(tuple<int, int> a) {
-	return get<1>(a);
+int get1(tuple<int, int> a)
+{
+    return get<1>(a);
 }
 
 #endif

--- a/matchpygen/bipartite.h
+++ b/matchpygen/bipartite.h
@@ -4,17 +4,25 @@
 #include <deque>
 #include <map>
 #include <set>
+
 #include <symengine/basic.h>
 #include <symengine/pow.h>
 #include <symengine/add.h>
 
 #include "common.h"
+#include "generator_trick.h"
 
 using namespace std;
 
 typedef tuple<int, int> TItem; // either TLeft or TRight, use <variant> instead?
 typedef TItem TRight;
 typedef TItem TLeft;
+// Node = Tuple[int, Union[TLeft, TRight]]
+// typedef tuple<int, variant<TLeft, TRight>> Node; ???
+typedef tuple<int, TItem> Node;
+typedef vector<Node> NodeList;
+typedef set<Node> NodeSet;
+typedef tuple<TLeft, TRight> Edge;
 
 const int LEFT = 0;
 const int RIGHT = 1;
@@ -22,7 +30,7 @@ const int RIGHT = 1;
 typedef map<tuple<int, int>, tuple<int, int>> Matching;
 
 //(Generic[TLeft, TRight, TEdgeValue], MutableMapping[Tuple[TLeft, TRight],
-//TEdgeValue])
+// TEdgeValue])
 /*
  * A bipartite graph representation.
  */
@@ -30,13 +38,6 @@ template <typename TEdgeValue>
 class BipartiteGraph
 {
 public:
-    // Node = Tuple[int, Union[TLeft, TRight]]
-    // typedef tuple<int, variant<TLeft, TRight>> Node; ???
-    typedef tuple<int, TItem> Node;
-    typedef vector<Node> NodeList;
-    typedef set<Node> NodeSet;
-    typedef tuple<TLeft, TRight> Edge;
-
     map<Edge, TEdgeValue> _edges;
     map<int, int> _matching;
     vector<int> _dfs_paths;
@@ -104,6 +105,51 @@ public:
         // self._graph[(RIGHT, key[1])].remove((LEFT, key[0]))
         _graph[make_tuple(RIGHT, get<1>(key))].erase(
             make_tuple(LEFT, get<0>(key)));
+    }
+
+    // def without_nodes(self, edge: Edge) -> 'BipartiteGraph[TLeft, TRight,
+    // TEdgeValue]':
+    //    """Returns a copy of this bipartite graph with the given edge and its
+    //    adjacent nodes removed."""
+    //    return BipartiteGraph(((n1, n2), v) for (n1, n2), v in
+    //    self._edges.items() if n1 != edge[0] and n2 != edge[1])
+    BipartiteGraph<TEdgeValue> without_nodes(Edge &edge)
+    {
+        //((n1, n2), v) for (n1, n2), v in self._edges.items() if n1 != edge[0]
+        // and n2 != edge[1])
+        BipartiteGraph<TEdgeValue> new_graph;
+        for (const pair<Edge, TEdgeValue> &p : _edges) {
+            Node &node = p.first;
+            TEdgeValue &v = p.second;
+            TLeft &n1 = get<0>(node);
+            TRight &n2 = get<1>(node);
+            if ((n1 == get<0>(edge)) || (n2 == get<1>(edge))) {
+                continue;
+            }
+            new_graph.__setitem__(node, v);
+        }
+        return new_graph;
+    }
+
+    // def without_edge(self, edge: Edge) -> 'BipartiteGraph[TLeft, TRight,
+    // TEdgeValue]':
+    //    """Returns a copy of this bipartite graph with the given edge
+    //    removed."""
+    //    return BipartiteGraph((e2, v) for e2, v in self._edges.items() if edge
+    //    != e2)
+    BipartiteGraph<TEdgeValue> without_edge(Edge &edge)
+    {
+        //((e2, v) for e2, v in self._edges.items() if edge != e2)
+        BipartiteGraph<TEdgeValue> new_graph;
+        for (const pair<Edge, TEdgeValue> &p : _edges) {
+            Node &e2 = p.first;
+            TEdgeValue &v = p.second;
+            if (edge == e2) {
+                continue;
+            }
+            new_graph.__setitem__(e2, v);
+        }
+        return new_graph;
     }
 
     // def edges_with_labels(self):
@@ -251,5 +297,453 @@ int get1(tuple<int, int> a)
 {
     return get<1>(a);
 }
+
+template <typename TEdgeValue>
+class _DirectedMatchGraph
+{
+public:
+    //  map<TLeft, TRight> _map_left;
+    //  map<TRight, TLeft> _map_right;
+    map<Node, set<Node>> _map;
+
+    _DirectedMatchGraph(BipartiteGraph<TEdgeValue> graph,
+                        map<TLeft, TRight> matching)
+    {
+        //        for (tail, head) in graph:
+        for (const pair<TLeft, TRight> &p : graph._graph) {
+            TLeft &tail = get<0>(p);
+            TRight &head = get<1>(p);
+            // if tail in matching and matching[tail] == head:
+            //    self[(LEFT, tail)] = {(RIGHT, head)}
+            if ((matching.find(tail) != matching.end())
+                && (matching.at(tail) == head)) {
+                set<TRight> s;
+                s.insert(head);
+                _map[make_tuple(LEFT, tail)] = s;
+            } else {
+                // if (RIGHT, head) not in self:
+                //    self[(RIGHT, head)] = set()
+                // self[(RIGHT, head)].add((LEFT, tail))
+                Node head_node = make_tuple(RIGHT, head);
+                if (_map.find(head_node) == _map.end()) {
+                    _map[head_node] = set<Node>();
+                }
+                Node tail_node = make_tuple(LEFT, tail);
+                _map[head_node].insert(tail_node);
+            }
+        }
+    }
+
+    // def find_cycle(self) -> NodeList:
+    //    visited = cast(NodeSet, set())
+    //    for n in self:
+    //	cycle = self._find_cycle(n, cast(NodeList, []), visited)
+    //	if cycle:
+    //	    return cycle
+    //    return cast(NodeList, [])
+    NodeList find_cycle()
+    {
+        NodeSet visited = set<Node>();
+        for (pair<Node, set<Node>> &n : _map) {
+            NodeList node_list;
+            NodeList &cycle = _find_cycle(n.first, node_list, visited);
+            if (cycle.size() > 0) {
+                return cycle;
+            }
+        }
+        return NodeList();
+    }
+
+    NodeList _find_cycle(const Node &node, NodeList &path, NodeSet &visited)
+    {
+        // if node in visited:
+        //	try:
+        //	    index = path.index(node)
+        //	    return path[index:]
+        //	except ValueError:
+        //	    return cast(NodeList, [])
+        if (visited.find(node) != visited.end()) {
+            NodeList::iterator &found_end
+                = find(path.begin(), path.end(), node);
+            if (found_end != path.end()) {
+                return NodeList(path.begin(), found_end);
+            } else {
+                return NodeList();
+            }
+        }
+        // visited.add(node)
+        visited.insert(node);
+        // if node not in self:
+        //	return cast(NodeList, [])
+        if (_map.find(node) == _map.end()) {
+            return NodeList();
+        }
+        // for other in self[node]:
+        //	cycle = self._find_cycle(other, path + [node], visited)
+        //	if cycle:
+        //	    return cycle
+        for (const Node &other : _map[node]) {
+            NodeList new_path(path.begin(), path.end());
+            new_path.push_back(node);
+            NodeList &cycle = _find_cycle(other, new_path, visited);
+            if (cycle.size() > 0) {
+                return cycle;
+            }
+        }
+        // return cast(NodeList, [])
+        return NodeList();
+    }
+};
+
+/*
+ * Algorithm described in "Algorithms for Enumerating All Perfect, Maximum and
+ * Maximal Matchings in Bipartite Graphs"
+ * By Takeaki Uno in "Algorithms and Computation: 8th International Symposium,
+ * ISAAC '97 Singapore,
+ * December 17-19, 1997 Proceedings"
+ * See http://dx.doi.org/10.1007/3-540-63890-3_11
+ */
+template <typename TEdgeValue>
+class _enum_maximum_matchings_iter : public GeneratorTrick<map<TLeft, TRight>>
+{
+private:
+    BipartiteGraph<TEdgeValue> graph;
+    map<TLeft, TRight> matching;
+    _DirectedMatchGraph<TEdgeValue> directed_match_graph;
+
+public:
+    _enum_maximum_matchings_iter(
+        BipartiteGraph<TEdgeValue> graph, map<TLeft, TRight> matching,
+        _DirectedMatchGraph<TEdgeValue> directed_match_graph)
+        : graph(graph), matching(matching),
+          directed_match_graph(directed_match_graph)
+    {
+    }
+    virtual ~_enum_maximum_matchings_iter()
+    {
+    }
+
+private:
+    map<TLeft, TRight> new_match;
+    Edge edge;
+    NodeList cycle;
+    _DirectedMatchGraph<TEdgeValue> directed_match_graph_minus,
+        directed_match_graph_plus;
+    set<Node> old_value;
+
+    BipartiteGraph<TEdgeValue> graph_plus, graph_minus;
+    _DirectedMatchGraph<TEdgeValue> dgm_plus, dgm_minus;
+    _enum_maximum_matchings_iter<TEdgeValue> iter_enum;
+
+    TLeft *left1, *left2;
+    TRight *right;
+    list<Edge> edges;
+
+    virtual void start()
+    {
+        current = bind(&_enum_maximum_matchings_iter::step1, this);
+    }
+
+    void step1()
+    {
+        //# Step 1
+        // if len(graph) == 0:
+        //    return
+        if (graph.empty()) {
+            generator_stop = true;
+        } else {
+            current = bind(&_enum_maximum_matchings_iter::step2, this);
+        }
+    }
+
+    void step2()
+    {
+        //# Step 2
+        //# Find a circle in the directed matching graph
+        //# Note that this circle alternates between nodes from the left and the
+        // right part of the graph
+        // raw_cycle = directed_match_graph.find_cycle()
+        //
+        // if raw_cycle:
+        //    # Make sure the circle "starts"" in the the left part
+        //    # If not, start the circle from the second node, which is in the
+        //    left part
+        //    if raw_cycle[0][0] != LEFT:
+        //        cycle = tuple([raw_cycle[-1][1]] + list(x[1] for x in
+        //        raw_cycle[:-1]))
+        //    else:
+        //        cycle = tuple(x[1] for x in raw_cycle)
+        // step3();
+        // else: step8()
+        //
+        NodeList &raw_cycle = directed_match_graph.find_cycle();
+        if (!raw_cycle.empty()) {
+            if (get<0>(raw_cycle[0]) != LEFT) {
+                cycle = NodeList();
+                cycle.push_back(cycle.back());
+                cycle.insert(cycle.end(), raw_cycle.begin() + 1,
+                             raw_cycle.end());
+            } else {
+                cycle = NodeList(raw_cycle.begin() + 1, raw_cycle.end());
+            }
+            current = bind(&_enum_maximum_matchings_iter::step3, this);
+        } else {
+            current = bind(&_enum_maximum_matchings_iter::step8, this);
+        }
+    }
+    void step3()
+    {
+        //# Step 3 - TODO: Properly find right edge? (to get complexity bound)
+        // edge = cast(Edge, cycle[:2])
+        edge = make_tuple(cycle[0], cycle[1]);
+        current = bind(&_enum_maximum_matchings_iter::step4, this);
+    }
+    void step4()
+    {
+        //# Step 4
+        //# already done because we are not really finding the optimal edge
+        current = bind(&_enum_maximum_matchings_iter::step5, this);
+    }
+    void step5()
+    {
+        //# Step 5
+        //# Construct new matching M' by flipping edges along the cycle, i.e.
+        // change the direction of all the
+        //# edges in the circle
+        // new_match = matching.copy()
+        // for i in range(0, len(cycle), 2):
+        //    new_match[cycle[i]] = cycle[i - 1]  # type: ignore
+        //
+        // yield new_match
+        //
+        //# Construct G+(e) and G-(e)
+        // old_value = graph[edge]
+        // del graph[edge]
+        new_match = matching;
+        for (int i = 0; i < cycle.size(); i += 2) {
+            new_match[(TLeft)cycle[i]] = cycle[i - 1];
+        }
+        yield(new_match);
+        old_value = graph._graph.at(edge);
+        graph.__delitem__(edge);
+        current = bind(&_enum_maximum_matchings_iter::step7, this);
+    }
+
+    void step7()
+    {
+        //# Step 7
+        //# Recurse with the new matching M' but without the edge e
+        // directed_match_graph_minus = _DirectedMatchGraph(graph, new_match)
+        //
+        // yield from _enum_maximum_matchings_iter(graph, new_match,
+        // directed_match_graph_minus)
+        //
+        // graph[edge] = old_value
+        directed_match_graph_minus
+            = _DirectedMatchGraph<TEdgeValue>(graph, new_match);
+        iter_enum = _enum_maximum_matchings_iter<TEdgeValue>(
+            graph, new_match, directed_match_graph_minus);
+        current = bind(&_enum_maximum_matchings_iter::step7part002, this);
+    }
+
+    void step7part002()
+    {
+        while (true) {
+            shared_ptr<TEdgeValue> v = iter_enum.next();
+            if (v == NULL) {
+                break;
+            }
+            yield(*v);
+            return;
+        }
+        current = bind(&_enum_maximum_matchings_iter::step6, this);
+    }
+
+    void step6()
+    {
+        //# Step 6
+        //# Recurse with the old matching M but without the edge e
+
+        // graph_plus = graph
+        graph_plus = graph;
+
+        // edges = []
+        edges = list<Edge>();
+
+        // for left, right in list(graph_plus.edges()):
+        //    if left == edge[0] or right == edge[1]:
+        //        edges.append((left, right, graph_plus[left, right]))
+        //        del graph_plus[left, right]
+        for (const pair<TLeft, TRight> &p : graph_plus._edges) {
+            TLeft &left = p.first;
+            TRight &right = p.second;
+            Edge lredge = make_tuple(left, right);
+            if ((left == get<0>(edge)) && (right == get<1>(edge))) {
+                edges.push_back(
+                    Edge(left, right, graph_plus.__getitem__(lredge)));
+                graph_plus.__delitem__(lredge);
+            }
+        }
+        // directed_match_graph_plus = _DirectedMatchGraph(graph_plus, matching)
+        directed_match_graph_plus
+            = _DirectedMatchGraph<TEdgeValue>(graph_plus, matching);
+        // yield from _enum_maximum_matchings_iter(graph_plus, matching,
+        // directed_match_graph_plus)
+        iter_enum = _enum_maximum_matchings_iter<TEdgeValue>(
+            graph_plus, matching, directed_match_graph_plus);
+        current = bind(&_enum_maximum_matchings_iter::step6part002, this);
+    }
+
+    void step6part002()
+    {
+        while (true) {
+            shared_ptr<TEdgeValue> v = iter_enum.next();
+            if (v == NULL) {
+                break;
+            }
+            yield(*v);
+            return;
+        }
+        current = bind(&_enum_maximum_matchings_iter::step6part003, this);
+    }
+
+    void step6part003()
+    {
+        // for left, right, value in edges:
+        //    graph_plus[left, right] = value
+        for (const tuple<TLeft, TRight, TEdgeValue> &p : edges) {
+            Node node(get<0>(p), get<1>(p));
+            graph_plus[node] = get<2>(p);
+        }
+        generator_stop = true;
+    }
+
+    void step8()
+    {
+        //# Step 8
+        //# Find feasible path of length 2 in D(graph, matching)
+        //# This path has the form left1 -> right -> left2
+        //# left1 must be in the left part of the graph and in matching
+        //# right must be in the right part of the graph
+        //# left2 is also in the left part of the graph and but must not be in
+        // matching
+        // left1 = None  # type: TLeft
+        // left2 = None  # type: TLeft
+        // right = None  # type: TRight
+        //
+        left1 = nullptr;
+        left2 = nullptr;
+        right = nullptr;
+        // for part1, node1 in directed_match_graph:
+        //    if part1 == LEFT and node1 in matching:
+        //        left1 = cast(TLeft, node1)
+        //        right = matching[left1]
+        //        if (RIGHT, right) in directed_match_graph:
+        //            for _, node2 in directed_match_graph[(RIGHT, right)]:
+        //                if node2 not in matching:
+        //                    left2 = cast(TLeft, node2)
+        //                    break
+        //            if left2 is not None:
+        //                break
+        for (pair<int, Node> &p : directed_match_graph._map) {
+            int part1 = p.first;
+            Node node1 = p.second;
+            if ((part1 == LEFT)
+                && (matching.find((TLeft)node1) != matching.end())) {
+                left1 = (TLeft *)&node1;
+                right = &matching[*left1];
+                if (directed_match_graph._map.find(make_tuple(RIGHT, right))
+                    != directed_match_graph._map.end()) {
+                    for (pair<int, Node> &p2 : directed_match_graph._map.at(
+                             make_tuple(RIGHT, right))) {
+                        Node node2 = p2.second;
+                        if (matching.find((TLeft)node2) == matching.end()) {
+                            left2 = (TLeft)node2;
+                            break;
+                        }
+                        if (left2 != nullptr) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        // if left2 is None:
+        //    return
+        if (left2 == nullptr) {
+            generator_stop = true;
+            return;
+        }
+        //# Construct M'
+        //# Exchange the direction of the path left1 -> right -> left2
+        //# to left1 <- right <- left2 in the new matching
+        // new_match = matching.copy()
+        // del new_match[left1]
+        // new_match[left2] = right
+        new_match = matching;
+        new_match.erase(*left1);
+        new_match[*left2] = *right;
+
+        // yield new_match
+        yield(new_match);
+
+        // edge = (left2, right)
+        edge = make_tuple(*left2, *right);
+
+        //# Construct G+(e) and G-(e)
+        graph_plus = graph.without_nodes(edge);
+        graph_minus = graph.without_edge(edge);
+
+        dgm_plus = _DirectedMatchGraph<TEdgeValue>(graph_plus, new_match);
+        dgm_minus = _DirectedMatchGraph<TEdgeValue>(graph_minus, matching);
+        current = bind(&_enum_maximum_matchings_iter::step9, this);
+    }
+
+    void step9()
+    {
+        //# Step 9
+        // yield from _enum_maximum_matchings_iter(graph_plus, new_match,
+        // dgm_plus)
+        iter_enum = _enum_maximum_matchings_iter<TEdgeValue>(
+            graph_plus, new_match, dgm_plus);
+        current = bind(&_enum_maximum_matchings_iter::step9part002, this);
+    }
+
+    void step9part002()
+    {
+        while (true) {
+            shared_ptr<TEdgeValue> v = iter_enum.next();
+            if (v == NULL) {
+                break;
+            }
+            yield(*v);
+            return;
+        }
+        current = bind(&_enum_maximum_matchings_iter::step10, this);
+    }
+
+    void step10()
+    {
+        //# Step 10
+        // yield from _enum_maximum_matchings_iter(graph_minus, matching,
+        // dgm_minus)
+        iter_enum = _enum_maximum_matchings_iter<TEdgeValue>(
+            graph_minus, matching, dgm_minus);
+        current = bind(&_enum_maximum_matchings_iter::step10part002, this);
+    }
+
+    void step10part002()
+    {
+        while (true) {
+            shared_ptr<TEdgeValue> v = iter_enum.next();
+            if (v == NULL) {
+                break;
+            }
+            yield(*v);
+            return;
+        }
+        generator_stop = true;
+    }
+};
 
 #endif

--- a/matchpygen/bipartite.h
+++ b/matchpygen/bipartite.h
@@ -1,0 +1,242 @@
+#ifndef MATCHPY_BIPARTITE_H
+#define MATCHPY_BIPARTITE_H
+
+#include <deque>
+#include <map>
+#include <set>
+#include <symengine/basic.h>
+#include <symengine/pow.h>
+#include <symengine/add.h>
+
+#include "common.h"
+
+using namespace std;
+
+typedef tuple<int, int> TItem; // either TLeft or TRight, use <variant> instead?
+typedef TItem TRight;
+typedef TItem TLeft;
+
+
+const int LEFT = 0;
+const int RIGHT = 1;
+
+typedef map<tuple<int, int>, tuple<int, int> > Matching;
+
+//(Generic[TLeft, TRight, TEdgeValue], MutableMapping[Tuple[TLeft, TRight], TEdgeValue])
+/*
+ * A bipartite graph representation.
+ */
+template<typename TEdgeValue>
+class BipartiteGraph {
+public:
+
+	//Node = Tuple[int, Union[TLeft, TRight]]
+	// typedef tuple<int, variant<TLeft, TRight>> Node; ???
+	typedef tuple<int, TItem> Node;
+	typedef vector<Node> NodeList;
+	typedef set<Node> NodeSet;
+	typedef tuple<TLeft, TRight> Edge;
+
+    map<Edge, TEdgeValue> _edges;
+    map<int, int> _matching;
+    vector<int> _dfs_paths;
+    map<int, int> _dfs_parent;
+    set<TLeft> _left;
+    set<TRight> _right;
+    map<Node, set<Node>> _graph;
+
+    BipartiteGraph() {}
+
+    void __setitem__(Edge key, TEdgeValue value) {
+//        if not isinstance(key, tuple) or len(key) != 2:
+//            raise TypeError("The edge must be a 2-tuple")
+        _edges[key] = value;
+        _left.insert(get<0>(key));
+        _right.insert(get<1>(key));
+
+        //_graph.setdefault((LEFT, key[0]), set()).add((RIGHT, key[1]));
+        tuple<int, TLeft> k1 = make_tuple(LEFT, get<0>(key));
+        if (_graph.find(k1) == _graph.end()) {
+            _graph[k1] = set<tuple<int, TRight>>();
+        }
+        _graph[k1].insert(make_tuple(RIGHT, get<1>(key)));
+
+        //_graph.setdefault((RIGHT, key[1]), set()).add((LEFT, key[0]));
+        tuple<int, TRight> k2 = make_tuple(RIGHT, get<1>(key));
+        if (_graph.find(k2) == _graph.end()) {
+            _graph[k2] = set<tuple<int, TLeft>>();
+        }
+        _graph[k2].insert(make_tuple(LEFT, get<0>(key)));
+    }
+
+    TEdgeValue &__getitem__(Edge key) {
+        return _edges[key];
+    }
+
+    void __delitem__(Edge key) {
+        _edges.erase(key);
+        //if all(l != key[0] for (l, _) in self._edges):
+        //    self._left.remove(key[0])
+        for (const pair<Edge, TEdgeValue> &p : _edges) {
+            TLeft l = get<0>(p.first);
+            if (l == get<0>(key)) {
+                _left.erase(get<0>(key));
+                break;
+            }
+        }
+        //if all(r != key[1] for (_, r) in self._edges):
+        //    self._right.remove(key[1])
+        for (const pair<Edge, TEdgeValue> &p : _edges) {
+            TRight l = get<1>(p.first);
+            if (l == get<1>(key)) {
+                _right.erase(get<0>(key));
+                break;
+            }
+        }
+        //self._graph[(LEFT, key[0])].remove((RIGHT, key[1]))
+        _graph[make_tuple(LEFT, get<0>(key))].erase(make_tuple(RIGHT, get<1>(key)));
+        //self._graph[(RIGHT, key[1])].remove((LEFT, key[0]))
+        _graph[make_tuple(RIGHT, get<1>(key))].erase(make_tuple(LEFT, get<0>(key)));
+    }
+
+//    def edges_with_labels(self):
+//        """Returns a view on the edges with labels."""
+//        return self._edges.items()
+
+//    def edges(self):
+//        return self._edges.keys()
+
+    void clear() {
+        _edges.clear();
+        _left.clear();
+        _right.clear();
+        _graph.clear();
+    }
+
+};
+
+
+template<typename TEdgeType>
+class HopcroftKarp {
+public:
+
+	HopcroftKarp(BipartiteGraph<TEdgeType> &bipartite) : bipartite(bipartite) {
+		reference_distance = -1;
+	}
+
+	int hopcroft_karp() {
+		pair_left.clear();
+		pair_right.clear();
+		dist_left.clear();
+		vertex_queue.clear();
+		int matching = 0;
+		while (true) {
+			if (!_bfs_hopcroft_karp())
+				break;
+			for (const TLeft &left : bipartite._left) {
+				if ((pair_left.find(left) == pair_left.end()) && _dfs_hopcroft_karp(left)) {
+					matching++;
+				}
+			}
+		}
+		return matching;
+	}
+
+	void dump_state() {
+		cout << endl;
+		for (const pair<TLeft, TRight> &p : pair_left) {
+			int l = get<1>(p.first);
+			cout << l << " " << get<1>(p.second) << endl;
+		}
+		cout << endl;
+		cout << "Distances:\n";
+		for (const pair<TLeft, int> &p : dist_left) {
+			cout << "Vertex: " << get<1>(p.first) << " " << p.second << endl;
+		}
+		return;
+	}
+
+private:
+	map<TLeft, TRight> pair_left;
+	map<TRight, TLeft> pair_right;
+	BipartiteGraph<TEdgeType> &bipartite;
+	deque<TLeft> vertex_queue;
+	map<TLeft, int> dist_left;
+	int reference_distance;
+
+	bool _bfs_hopcroft_karp() {
+		for (const TLeft &left_vert : bipartite._left) {
+			if (pair_left.find(left_vert) == pair_left.end()) {
+				vertex_queue.push_back(left_vert);
+				dist_left[left_vert] = 0;
+			} else {
+				dist_left.erase(left_vert);
+			}
+		}
+		reference_distance = -1;
+		while (true) {
+			if (vertex_queue.size() == 0)
+				break;
+			TLeft &left_vertex = vertex_queue.front();
+			vertex_queue.pop_front();
+			if (dist_left.find(left_vertex) == dist_left.end())
+				continue;
+			for (const tuple<int, TRight> &p : bipartite._graph[make_tuple(LEFT, left_vertex)]) {
+				if (get<0>(p) == LEFT) {
+					// not a left vertex, continue
+					throw("inconsistent graph");
+				}
+				const TRight &right_vertex = get<1>(p);
+				if (pair_right.find(right_vertex) == pair_right.end()) {
+					if (reference_distance == -1) {
+						reference_distance = dist_left[left_vertex] + 1;
+					}
+				} else {
+					TLeft &other_left = pair_right.at(right_vertex);
+					if (dist_left.find(other_left) == dist_left.end()) {
+						dist_left[other_left] = dist_left[left_vertex] + 1;
+						vertex_queue.push_back(other_left);
+					}
+				}
+
+			}
+		}
+		return reference_distance != -1;
+	}
+
+	bool _dfs_hopcroft_karp(const TLeft &left) {
+		for (const tuple<int, TRight> &p : bipartite._graph[make_tuple(LEFT, left)]) {
+			const TRight &right = get<1>(p);
+			int distance;
+
+			if (pair_right.find(right) == pair_right.end()) {
+				distance = reference_distance;
+			} else {
+				TLeft &other_left = pair_right.at(right);
+				if (dist_left.find(other_left) == dist_left.end()) {
+					distance = reference_distance;
+				} else {
+					distance = dist_left.at(other_left);
+				}
+			}
+			if (distance == dist_left.at(left) + 1) {
+				pair_left[left] = right;
+				pair_right[right] = left;
+				return true;
+			}
+
+		}
+		dist_left.erase(left);
+		return false;
+	}
+
+};
+
+int get0(tuple<int, int> a) {
+	return get<0>(a);
+}
+int get1(tuple<int, int> a) {
+	return get<1>(a);
+}
+
+#endif

--- a/matchpygen/common.h
+++ b/matchpygen/common.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <string>
 
-typedef std::map<std::string, SymEngine::RCP<const SymEngine::Basic> > Substitution2;
+typedef std::map<std::string, SymEngine::RCP<const SymEngine::Basic>>
+    Substitution2;
 
 #endif

--- a/matchpygen/common.h
+++ b/matchpygen/common.h
@@ -1,0 +1,10 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <symengine/basic.h>
+#include <map>
+#include <string>
+
+typedef std::map<std::string, SymEngine::RCP<const SymEngine::Basic> > Substitution2;
+
+#endif

--- a/matchpygen/generator_trick.h
+++ b/matchpygen/generator_trick.h
@@ -1,0 +1,52 @@
+#ifndef GENERATOR_TRICK_H
+#define GENERATOR_TRICK_H
+
+#include <deque>
+#include <functional>
+#include <memory>
+
+template <typename T>
+class GeneratorTrick
+{
+public:
+    GeneratorTrick()
+    {
+        generator_stop = false;
+    }
+    virtual ~GeneratorTrick(){};
+
+    std::shared_ptr<T> next()
+    {
+        if (current == nullptr) {
+            start();
+        }
+        while (true) {
+            if (generator_stop) {
+                break;
+            }
+            current();
+            if (yield_queue.size() > 0) {
+                std::shared_ptr<T> front
+                    = std::make_shared<T>(yield_queue.front());
+                yield_queue.pop_front();
+                return front;
+            }
+        }
+        return nullptr;
+    }
+
+    void yield(T &value)
+    {
+        yield_queue.push_back(value);
+    }
+
+protected:
+    bool generator_stop;
+    std::function<void()> current;
+
+private:
+    std::deque<T> yield_queue;
+    virtual void start() = 0;
+};
+
+#endif

--- a/matchpygen/test_bipartite.cpp
+++ b/matchpygen/test_bipartite.cpp
@@ -86,81 +86,84 @@ def test_directed_graph_find_cycle(graph, expected_cycle):
         cycle = cycle[start:] + cycle[:start]
     assert cycle == expected_cycle
 */
-template<typename T1, typename T2>
-void test_directed_graph_find_cycle(map<T1, set<T2>> graph, vector<T1> expected_cycle) {
-	_DirectedMatchGraph<T1, T2, int> dmg;
-	for (const pair<T1, set<T2>> &p : graph) {
-	    if (p.first % 2 == 0)
-	      dmg._map_left[p.first] = p.second;
-	    else
-	      dmg._map_right[p.first] = p.second;
-	}
-	vector<pair<T1, T2>> node_list = dmg.find_cycle();
-//	cout << "Size dmg: " << dmg._map_left.size() << endl;
-//	cout << "Size graph: " << graph.size() << endl;
-//	cout << "Size: " << node_list.size() << endl;
-	cout << "Found cycle ";
-	for (auto &i : node_list) {
-		cout << i.first << " " << i.second << " ";
-	}
-	cout << endl << "Expected cycle: ";
-	for (auto &i : expected_cycle) {
-	    cout << i << " ";
-	}
-	cout << endl << endl;
+template <typename T1, typename T2>
+void test_directed_graph_find_cycle(map<T1, set<T2>> graph,
+                                    vector<T1> expected_cycle)
+{
+    _DirectedMatchGraph<T1, T2, int> dmg;
+    for (const pair<T1, set<T2>> &p : graph) {
+        if (p.first % 2 == 0)
+            dmg._map_left[p.first] = p.second;
+        else
+            dmg._map_right[p.first] = p.second;
+    }
+    vector<pair<T1, T2>> node_list = dmg.find_cycle();
+    //	cout << "Size dmg: " << dmg._map_left.size() << endl;
+    //	cout << "Size graph: " << graph.size() << endl;
+    //	cout << "Size: " << node_list.size() << endl;
+    cout << "Found cycle ";
+    for (auto &i : node_list) {
+        cout << i.first << " " << i.second << " ";
+    }
+    cout << endl << "Expected cycle: ";
+    for (auto &i : expected_cycle) {
+        cout << i << " ";
+    }
+    cout << endl << endl;
 }
 
-void run_test_directed_graph_find_cycle() {
-	map<int, set<int>> graph;
-	vector<int> expected_cycle;
+void run_test_directed_graph_find_cycle()
+{
+    map<int, set<int>> graph;
+    vector<int> expected_cycle;
 
-	graph = {};
-	expected_cycle = {};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {1}},                  []),
-	graph = {{0, {1}}};
-	expected_cycle = {};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {1}, 1: {2}},          []),
-	graph = {{0, {1}}, {1, {2}}};
-	expected_cycle = {};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {1}, 1: {0}},          [0, 1]),
-	graph = {{0, {1}}, {1, {0}}};
-	expected_cycle = {0, 1};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {1}, 1: {0}},          [1, 0]),
-	graph = {{0, {1}}, {1, {0}}};
-	expected_cycle = {1, 0};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {1}, 1: {0, 2}},       [0, 1]),
-	graph = {{0, {1}}, {1, {0, 2}}};
-	expected_cycle = {0, 1};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {1, 2}, 1: {0, 2}},    [0, 1]),
-	graph = {{0, {1, 2}}, {1, {0, 2}}};
-	expected_cycle = {0, 1};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {1, 2}, 1: {0}},       [0, 1]),
-	graph = {{0, {1, 2}}, {1, {0}}};
-	expected_cycle = {0, 1};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {1}, 1: {2}, 2: {0}},  [0, 1, 2]),
-	graph = {{0, {1}}, {1, {2}}, {2, {0}}};
-	expected_cycle = {0, 1, 2};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {2}, 1: {2}},          []),
-	graph = {{0, {2}}, {1, {2}}};
-	expected_cycle = {};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {2}, 1: {2}, 2: {0}},  [0, 2]),
-	graph = {{0, {2}}, {1, {2}}, {2, {0}}};
-	expected_cycle = {0, 2};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
-	//	        ({0: {2}, 1: {2}, 2: {1}},  [1, 2]),
-	graph = {{0, {2}}, {1, {2}}, {2, {1}}};
-	expected_cycle = {1, 2};
-	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    graph = {};
+    expected_cycle = {};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {1}},                  []),
+    graph = {{0, {1}}};
+    expected_cycle = {};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {1}, 1: {2}},          []),
+    graph = {{0, {1}}, {1, {2}}};
+    expected_cycle = {};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {1}, 1: {0}},          [0, 1]),
+    graph = {{0, {1}}, {1, {0}}};
+    expected_cycle = {0, 1};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {1}, 1: {0}},          [1, 0]),
+    graph = {{0, {1}}, {1, {0}}};
+    expected_cycle = {1, 0};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {1}, 1: {0, 2}},       [0, 1]),
+    graph = {{0, {1}}, {1, {0, 2}}};
+    expected_cycle = {0, 1};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {1, 2}, 1: {0, 2}},    [0, 1]),
+    graph = {{0, {1, 2}}, {1, {0, 2}}};
+    expected_cycle = {0, 1};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {1, 2}, 1: {0}},       [0, 1]),
+    graph = {{0, {1, 2}}, {1, {0}}};
+    expected_cycle = {0, 1};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {1}, 1: {2}, 2: {0}},  [0, 1, 2]),
+    graph = {{0, {1}}, {1, {2}}, {2, {0}}};
+    expected_cycle = {0, 1, 2};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {2}, 1: {2}},          []),
+    graph = {{0, {2}}, {1, {2}}};
+    expected_cycle = {};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {2}, 1: {2}, 2: {0}},  [0, 2]),
+    graph = {{0, {2}}, {1, {2}}, {2, {0}}};
+    expected_cycle = {0, 2};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+    //	        ({0: {2}, 1: {2}, 2: {1}},  [1, 2]),
+    graph = {{0, {2}}, {1, {2}}, {2, {1}}};
+    expected_cycle = {1, 2};
+    test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
 }
 
 int main(int argc, char **argv)
@@ -171,4 +174,3 @@ int main(int argc, char **argv)
     test_hopcroft_karp_bipartite2();
     run_test_directed_graph_find_cycle();
 }
-

--- a/matchpygen/test_bipartite.cpp
+++ b/matchpygen/test_bipartite.cpp
@@ -5,25 +5,25 @@ void test_hopcroft_karp_bipartite1()
     BipartiteGraph<string> bipartite;
 
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 0)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 1)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 1), make_tuple(RIGHT, 0)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 1), make_tuple(RIGHT, 4)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 2), make_tuple(RIGHT, 2)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 2), make_tuple(RIGHT, 3)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 3), make_tuple(RIGHT, 0)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 3), make_tuple(RIGHT, 4)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 1)),
-            "X");
+                          "X");
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 3)),
-            "X");
+                          "X");
 
     HopcroftKarp<string> hk(bipartite);
     cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
@@ -35,39 +35,39 @@ void test_hopcroft_karp_bipartite2()
     BipartiteGraph<string> bipartite;
 
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'a' - 'a'), make_tuple(RIGHT, 1)), "X");
+        make_tuple(make_tuple(LEFT, 'a' - 'a'), make_tuple(RIGHT, 1)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'b' - 'a'), make_tuple(RIGHT, 1)), "X");
+        make_tuple(make_tuple(LEFT, 'b' - 'a'), make_tuple(RIGHT, 1)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'b' - 'a'), make_tuple(RIGHT, 2)), "X");
+        make_tuple(make_tuple(LEFT, 'b' - 'a'), make_tuple(RIGHT, 2)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'c' - 'a'), make_tuple(RIGHT, 1)), "X");
+        make_tuple(make_tuple(LEFT, 'c' - 'a'), make_tuple(RIGHT, 1)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'c' - 'a'), make_tuple(RIGHT, 2)), "X");
+        make_tuple(make_tuple(LEFT, 'c' - 'a'), make_tuple(RIGHT, 2)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 2)), "X");
+        make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 2)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 3)), "X");
+        make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 3)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 4)), "X");
+        make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 4)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'e' - 'a'), make_tuple(RIGHT, 3)), "X");
+        make_tuple(make_tuple(LEFT, 'e' - 'a'), make_tuple(RIGHT, 3)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'e' - 'a'), make_tuple(RIGHT, 4)), "X");
+        make_tuple(make_tuple(LEFT, 'e' - 'a'), make_tuple(RIGHT, 4)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 4)), "X");
+        make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 4)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 5)), "X");
+        make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 5)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 6)), "X");
+        make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 6)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 5)), "X");
+        make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 5)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 6)), "X");
+        make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 6)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 7)), "X");
+        make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 7)), "X");
     bipartite.__setitem__(
-            make_tuple(make_tuple(LEFT, 'h' - 'a'), make_tuple(RIGHT, 8)), "X");
+        make_tuple(make_tuple(LEFT, 'h' - 'a'), make_tuple(RIGHT, 8)), "X");
 
     HopcroftKarp<string> hk(bipartite);
     cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;

--- a/matchpygen/test_bipartite.cpp
+++ b/matchpygen/test_bipartite.cpp
@@ -1,55 +1,83 @@
 #include "bipartite.h"
 
-void test_hopcroft_karp_bipartite1() {
-	BipartiteGraph<string> bipartite;
+void test_hopcroft_karp_bipartite1()
+{
+    BipartiteGraph<string> bipartite;
 
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 0)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 1)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 1), make_tuple(RIGHT, 0)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 1), make_tuple(RIGHT, 4)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 2), make_tuple(RIGHT, 2)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 2), make_tuple(RIGHT, 3)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 3), make_tuple(RIGHT, 0)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 3), make_tuple(RIGHT, 4)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 1)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 3)), "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 0)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 1)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 1), make_tuple(RIGHT, 0)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 1), make_tuple(RIGHT, 4)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 2), make_tuple(RIGHT, 2)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 2), make_tuple(RIGHT, 3)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 3), make_tuple(RIGHT, 0)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 3), make_tuple(RIGHT, 4)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 1)),
+            "X");
+    bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 3)),
+            "X");
 
-	HopcroftKarp<string> hk(bipartite);
-	cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
-	hk.dump_state();
+    HopcroftKarp<string> hk(bipartite);
+    cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
+    hk.dump_state();
 }
 
-void test_hopcroft_karp_bipartite2() {
-	BipartiteGraph<string> bipartite;
+void test_hopcroft_karp_bipartite2()
+{
+    BipartiteGraph<string> bipartite;
 
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'a'-'a'), make_tuple(RIGHT, 1)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'b'-'a'), make_tuple(RIGHT, 1)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'b'-'a'), make_tuple(RIGHT, 2)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'c'-'a'), make_tuple(RIGHT, 1)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'c'-'a'), make_tuple(RIGHT, 2)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'd'-'a'), make_tuple(RIGHT, 2)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'd'-'a'), make_tuple(RIGHT, 3)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'd'-'a'), make_tuple(RIGHT, 4)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'e'-'a'), make_tuple(RIGHT, 3)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'e'-'a'), make_tuple(RIGHT, 4)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'f'-'a'), make_tuple(RIGHT, 4)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'f'-'a'), make_tuple(RIGHT, 5)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'f'-'a'), make_tuple(RIGHT, 6)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'g'-'a'), make_tuple(RIGHT, 5)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'g'-'a'), make_tuple(RIGHT, 6)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'g'-'a'), make_tuple(RIGHT, 7)), "X");
-	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'h'-'a'), make_tuple(RIGHT, 8)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'a' - 'a'), make_tuple(RIGHT, 1)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'b' - 'a'), make_tuple(RIGHT, 1)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'b' - 'a'), make_tuple(RIGHT, 2)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'c' - 'a'), make_tuple(RIGHT, 1)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'c' - 'a'), make_tuple(RIGHT, 2)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 2)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 3)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'd' - 'a'), make_tuple(RIGHT, 4)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'e' - 'a'), make_tuple(RIGHT, 3)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'e' - 'a'), make_tuple(RIGHT, 4)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 4)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 5)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'f' - 'a'), make_tuple(RIGHT, 6)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 5)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 6)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'g' - 'a'), make_tuple(RIGHT, 7)), "X");
+    bipartite.__setitem__(
+            make_tuple(make_tuple(LEFT, 'h' - 'a'), make_tuple(RIGHT, 8)), "X");
 
-	HopcroftKarp<string> hk(bipartite);
-	cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
-	hk.dump_state();
+    HopcroftKarp<string> hk(bipartite);
+    cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
+    hk.dump_state();
 }
 
-int main(int argc, char **argv) {
-	cout << "hello\n";
+int main(int argc, char **argv)
+{
+    cout << "Test BipartiteGraph\n";
 
-	test_hopcroft_karp_bipartite1();
-	test_hopcroft_karp_bipartite2();
-
+    test_hopcroft_karp_bipartite1();
+    test_hopcroft_karp_bipartite2();
 }
-

--- a/matchpygen/test_bipartite.cpp
+++ b/matchpygen/test_bipartite.cpp
@@ -2,7 +2,7 @@
 
 void test_hopcroft_karp_bipartite1()
 {
-    BipartiteGraph<string> bipartite;
+    BipartiteGraph<tuple<int, int>, tuple<int, int>, string> bipartite;
 
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 0)),
                           "X");
@@ -25,14 +25,15 @@ void test_hopcroft_karp_bipartite1()
     bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 3)),
                           "X");
 
-    HopcroftKarp<string> hk(bipartite);
+    // TODO: turn tuples into ints
+    HopcroftKarp<tuple<int, int>, tuple<int, int>, string> hk(bipartite);
     cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
     hk.dump_state();
 }
 
 void test_hopcroft_karp_bipartite2()
 {
-    BipartiteGraph<string> bipartite;
+    BipartiteGraph<tuple<int, int>, tuple<int, int>, string> bipartite;
 
     bipartite.__setitem__(
         make_tuple(make_tuple(LEFT, 'a' - 'a'), make_tuple(RIGHT, 1)), "X");
@@ -69,9 +70,81 @@ void test_hopcroft_karp_bipartite2()
     bipartite.__setitem__(
         make_tuple(make_tuple(LEFT, 'h' - 'a'), make_tuple(RIGHT, 8)), "X");
 
-    HopcroftKarp<string> hk(bipartite);
+    HopcroftKarp<tuple<int, int>, tuple<int, int>, string> hk(bipartite);
     cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
     hk.dump_state();
+}
+
+/*
+@pytest.mark.parametrize(
+    '   graph,                      expected_cycle',
+    [
+        ({},                        []),
+        ({0: {1}},                  []),
+        ({0: {1}, 1: {2}},          []),
+        ({0: {1}, 1: {0}},          [0, 1]),
+        ({0: {1}, 1: {0}},          [1, 0]),
+        ({0: {1}, 1: {0, 2}},       [0, 1]),
+        ({0: {1, 2}, 1: {0, 2}},    [0, 1]),
+        ({0: {1, 2}, 1: {0}},       [0, 1]),
+        ({0: {1}, 1: {2}, 2: {0}},  [0, 1, 2]),
+        ({0: {2}, 1: {2}},          []),
+        ({0: {2}, 1: {2}, 2: {0}},  [0, 2]),
+        ({0: {2}, 1: {2}, 2: {1}},  [1, 2]),
+    ]
+)  # yapf: disable
+def test_directed_graph_find_cycle(graph, expected_cycle):
+    dmg = _DirectedMatchGraph({}, {})
+    dmg.update(graph)
+    cycle = dmg.find_cycle()
+    if len(expected_cycle) > 0:
+        assert expected_cycle[0] in cycle
+        start = cycle.index(expected_cycle[0])
+        cycle = cycle[start:] + cycle[:start]
+    assert cycle == expected_cycle
+*/
+
+template<typename T1, typename T2>
+void test_directed_graph_find_cycle(map<T1, set<T2>> graph, vector<int> expected_cycle) {
+	_DirectedMatchGraph<T1, T2, int> dmg;
+	for (const pair<T1, set<T2>> &p : graph) {
+		dmg._map_left[p.first] = p.second;
+	}
+	vector<variant<T1, T2>> node_list_v = dmg.find_cycle();
+	vector<T1> node_list;
+	for (auto &i : node_list_v) {
+		node_list.push_back(get<0>(i));
+	}
+	cout << "Size dmg: " << dmg._map_left.size() << endl;
+	cout << "Size graph: " << graph.size() << endl;
+	cout << "Size: " << node_list.size() << endl;
+	for (auto &i : node_list) {
+		cout << i << " ";
+	}
+	cout << endl;
+}
+
+void run_test_directed_graph_find_cycle() {
+	map<int, set<double>> graph;
+	vector<int> expected_cycle;
+	set<double> node_set;
+        //({0: {1}, 1: {2}, 2: {0}},  [0, 1, 2]),
+	node_set.insert(1);
+	graph[0] = node_set;
+	node_set.clear();
+	node_set.insert(2);
+	graph[1] = node_set;
+	node_set.clear();
+	node_set.insert(0);
+	graph[2] = node_set;
+	node_set.clear();
+	for (auto &i : graph) {
+		cout << "set size " << i.second.size() << endl;
+		for (auto &j : i.second)
+			cout << j << " ";
+		cout << endl;
+	}
+	test_directed_graph_find_cycle<int, double>(graph, expected_cycle);
 }
 
 int main(int argc, char **argv)
@@ -80,4 +153,6 @@ int main(int argc, char **argv)
 
     test_hopcroft_karp_bipartite1();
     test_hopcroft_karp_bipartite2();
+    run_test_directed_graph_find_cycle();
 }
+

--- a/matchpygen/test_bipartite.cpp
+++ b/matchpygen/test_bipartite.cpp
@@ -1,0 +1,55 @@
+#include "bipartite.h"
+
+void test_hopcroft_karp_bipartite1() {
+	BipartiteGraph<string> bipartite;
+
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 0)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 0), make_tuple(RIGHT, 1)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 1), make_tuple(RIGHT, 0)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 1), make_tuple(RIGHT, 4)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 2), make_tuple(RIGHT, 2)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 2), make_tuple(RIGHT, 3)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 3), make_tuple(RIGHT, 0)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 3), make_tuple(RIGHT, 4)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 1)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 4), make_tuple(RIGHT, 3)), "X");
+
+	HopcroftKarp<string> hk(bipartite);
+	cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
+	hk.dump_state();
+}
+
+void test_hopcroft_karp_bipartite2() {
+	BipartiteGraph<string> bipartite;
+
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'a'-'a'), make_tuple(RIGHT, 1)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'b'-'a'), make_tuple(RIGHT, 1)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'b'-'a'), make_tuple(RIGHT, 2)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'c'-'a'), make_tuple(RIGHT, 1)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'c'-'a'), make_tuple(RIGHT, 2)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'd'-'a'), make_tuple(RIGHT, 2)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'd'-'a'), make_tuple(RIGHT, 3)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'd'-'a'), make_tuple(RIGHT, 4)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'e'-'a'), make_tuple(RIGHT, 3)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'e'-'a'), make_tuple(RIGHT, 4)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'f'-'a'), make_tuple(RIGHT, 4)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'f'-'a'), make_tuple(RIGHT, 5)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'f'-'a'), make_tuple(RIGHT, 6)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'g'-'a'), make_tuple(RIGHT, 5)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'g'-'a'), make_tuple(RIGHT, 6)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'g'-'a'), make_tuple(RIGHT, 7)), "X");
+	bipartite.__setitem__(make_tuple(make_tuple(LEFT, 'h'-'a'), make_tuple(RIGHT, 8)), "X");
+
+	HopcroftKarp<string> hk(bipartite);
+	cout << "Maximum matchings: " << hk.hopcroft_karp() << endl;
+	hk.dump_state();
+}
+
+int main(int argc, char **argv) {
+	cout << "hello\n";
+
+	test_hopcroft_karp_bipartite1();
+	test_hopcroft_karp_bipartite2();
+
+}
+

--- a/matchpygen/test_bipartite.cpp
+++ b/matchpygen/test_bipartite.cpp
@@ -76,23 +76,6 @@ void test_hopcroft_karp_bipartite2()
 }
 
 /*
-@pytest.mark.parametrize(
-    '   graph,                      expected_cycle',
-    [
-        ({},                        []),
-        ({0: {1}},                  []),
-        ({0: {1}, 1: {2}},          []),
-        ({0: {1}, 1: {0}},          [0, 1]),
-        ({0: {1}, 1: {0}},          [1, 0]),
-        ({0: {1}, 1: {0, 2}},       [0, 1]),
-        ({0: {1, 2}, 1: {0, 2}},    [0, 1]),
-        ({0: {1, 2}, 1: {0}},       [0, 1]),
-        ({0: {1}, 1: {2}, 2: {0}},  [0, 1, 2]),
-        ({0: {2}, 1: {2}},          []),
-        ({0: {2}, 1: {2}, 2: {0}},  [0, 2]),
-        ({0: {2}, 1: {2}, 2: {1}},  [1, 2]),
-    ]
-)  # yapf: disable
 def test_directed_graph_find_cycle(graph, expected_cycle):
     dmg = _DirectedMatchGraph({}, {})
     dmg.update(graph)
@@ -103,48 +86,81 @@ def test_directed_graph_find_cycle(graph, expected_cycle):
         cycle = cycle[start:] + cycle[:start]
     assert cycle == expected_cycle
 */
-
 template<typename T1, typename T2>
-void test_directed_graph_find_cycle(map<T1, set<T2>> graph, vector<int> expected_cycle) {
+void test_directed_graph_find_cycle(map<T1, set<T2>> graph, vector<T1> expected_cycle) {
 	_DirectedMatchGraph<T1, T2, int> dmg;
 	for (const pair<T1, set<T2>> &p : graph) {
-		dmg._map_left[p.first] = p.second;
+	    if (p.first % 2 == 0)
+	      dmg._map_left[p.first] = p.second;
+	    else
+	      dmg._map_right[p.first] = p.second;
 	}
-	vector<variant<T1, T2>> node_list_v = dmg.find_cycle();
-	vector<T1> node_list;
-	for (auto &i : node_list_v) {
-		node_list.push_back(get<0>(i));
-	}
-	cout << "Size dmg: " << dmg._map_left.size() << endl;
-	cout << "Size graph: " << graph.size() << endl;
-	cout << "Size: " << node_list.size() << endl;
+	vector<pair<T1, T2>> node_list = dmg.find_cycle();
+//	cout << "Size dmg: " << dmg._map_left.size() << endl;
+//	cout << "Size graph: " << graph.size() << endl;
+//	cout << "Size: " << node_list.size() << endl;
+	cout << "Found cycle ";
 	for (auto &i : node_list) {
-		cout << i << " ";
+		cout << i.first << " " << i.second << " ";
 	}
-	cout << endl;
+	cout << endl << "Expected cycle: ";
+	for (auto &i : expected_cycle) {
+	    cout << i << " ";
+	}
+	cout << endl << endl;
 }
 
 void run_test_directed_graph_find_cycle() {
-	map<int, set<double>> graph;
+	map<int, set<int>> graph;
 	vector<int> expected_cycle;
-	set<double> node_set;
-        //({0: {1}, 1: {2}, 2: {0}},  [0, 1, 2]),
-	node_set.insert(1);
-	graph[0] = node_set;
-	node_set.clear();
-	node_set.insert(2);
-	graph[1] = node_set;
-	node_set.clear();
-	node_set.insert(0);
-	graph[2] = node_set;
-	node_set.clear();
-	for (auto &i : graph) {
-		cout << "set size " << i.second.size() << endl;
-		for (auto &j : i.second)
-			cout << j << " ";
-		cout << endl;
-	}
-	test_directed_graph_find_cycle<int, double>(graph, expected_cycle);
+
+	graph = {};
+	expected_cycle = {};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {1}},                  []),
+	graph = {{0, {1}}};
+	expected_cycle = {};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {1}, 1: {2}},          []),
+	graph = {{0, {1}}, {1, {2}}};
+	expected_cycle = {};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {1}, 1: {0}},          [0, 1]),
+	graph = {{0, {1}}, {1, {0}}};
+	expected_cycle = {0, 1};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {1}, 1: {0}},          [1, 0]),
+	graph = {{0, {1}}, {1, {0}}};
+	expected_cycle = {1, 0};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {1}, 1: {0, 2}},       [0, 1]),
+	graph = {{0, {1}}, {1, {0, 2}}};
+	expected_cycle = {0, 1};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {1, 2}, 1: {0, 2}},    [0, 1]),
+	graph = {{0, {1, 2}}, {1, {0, 2}}};
+	expected_cycle = {0, 1};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {1, 2}, 1: {0}},       [0, 1]),
+	graph = {{0, {1, 2}}, {1, {0}}};
+	expected_cycle = {0, 1};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {1}, 1: {2}, 2: {0}},  [0, 1, 2]),
+	graph = {{0, {1}}, {1, {2}}, {2, {0}}};
+	expected_cycle = {0, 1, 2};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {2}, 1: {2}},          []),
+	graph = {{0, {2}}, {1, {2}}};
+	expected_cycle = {};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {2}, 1: {2}, 2: {0}},  [0, 2]),
+	graph = {{0, {2}}, {1, {2}}, {2, {0}}};
+	expected_cycle = {0, 2};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
+	//	        ({0: {2}, 1: {2}, 2: {1}},  [1, 2]),
+	graph = {{0, {2}}, {1, {2}}, {2, {1}}};
+	expected_cycle = {1, 2};
+	test_directed_graph_find_cycle<int, int>(graph, expected_cycle);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This is not supposed to be merged. These are algorithms needed for the commutative matcher of MatchPy. We will need these algorithms to port RUBI into C++.

Class `BipartiteGraph` was translated from its Python implementation at [MatchPy](https://github.com/HPAC/matchpy)

The Hopcroft Karp algorithm is my implementation, which solves the issue of relying on the GPL'd Python library (dependency of MatchPy).

- [ ] add license of MatchPy