### PR TITLE
DON'T MERGE: Example matching decision trees for sample patterns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,6 +666,8 @@ if (BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif()
 
+add_subdirectory(matchpygen)
+
 # At the end we print a nice summary
 
 message("--------------------------------------------------------------------------------")

--- a/matchpygen/CMakeLists.txt
+++ b/matchpygen/CMakeLists.txt
@@ -16,3 +16,6 @@ target_link_libraries(example_coroutine symengine)
 
 add_executable(example_coroutine2 example_coroutine2.cpp)
 target_link_libraries(example_coroutine2 symengine)
+
+add_executable(example_setjmp example_setjmp.cpp)
+target_link_libraries(example_setjmp symengine)

--- a/matchpygen/CMakeLists.txt
+++ b/matchpygen/CMakeLists.txt
@@ -7,3 +7,6 @@ include_directories(BEFORE ${teuchos_BINARY_DIR})
 
 add_executable(example example.cpp)
 target_link_libraries(example symengine)
+
+add_executable(example_yield example_yield.cpp)
+target_link_libraries(example_yield symengine)

--- a/matchpygen/CMakeLists.txt
+++ b/matchpygen/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(matchpygen)
+
+include_directories(BEFORE ${symengine_SOURCE_DIR})
+include_directories(BEFORE ${symengine_BINARY_DIR})
+include_directories(BEFORE ${teuchos_SOURCE_DIR})
+include_directories(BEFORE ${teuchos_BINARY_DIR})
+
+add_executable(example example.cpp)
+target_link_libraries(example symengine)

--- a/matchpygen/CMakeLists.txt
+++ b/matchpygen/CMakeLists.txt
@@ -10,3 +10,9 @@ target_link_libraries(example symengine)
 
 add_executable(example_yield example_yield.cpp)
 target_link_libraries(example_yield symengine)
+
+add_executable(example_coroutine example_coroutine.cpp)
+target_link_libraries(example_coroutine symengine)
+
+add_executable(example_coroutine2 example_coroutine2.cpp)
+target_link_libraries(example_coroutine2 symengine)

--- a/matchpygen/example.cpp
+++ b/matchpygen/example.cpp
@@ -1,0 +1,132 @@
+#include <iostream>
+#include <tuple>
+#include <map>
+#include <string>
+#include <deque>
+
+#include <symengine/basic.h>
+#include <symengine/pow.h>
+
+using namespace std;
+using namespace SymEngine;
+
+typedef map<string, RCP<const Basic>> Substitution2;
+
+int try_add_variable(Substitution2 &subst, string variable_name,
+                     RCP<const Basic> &replacement)
+{
+    if (subst.find(variable_name) == subst.end()) {
+        subst[variable_name] = replacement;
+        // this[variable_name] = replacement; //.copy() if
+        // isinstance(replacement, Multiset) else replacement
+    } else {
+        // Node &existing_value = *(this->find(variable_name));
+        /*
+        if (isinstance(existing_value, tuple)) {
+            if (isinstance(replacement, Multiset)) {
+                if (Multiset(existing_value) != replacement){
+                    return -1;
+                }
+            } else if (replacement != existing_value) {
+                return -1;
+            }
+            else if (isinstance(existing_value, Multiset)) {
+                if (!isinstance(replacement, (tuple, list, Multiset))) {
+                    return -1;
+                }
+                auto &compare_value = Multiset(replacement);
+                if (existing_value == compare_value){
+                    if (! isinstance(replacement, Multiset)) {
+                        this->insert(make_pair(variable_name, replacement));
+                    } else {
+                        return -1;
+                    }
+                } else if (replacement != existing_value){
+                    return -1;
+                }
+            }
+        }
+        */
+    }
+    return 0;
+}
+
+typedef deque<RCP<const Basic>> Deque;
+
+Deque get_deque(RCP<const Basic> expr)
+{
+    Deque d;
+    for (RCP<const Basic> i : expr->get_args()) {
+        d.push_back(i);
+    }
+    return d;
+}
+
+tuple<int, Substitution2> match_root(RCP<const Basic> subject)
+{
+    ;
+    Deque subjects;
+    subjects.push_back(subject);
+    Substitution2 subst0;
+    // state 2200;
+    if (subjects.size() >= 1 && is_a<Pow>(*subjects[0])) {
+        RCP<const Basic> tmp1 = subjects.front();
+        subjects.pop_front();
+        Deque subjects2 = get_deque(tmp1);
+        // state 2201;
+        if (subjects2.size() >= 1 && subjects2[0]->__eq__(*symbol("x"))) {
+            RCP<const Basic> tmp3 = subjects2.front();
+            subjects2.pop_front();
+            // state 2202;
+            if (subjects2.size() >= 1) {
+                auto tmp4 = subjects2.front();
+                subjects2.pop_front();
+                Substitution2 subst1(subst0);
+                if (!try_add_variable(subst1, "i2", tmp4)) {
+                    // state 2203;
+                    if (subjects2.size() == 0) {
+                        // state 2204;
+                        if (subjects.size() == 0) {
+                            Substitution2 tmp_subst;
+                            tmp_subst["w"] = subst1["i2"];
+                            // 0: x**w;
+                            return make_tuple(0, tmp_subst);
+                        }
+                    }
+                }
+                subjects2.push_front(tmp4);
+            }
+            subjects2.push_front(tmp3);
+        }
+        subjects.push_front(tmp1);
+    }
+    if (subjects.size() >= 1 && subjects[0]->__eq__(*symbol("y"))) {
+        auto &tmp6 = subjects.front();
+        subjects.pop_front();
+        // state 2205;
+        if (subjects.size() == 0) {
+            // 1: y;
+            return make_tuple(1, subst0);
+        }
+        subjects.push_front(tmp6);
+    }
+    return make_tuple(-1, subst0);
+};
+
+int main(int argc, char *argv[])
+{
+    // Allowed patterns: x^w, y. w is a wildcard.
+    RCP<const Basic> expr;
+    RCP<const Basic> x = symbol("x");
+    expr = pow(x, integer(3));
+    auto result = match_root(expr);
+    RCP<const Basic> y = symbol("y");
+    std::cout << "Result for " << expr->__str__() << " is " << get<0>(result)
+              << std::endl;
+    result = match_root(y);
+    std::cout << "Result for " << y->__str__() << " is " << get<0>(result)
+              << std::endl;
+    result = match_root(x);
+    std::cout << "Result for " << x->__str__() << " is " << get<0>(result)
+              << std::endl;
+}

--- a/matchpygen/example_coroutine.cpp
+++ b/matchpygen/example_coroutine.cpp
@@ -37,11 +37,10 @@ Deque get_deque(RCP<const Basic> expr)
 
 coroutine::Channel<tuple<int, Substitution2>> channel;
 
-
 void yield(tuple<int, Substitution2> val)
 {
-	channel.push(val);
-	coroutine::yield();
+    channel.push(val);
+    coroutine::yield();
 }
 
 void match_root(RCP<const Basic> subject)

--- a/matchpygen/example_coroutine.cpp
+++ b/matchpygen/example_coroutine.cpp
@@ -1,0 +1,125 @@
+#include <iostream>
+#include <tuple>
+#include <map>
+#include <string>
+#include <deque>
+
+#include <symengine/basic.h>
+#include <symengine/pow.h>
+
+#include "coroutine.h"
+
+using namespace std;
+using namespace SymEngine;
+
+typedef map<string, RCP<const Basic>> Substitution2;
+
+int try_add_variable(Substitution2 &subst, string variable_name,
+                     RCP<const Basic> &replacement)
+{
+    if (subst.find(variable_name) == subst.end()) {
+        subst[variable_name] = replacement;
+    } else {
+    }
+    return 0;
+}
+
+typedef deque<RCP<const Basic>> Deque;
+
+Deque get_deque(RCP<const Basic> expr)
+{
+    Deque d;
+    for (RCP<const Basic> i : expr->get_args()) {
+        d.push_back(i);
+    }
+    return d;
+}
+
+coroutine::Channel<tuple<int, Substitution2>> channel;
+
+
+void yield(tuple<int, Substitution2> val)
+{
+	channel.push(val);
+	coroutine::yield();
+}
+
+void match_root(RCP<const Basic> subject)
+{
+    Deque subjects;
+    subjects.push_back(subject);
+    Substitution2 subst0;
+    // state 2200;
+    if (subjects.size() >= 1 && is_a<Pow>(*subjects[0])) {
+        RCP<const Basic> tmp1 = subjects.front();
+        subjects.pop_front();
+        Deque subjects2 = get_deque(tmp1);
+        // state 2201;
+        if (subjects2.size() >= 1 && subjects2[0]->__eq__(*symbol("x"))) {
+            RCP<const Basic> tmp3 = subjects2.front();
+            subjects2.pop_front();
+            // state 2202;
+            if (subjects2.size() >= 1) {
+                auto tmp4 = subjects2.front();
+                subjects2.pop_front();
+                Substitution2 subst1(subst0);
+                if (!try_add_variable(subst1, "i2", tmp4)) {
+                    // state 2203;
+                    if (subjects2.size() == 0) {
+                        // state 2204;
+                        if (subjects.size() == 0) {
+                            Substitution2 tmp_subst;
+                            tmp_subst["w"] = subst1["i2"];
+                            // 0: x**w;
+                            yield(make_tuple(0, tmp_subst));
+                        }
+                    }
+                }
+                subjects2.push_front(tmp4);
+            }
+            subjects2.push_front(tmp3);
+        }
+        subjects.push_front(tmp1);
+    }
+    if (subjects.size() >= 1 && subjects[0]->__eq__(*symbol("y"))) {
+        auto &tmp6 = subjects.front();
+        subjects.pop_front();
+        // state 2205;
+        if (subjects.size() == 0) {
+            // 1: y;
+            yield(make_tuple(1, subst0));
+        }
+        subjects.push_front(tmp6);
+    }
+    yield(make_tuple(-1, subst0));
+};
+
+int main(int argc, char *argv[])
+{
+    // Allowed patterns: x^w, y. w is a wildcard.
+    RCP<const Basic> expr;
+    RCP<const Basic> x = symbol("x");
+
+    expr = pow(x, integer(3));
+    coroutine::routine_t mr1 = coroutine::create(std::bind(match_root, expr));
+    coroutine::resume(mr1);
+    auto result = channel.pop();
+    coroutine::destroy(mr1);
+
+    RCP<const Basic> y = symbol("y");
+    std::cout << "Result for " << expr->__str__() << " is " << get<0>(result)
+              << std::endl;
+    mr1 = coroutine::create(std::bind(match_root, y));
+    coroutine::resume(mr1);
+    result = channel.pop();
+    coroutine::destroy(mr1);
+
+    std::cout << "Result for " << y->__str__() << " is " << get<0>(result)
+              << std::endl;
+    mr1 = coroutine::create(std::bind(match_root, x));
+    coroutine::resume(mr1);
+    result = channel.pop();
+    coroutine::destroy(mr1);
+    std::cout << "Result for " << x->__str__() << " is " << get<0>(result)
+              << std::endl;
+}

--- a/matchpygen/example_coroutine2.cpp
+++ b/matchpygen/example_coroutine2.cpp
@@ -26,7 +26,7 @@ int try_add_variable(Substitution2 &subst, string variable_name,
 
 typedef std::deque<RCP<const Basic>> Deque;
 
-Deque get_deque(RCP<const Basic>& expr)
+Deque get_deque(RCP<const Basic> &expr)
 {
     Deque d;
     for (RCP<const Basic> i : expr->get_args()) {
@@ -44,7 +44,6 @@ public:
     }
     virtual ~Yielder()
     {
-        std::cout << "print destructor" << std::endl;
         coroutine::destroy(routine);
     }
 
@@ -55,7 +54,7 @@ public:
     }
 
 protected:
-    void yield(int value_int_, Substitution2& value_subst_)
+    void yield(int value_int_, Substitution2 &value_subst_)
     {
         value_int = value_int_;
         value_subst = value_subst_;
@@ -74,7 +73,7 @@ public:
     RCP<const Basic> tmp1, tmp3, tmp4, tmp6;
     Substitution2 subst0, subst1, tmp_subst;
 
-    match_root(RCP<const Basic>& subject_) : subject(subject_)
+    match_root(RCP<const Basic> &subject_) : subject(subject_)
     {
         routine = coroutine::create(std::bind(&match_root::run, this));
     }
@@ -138,8 +137,8 @@ int main(int argc, char *argv[])
     auto result = mr1.next();
 
     RCP<const Basic> y = symbol("y");
-    std::cout << "Result for " << expr->__str__() << " is " << std::get<0>(result)
-              << std::endl;
+    std::cout << "Result for " << expr->__str__() << " is "
+              << std::get<0>(result) << std::endl;
     result = match_root(y).next();
     std::cout << "Result for " << y->__str__() << " is " << std::get<0>(result)
               << std::endl;

--- a/matchpygen/example_coroutine2.cpp
+++ b/matchpygen/example_coroutine2.cpp
@@ -1,0 +1,149 @@
+#include <iostream>
+#include <tuple>
+#include <map>
+#include <string>
+#include <deque>
+#include <functional>
+
+#include <symengine/basic.h>
+#include <symengine/pow.h>
+
+#include "coroutine.h"
+
+using namespace std;
+using namespace SymEngine;
+
+typedef map<string, RCP<const Basic>> Substitution2;
+
+int try_add_variable(Substitution2 &subst, string variable_name,
+                     RCP<const Basic> &replacement)
+{
+    if (subst.find(variable_name) == subst.end()) {
+        subst[variable_name] = replacement;
+    } else {
+    }
+    return 0;
+}
+
+typedef deque<RCP<const Basic>> Deque;
+
+Deque get_deque(RCP<const Basic> expr)
+{
+    Deque d;
+    for (RCP<const Basic> i : expr->get_args()) {
+        d.push_back(i);
+    }
+    return d;
+}
+
+coroutine::Channel<tuple<int, Substitution2>> channel;
+
+
+template<typename T>
+class Yielder
+{
+public:
+	Yielder() {}
+	virtual ~Yielder() {
+		coroutine::destroy(routine);
+	}
+
+	T next()
+	{
+		coroutine::resume(routine);
+		return value;
+	}
+protected:
+	void yield(T val)
+	{
+		value = val;
+		//channel.push(val);
+		coroutine::yield();
+	}
+	coroutine::routine_t routine;
+	T value;
+};
+
+//Yielder<tuple<int, Substitution2>> match_root;
+
+
+class match_root : public Yielder<tuple<int, Substitution2>>
+{
+public:
+	RCP<const Basic> subject;
+
+	match_root(RCP<const Basic> subject) : subject(subject)
+	{
+		routine = coroutine::create(std::bind(&match_root::run, this));
+	}
+	void run() {
+		Deque subjects;
+		subjects.push_back(subject);
+		Substitution2 subst0;
+		// state 2200;
+		if (subjects.size() >= 1 && is_a<Pow>(*subjects[0])) {
+			RCP<const Basic> tmp1 = subjects.front();
+			subjects.pop_front();
+			Deque subjects2 = get_deque(tmp1);
+			// state 2201;
+			if (subjects2.size() >= 1 && subjects2[0]->__eq__(*symbol("x"))) {
+				RCP<const Basic> tmp3 = subjects2.front();
+				subjects2.pop_front();
+				// state 2202;
+				if (subjects2.size() >= 1) {
+					auto tmp4 = subjects2.front();
+					subjects2.pop_front();
+					Substitution2 subst1(subst0);
+					if (!try_add_variable(subst1, "i2", tmp4)) {
+						// state 2203;
+						if (subjects2.size() == 0) {
+							// state 2204;
+							if (subjects.size() == 0) {
+								Substitution2 tmp_subst;
+								tmp_subst["w"] = subst1["i2"];
+								// 0: x**w;
+								yield(make_tuple(0, tmp_subst));
+							}
+						}
+					}
+					subjects2.push_front(tmp4);
+				}
+				subjects2.push_front(tmp3);
+			}
+			subjects.push_front(tmp1);
+		}
+		if (subjects.size() >= 1 && subjects[0]->__eq__(*symbol("y"))) {
+			auto &tmp6 = subjects.front();
+			subjects.pop_front();
+			// state 2205;
+			if (subjects.size() == 0) {
+				// 1: y;
+				yield(make_tuple(1, subst0));
+			}
+			subjects.push_front(tmp6);
+		}
+		yield(make_tuple(-1, subst0));
+	}
+
+};
+
+
+int main(int argc, char *argv[])
+{
+    // Allowed patterns: x^w, y. w is a wildcard.
+    RCP<const Basic> expr;
+    RCP<const Basic> x = symbol("x");
+    expr = pow(x, integer(3));
+    match_root mr1(expr);
+    auto result = mr1.next();
+
+    RCP<const Basic> y = symbol("y");
+    std::cout << "Result for " << expr->__str__() << " is " << get<0>(result)
+              << std::endl;
+    result = match_root(y).next();
+    std::cout << "Result for " << y->__str__() << " is " << get<0>(result)
+              << std::endl;
+    result = match_root(x).next();
+    std::cout << "Result for " << x->__str__() << " is " << get<0>(result)
+              << std::endl;
+}

--- a/matchpygen/example_coroutine2.cpp
+++ b/matchpygen/example_coroutine2.cpp
@@ -43,25 +43,25 @@ template<typename T>
 class Yielder
 {
 public:
-	Yielder() {}
-	virtual ~Yielder() {
-		coroutine::destroy(routine);
-	}
+    Yielder() {}
+    virtual ~Yielder() {
+        coroutine::destroy(routine);
+    }
 
-	T next()
-	{
-		coroutine::resume(routine);
-		return value;
-	}
+    T next()
+    {
+        coroutine::resume(routine);
+        return value;
+    }
 protected:
-	void yield(T val)
-	{
-		value = val;
-		//channel.push(val);
-		coroutine::yield();
-	}
-	coroutine::routine_t routine;
-	T value;
+    void yield(T val)
+    {
+        value = val;
+        //channel.push(val);
+        coroutine::yield();
+    }
+    coroutine::routine_t routine;
+    T value;
 };
 
 //Yielder<tuple<int, Substitution2>> match_root;
@@ -70,60 +70,60 @@ protected:
 class match_root : public Yielder<tuple<int, Substitution2>>
 {
 public:
-	RCP<const Basic> subject;
+    RCP<const Basic> subject;
 
-	match_root(RCP<const Basic> subject) : subject(subject)
-	{
-		routine = coroutine::create(std::bind(&match_root::run, this));
-	}
-	void run() {
-		Deque subjects;
-		subjects.push_back(subject);
-		Substitution2 subst0;
-		// state 2200;
-		if (subjects.size() >= 1 && is_a<Pow>(*subjects[0])) {
-			RCP<const Basic> tmp1 = subjects.front();
-			subjects.pop_front();
-			Deque subjects2 = get_deque(tmp1);
-			// state 2201;
-			if (subjects2.size() >= 1 && subjects2[0]->__eq__(*symbol("x"))) {
-				RCP<const Basic> tmp3 = subjects2.front();
-				subjects2.pop_front();
-				// state 2202;
-				if (subjects2.size() >= 1) {
-					auto tmp4 = subjects2.front();
-					subjects2.pop_front();
-					Substitution2 subst1(subst0);
-					if (!try_add_variable(subst1, "i2", tmp4)) {
-						// state 2203;
-						if (subjects2.size() == 0) {
-							// state 2204;
-							if (subjects.size() == 0) {
-								Substitution2 tmp_subst;
-								tmp_subst["w"] = subst1["i2"];
-								// 0: x**w;
-								yield(make_tuple(0, tmp_subst));
-							}
-						}
-					}
-					subjects2.push_front(tmp4);
-				}
-				subjects2.push_front(tmp3);
-			}
-			subjects.push_front(tmp1);
-		}
-		if (subjects.size() >= 1 && subjects[0]->__eq__(*symbol("y"))) {
-			auto &tmp6 = subjects.front();
-			subjects.pop_front();
-			// state 2205;
-			if (subjects.size() == 0) {
-				// 1: y;
-				yield(make_tuple(1, subst0));
-			}
-			subjects.push_front(tmp6);
-		}
-		yield(make_tuple(-1, subst0));
-	}
+    match_root(RCP<const Basic> subject) : subject(subject)
+    {
+        routine = coroutine::create(std::bind(&match_root::run, this));
+    }
+    void run() {
+        Deque subjects;
+        subjects.push_back(subject);
+        Substitution2 subst0;
+        // state 2200;
+        if (subjects.size() >= 1 && is_a<Pow>(*subjects[0])) {
+            RCP<const Basic> tmp1 = subjects.front();
+            subjects.pop_front();
+            Deque subjects2 = get_deque(tmp1);
+            // state 2201;
+            if (subjects2.size() >= 1 && subjects2[0]->__eq__(*symbol("x"))) {
+                RCP<const Basic> tmp3 = subjects2.front();
+                subjects2.pop_front();
+                // state 2202;
+                if (subjects2.size() >= 1) {
+                    auto tmp4 = subjects2.front();
+                    subjects2.pop_front();
+                    Substitution2 subst1(subst0);
+                    if (!try_add_variable(subst1, "i2", tmp4)) {
+                        // state 2203;
+                        if (subjects2.size() == 0) {
+                            // state 2204;
+                            if (subjects.size() == 0) {
+                                Substitution2 tmp_subst;
+                                tmp_subst["w"] = subst1["i2"];
+                                // 0: x**w;
+                                yield(make_tuple(0, tmp_subst));
+                            }
+                        }
+                    }
+                    subjects2.push_front(tmp4);
+                }
+                subjects2.push_front(tmp3);
+            }
+            subjects.push_front(tmp1);
+        }
+        if (subjects.size() >= 1 && subjects[0]->__eq__(*symbol("y"))) {
+            auto &tmp6 = subjects.front();
+            subjects.pop_front();
+            // state 2205;
+            if (subjects.size() == 0) {
+                // 1: y;
+                yield(make_tuple(1, subst0));
+            }
+            subjects.push_front(tmp6);
+        }
+        yield(make_tuple(-1, subst0));
+    }
 
 };
 

--- a/matchpygen/example_coroutine2.cpp
+++ b/matchpygen/example_coroutine2.cpp
@@ -38,13 +38,15 @@ Deque get_deque(RCP<const Basic> expr)
 
 coroutine::Channel<tuple<int, Substitution2>> channel;
 
-
-template<typename T>
+template <typename T>
 class Yielder
 {
 public:
-    Yielder() {}
-    virtual ~Yielder() {
+    Yielder()
+    {
+    }
+    virtual ~Yielder()
+    {
         coroutine::destroy(routine);
     }
 
@@ -53,19 +55,19 @@ public:
         coroutine::resume(routine);
         return value;
     }
+
 protected:
     void yield(T val)
     {
         value = val;
-        //channel.push(val);
+        // channel.push(val);
         coroutine::yield();
     }
     coroutine::routine_t routine;
     T value;
 };
 
-//Yielder<tuple<int, Substitution2>> match_root;
-
+// Yielder<tuple<int, Substitution2>> match_root;
 
 class match_root : public Yielder<tuple<int, Substitution2>>
 {
@@ -76,7 +78,8 @@ public:
     {
         routine = coroutine::create(std::bind(&match_root::run, this));
     }
-    void run() {
+    void run()
+    {
         Deque subjects;
         subjects.push_back(subject);
         Substitution2 subst0;
@@ -124,9 +127,7 @@ public:
         }
         yield(make_tuple(-1, subst0));
     }
-
 };
-
 
 int main(int argc, char *argv[])
 {

--- a/matchpygen/example_setjmp.cpp
+++ b/matchpygen/example_setjmp.cpp
@@ -139,7 +139,6 @@ public:
 
 protected:
     jmp_buf childTask;
-    jmp_buf mainTask;
     bool finished;
     bool yielded;
     T value;

--- a/matchpygen/example_setjmp.cpp
+++ b/matchpygen/example_setjmp.cpp
@@ -1,0 +1,272 @@
+#include <iostream>
+#include <tuple>
+#include <map>
+#include <string>
+#include <deque>
+#include <functional>
+#include <setjmp.h>
+
+#include <symengine/basic.h>
+#include <symengine/pow.h>
+
+using namespace std;
+using namespace SymEngine;
+
+typedef map<string, const Basic*> Substitution2;
+
+int try_add_variable(Substitution2 &subst, string variable_name,
+                     const Basic *replacement)
+{
+    if (subst.find(variable_name) == subst.end()) {
+        subst[variable_name] = replacement;
+    } else {
+    }
+    return 0;
+}
+
+class Deque
+{
+public:
+    Deque()
+    {
+        N = 0;
+    }
+    const Basic *front()
+    {
+        return _deque[N-1];
+    }
+    void pop_front()
+    {
+        N--;
+    }
+    void push_front(const Basic *obj)
+    {
+        N++;
+        _deque[N-1] = obj;
+    }
+    void push_back(const Basic *obj)
+    {
+        for (int i=N; i>0; i--) {
+            _deque[N] = _deque[N-1];
+        }
+        _deque[0] = obj;
+        N++;
+    }
+    int size()
+    {
+        return N;
+    }
+    const Basic *operator[](int i)
+    {
+        return _deque[N-i-1];
+    }
+
+private:
+    const Basic *_deque[100];
+    int N;
+};
+
+Deque get_deque(const Basic *expr)
+{
+    Deque d;
+    for (RCP<const Basic> i : expr->get_args()) {
+        d.push_back(i.access_private_ptr());
+    }
+    return d;
+}
+
+
+#define YIELDABLE if (yielded) { longjmp(childTask, 1); } else { yielded = true; }
+
+#define yield(val) if (!setjmp(childTask)) { value = (val); return; }
+
+
+template<typename T>
+class Yielder
+{
+public:
+    Yielder() : finished(false), yielded(false)
+    {
+    }
+
+    virtual ~Yielder() {
+    }
+
+    T _next()
+    {
+        run();
+        return value;
+    }
+
+    T next()
+    {
+        T v = _next();
+        if (finished) {
+            throw(-1);
+        }
+        return v;
+    }
+
+    std::vector<T> tovector()
+    {
+        if (yielded)
+            throw("iterator already started");
+        std::vector<T> vec;
+        while (true) {
+            T v = _next();
+            if (finished) {
+                break;
+            }
+            vec.push_back(v);
+        }
+        return vec;
+    }
+
+    void stop()
+    {
+        finished = true;
+    }
+
+    virtual void run() = 0;
+
+protected:
+    jmp_buf childTask;
+    jmp_buf mainTask;
+    bool finished;
+    bool yielded;
+    T value;
+};
+
+class match_root : public Yielder<tuple<int, Substitution2>>
+{
+public:
+
+    match_root(Basic *subject) : subject(subject)
+    {
+    }
+    match_root(RCP<const Basic> subject)
+    {
+        this->subject = subject.access_private_ptr();
+    }
+    void run() {
+
+        YIELDABLE
+
+        subjects.push_back(subject);
+        // state 2200;
+        if (subjects.size() >= 1 && is_a<Pow>(*subjects[0])) {
+            tmp1 = subjects.front();
+            subjects.pop_front();
+            subjects2 = get_deque(tmp1);
+            // state 2201;
+            if (subjects2.size() >= 1 && subjects2[0]->__eq__(*symbol("x"))) {
+                tmp3 = subjects2.front();
+                subjects2.pop_front();
+                // state 2202;
+                if (subjects2.size() >= 1) {
+                    tmp4 = subjects2.front();
+                    subjects2.pop_front();
+                    Substitution2 subst1(subst0);
+                    if (!try_add_variable(subst1, "i2", tmp4)) {
+                        // state 2203;
+                        if (subjects2.size() == 0) {
+                            // state 2204;
+                            if (subjects.size() == 0) {
+                                tmp_subst["w"] = subst1["i2"];
+                                // 0: x**w;
+                                yield(make_tuple(0, tmp_subst));
+                            }
+                        }
+                    }
+                    subjects2.push_front(tmp4);
+                }
+                subjects2.push_front(tmp3);
+            }
+            subjects.push_front(tmp1);
+        }
+        if (subjects.size() >= 1 && subjects[0]->__eq__(*symbol("y"))) {
+            tmp6 = subjects.front();
+            subjects.pop_front();
+            // state 2205;
+            if (subjects.size() == 0) {
+                // 1: y;
+                yield(make_tuple(1, subst0));
+            }
+            subjects.push_front(tmp6);
+        }
+        yield(make_tuple(-1, subst0));
+        stop();
+    }
+
+    void deque_push_front(Deque d, const Basic *obj)
+    {
+        d.push_front(obj);
+    }
+    const Basic *deque_pop(Deque &d)
+    {
+        const Basic *obj = d.front();
+        d.pop_front();
+        return obj;
+    }
+private:
+    const Basic *subject;
+
+    Deque subjects;
+    Deque subjects2;
+    Substitution2 subst0;
+    Substitution2 tmp_subst;
+    const Basic *tmp1;
+    const Basic *tmp2;
+    const Basic *tmp3;
+    const Basic *tmp4;
+    const Basic *tmp5;
+    const Basic *tmp6;
+};
+
+
+class generator : public Yielder<int>
+{
+public:
+    void run()
+    {
+        YIELDABLE
+        for (i=0; i<10; ++i) {
+            yield(i);
+        }
+        stop();
+    }
+    int i;
+};
+
+int main(int argc, char *argv[])
+{
+    generator g;
+    cout << "Size " << g.tovector().size() << endl;
+
+    // Allowed patterns: x^w, y. w is a wildcard.
+    RCP<const Basic> expr;
+    RCP<const Basic> x = symbol("x");
+    RCP<const Basic> i3 = integer(3);
+    expr = pow(x, i3);
+    match_root mr1(expr);
+    auto result = mr1.next();
+
+    RCP<const Basic> y = symbol("y");
+    std::cout << "Result for " << expr->__str__() << " is " << get<0>(result)
+              << std::endl;
+    result = match_root(y).next();
+    std::cout << "Result for " << y->__str__() << " is " << get<0>(result)
+              << std::endl;
+    result = match_root(x).next();
+    std::cout << "Result for " << x->__str__() << " is " << get<0>(result)
+              << std::endl;
+
+    // Test `.tovector()`:
+    vector<tuple<int, Substitution2>> vec;
+    vec = match_root(expr).tovector();
+    std::cout << "Vector:\n";
+    for (const tuple<int, Substitution2> &p : vec) {
+        std::cout << "pair::first\t" << get<0>(p) << std::endl;
+    }
+
+}

--- a/matchpygen/example_setjmp.cpp
+++ b/matchpygen/example_setjmp.cpp
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace SymEngine;
 
-typedef map<string, const Basic*> Substitution2;
+typedef map<string, const Basic *> Substitution2;
 
 int try_add_variable(Substitution2 &subst, string variable_name,
                      const Basic *replacement)
@@ -33,7 +33,7 @@ public:
     }
     const Basic *front()
     {
-        return _deque[N-1];
+        return _deque[N - 1];
     }
     void pop_front()
     {
@@ -42,12 +42,12 @@ public:
     void push_front(const Basic *obj)
     {
         N++;
-        _deque[N-1] = obj;
+        _deque[N - 1] = obj;
     }
     void push_back(const Basic *obj)
     {
-        for (int i=N; i>0; i--) {
-            _deque[N] = _deque[N-1];
+        for (int i = N; i > 0; i--) {
+            _deque[N] = _deque[N - 1];
         }
         _deque[0] = obj;
         N++;
@@ -58,7 +58,7 @@ public:
     }
     const Basic *operator[](int i)
     {
-        return _deque[N-i-1];
+        return _deque[N - i - 1];
     }
 
 private:
@@ -75,13 +75,20 @@ Deque get_deque(const Basic *expr)
     return d;
 }
 
+#define YIELDABLE                                                              \
+    if (yielded) {                                                             \
+        longjmp(childTask, 1);                                                 \
+    } else {                                                                   \
+        yielded = true;                                                        \
+    }
 
-#define YIELDABLE if (yielded) { longjmp(childTask, 1); } else { yielded = true; }
+#define yield(val)                                                             \
+    if (!setjmp(childTask)) {                                                  \
+        value = (val);                                                         \
+        return;                                                                \
+    }
 
-#define yield(val) if (!setjmp(childTask)) { value = (val); return; }
-
-
-template<typename T>
+template <typename T>
 class Yielder
 {
 public:
@@ -89,7 +96,8 @@ public:
     {
     }
 
-    virtual ~Yielder() {
+    virtual ~Yielder()
+    {
     }
 
     T _next()
@@ -140,7 +148,6 @@ protected:
 class match_root : public Yielder<tuple<int, Substitution2>>
 {
 public:
-
     match_root(Basic *subject) : subject(subject)
     {
     }
@@ -148,7 +155,8 @@ public:
     {
         this->subject = subject.access_private_ptr();
     }
-    void run() {
+    void run()
+    {
 
         YIELDABLE
 
@@ -208,6 +216,7 @@ public:
         d.pop_front();
         return obj;
     }
+
 private:
     const Basic *subject;
 
@@ -223,14 +232,13 @@ private:
     const Basic *tmp6;
 };
 
-
 class generator : public Yielder<int>
 {
 public:
     void run()
     {
         YIELDABLE
-        for (i=0; i<10; ++i) {
+        for (i = 0; i < 10; ++i) {
             yield(i);
         }
         stop();
@@ -268,5 +276,4 @@ int main(int argc, char *argv[])
     for (const tuple<int, Substitution2> &p : vec) {
         std::cout << "pair::first\t" << get<0>(p) << std::endl;
     }
-
 }

--- a/matchpygen/example_setjmp.cpp
+++ b/matchpygen/example_setjmp.cpp
@@ -205,17 +205,6 @@ public:
         stop();
     }
 
-    void deque_push_front(Deque d, const Basic *obj)
-    {
-        d.push_front(obj);
-    }
-    const Basic *deque_pop(Deque &d)
-    {
-        const Basic *obj = d.front();
-        d.pop_front();
-        return obj;
-    }
-
 private:
     const Basic *subject;
 

--- a/matchpygen/example_yield.cpp
+++ b/matchpygen/example_yield.cpp
@@ -1,0 +1,253 @@
+#include <iostream>
+#include <tuple>
+#include <map>
+#include <string>
+#include <deque>
+#include <functional>
+
+#include <symengine/basic.h>
+#include <symengine/pow.h>
+
+using namespace std;
+using namespace SymEngine;
+
+typedef map<string, RCP<const Basic>> Substitution2;
+
+int try_add_variable(Substitution2 &subst, string variable_name,
+                     RCP<const Basic> &replacement)
+{
+    if (subst.find(variable_name) == subst.end()) {
+        subst[variable_name] = replacement;
+        // this[variable_name] = replacement; //.copy() if
+        // isinstance(replacement, Multiset) else replacement
+    } else {
+        // Node &existing_value = *(this->find(variable_name));
+        /*
+         if (isinstance(existing_value, tuple)) {
+         if (isinstance(replacement, Multiset)) {
+         if (Multiset(existing_value) != replacement){
+         return -1;
+         }
+         } else if (replacement != existing_value) {
+         return -1;
+         }
+         else if (isinstance(existing_value, Multiset)) {
+         if (!isinstance(replacement, (tuple, list, Multiset))) {
+         return -1;
+         }
+         auto &compare_value = Multiset(replacement);
+         if (existing_value == compare_value){
+         if (! isinstance(replacement, Multiset)) {
+         this->insert(make_pair(variable_name, replacement));
+         } else {
+         return -1;
+         }
+         } else if (replacement != existing_value){
+         return -1;
+         }
+         }
+         }
+         */
+    }
+    return 0;
+}
+
+typedef deque<RCP<const Basic>> Deque;
+
+Deque get_deque(RCP<const Basic> expr)
+{
+    Deque d;
+    for (RCP<const Basic> i : expr->get_args()) {
+        d.push_back(i);
+    }
+    return d;
+}
+
+class match_root
+{
+public:
+    typedef tuple<int, Substitution2> YieldType;
+    void (match_root::*current)();
+    Deque subjects;
+    Deque subjects2;
+    Substitution2 subst0;
+    Substitution2 subst1;
+    RCP<const Basic> tmp1;
+    RCP<const Basic> tmp3;
+    RCP<const Basic> tmp4;
+    RCP<const Basic> tmp6;
+    Substitution2 tmp_subst;
+
+    deque<tuple<int, Substitution2>> yield_queue;
+
+    void yield(int a, Substitution2 b)
+    {
+        yield_queue.push_back(make_tuple(a, b));
+    }
+
+    shared_ptr<YieldType> next()
+    {
+        while (true) {
+            if (current == NULL) {
+                break;
+            }
+            (*this.*current)();
+            if (yield_queue.size() > 0) {
+                shared_ptr<YieldType> front
+                    = make_shared<YieldType>(yield_queue.front());
+                yield_queue.pop_front();
+                return front;
+            }
+        }
+        return NULL;
+    }
+
+    match_root(RCP<const Basic> &subject)
+    {
+        subjects.push_back(subject);
+        current = &match_root::state2200;
+    }
+
+    void state2200()
+    {
+        // state 2200;
+        cout << "State 2200" << endl;
+        if (subjects.size() >= 1 && is_a<Pow>(*subjects[0])) {
+            tmp1 = subjects.front();
+            subjects.pop_front();
+            subjects2 = get_deque(tmp1);
+            current = &match_root::state2201;
+        } else {
+            current = &match_root::state2200part003;
+        }
+    }
+
+    void state2201()
+    {
+        // state 2201;
+        cout << "State 2201" << endl;
+        if (subjects2.size() >= 1 && subjects2[0]->__eq__(*symbol("x"))) {
+            tmp3 = subjects2.front();
+            subjects2.pop_front();
+            current = &match_root::state2202;
+        } else {
+            current = &match_root::state2201part002;
+        }
+    }
+
+    void state2201part002()
+    {
+        subjects2.push_front(tmp3);
+        current = &match_root::state2200part002;
+    }
+
+    void state2202()
+    {
+        // state 2202;
+        cout << "State 2202" << endl;
+        if (subjects2.size() >= 1) {
+            tmp4 = subjects2.front();
+            subjects2.pop_front();
+            subst1 = subst0;
+            if (!try_add_variable(subst1, "i2", tmp4)) {
+                current = &match_root::state2203;
+            }
+        } else {
+            current = &match_root::state2202part002;
+        }
+    }
+
+    void state2202part002()
+    {
+        subjects2.push_front(tmp4);
+        current = &match_root::state2201part002;
+    }
+
+    void state2203()
+    {
+        // state 2203;
+        cout << "State 2203" << endl;
+        if (subjects2.size() == 0) {
+            current = &match_root::state2204;
+        } else {
+            current = &match_root::state2202part002;
+        }
+    }
+
+    void state2204()
+    {
+        // state 2204;
+        cout << "State 2204" << endl;
+        if (subjects.size() == 0) {
+            tmp_subst["w"] = subst1["i2"];
+            // 0: x**w;
+            yield(0, tmp_subst);
+        }
+        current = &match_root::state2202part002;
+    }
+
+    void state2200part002()
+    {
+        subjects.push_front(tmp1);
+        current = &match_root::state2200part003;
+    }
+
+    void state2200part003()
+    {
+        if (subjects.size() >= 1 && subjects[0]->__eq__(*symbol("y"))) {
+            tmp6 = subjects.front();
+            subjects.pop_front();
+            current = &match_root::state2205;
+        } else {
+            current = &match_root::state2200part004;
+        }
+    }
+
+    void state2205()
+    {
+        // state 2205;
+        cout << "State 2205" << endl;
+        if (subjects.size() == 0) {
+            // 1: y;
+            yield(1, subst0);
+        }
+        current = &match_root::state2205part002;
+    }
+
+    void state2205part002()
+    {
+        subjects.push_front(tmp6);
+        current = &match_root::state2200part002;
+    }
+
+    void state2200part004()
+    {
+        current = NULL;
+    }
+};
+
+int main(int argc, char *argv[])
+{
+    // Allowed patterns: x^w, y. w is a wildcard.
+    RCP<const Basic> expr;
+    RCP<const Basic> x = symbol("x");
+    expr = pow(x, integer(3));
+    RCP<const Basic> y = symbol("y");
+
+    match_root matcher(expr);
+
+    shared_ptr<tuple<int, Substitution2>> result = matcher.next();
+    std::cout << "Result for " << expr->__str__() << " is " << get<0>(*result)
+              << std::endl;
+
+    matcher = match_root(y);
+    result = matcher.next();
+    std::cout << "Result for " << y->__str__() << " is " << get<0>(*result)
+              << std::endl;
+
+    matcher = match_root(x);
+    result = matcher.next();
+    if (result == NULL) {
+        std::cout << "Result for " << x->__str__() << " is NULL" << std::endl;
+    }
+}

--- a/matchpygen/generator_trick.h
+++ b/matchpygen/generator_trick.h
@@ -1,0 +1,52 @@
+#ifndef GENERATOR_TRICK_H
+#define GENERATOR_TRICK_H
+
+#include <deque>
+#include <functional>
+#include <memory>
+
+template <typename T>
+class GeneratorTrick
+{
+public:
+    GeneratorTrick()
+    {
+        generator_stop = false;
+    }
+    virtual ~GeneratorTrick(){};
+
+    std::shared_ptr<T> next()
+    {
+        if (current == nullptr) {
+            start();
+        }
+        while (true) {
+            if (generator_stop) {
+                break;
+            }
+            current();
+            if (yield_queue.size() > 0) {
+                std::shared_ptr<T> front
+                    = std::make_shared<T>(yield_queue.front());
+                yield_queue.pop_front();
+                return front;
+            }
+        }
+        return nullptr;
+    }
+
+    void yield(T value)
+    {
+        yield_queue.push_back(value);
+    }
+
+protected:
+    bool generator_stop;
+    std::function<void()> current;
+
+private:
+    std::deque<T> yield_queue;
+    virtual void start() = 0;
+};
+
+#endif


### PR DESCRIPTION
This example shows how two matching patterns can be represented by a decision tree in SymEngine.

The patterns are `x**w` and `y`, where `w` is a wildcard. This example explicitly avoids the commutative property.

The SymPy-MatchPy script to create this is:
```python
matcher = ManyToOneMatcher()
var("x y z")
w = WC("w")
matcher.add(Pattern(x**w))
matcher.add(Pattern(y))
```

Files:
- **example.cpp** contains the decision tree in the form of a function, that is all `yield`'s have been replaced by `return`'s. This has the disadvantage of returning only the first match.
- **example_yield.cpp** contains the decision tree in a class. The generator function has been broken into many functions contained in the `match_root` class. The `match_root` class contains a pointer to a function to execute. After the pointer is called, the function will change to pointer to point to the next function to execute. Local variables of the generator are stored as class variables.

### Generators in C++

Alternatives for generators in C++ are:

- Threads: they are expansive to initialize, discarded.
- `boost::coroutines` seems interesting, but using low level code to hack the stack trace is concern for potential issues. Furthermore, better keep the code free of `boost` library dependencies.
- The trick of breaking up the generator function in blocks and using a pointer to a function.