### PR TITLE
Utility library build configuration

### DIFF
--- a/symengine/utilities/catch/CMakeLists.txt
+++ b/symengine/utilities/catch/CMakeLists.txt
@@ -4,5 +4,5 @@ set(SRC
     catch.cpp
 )
 
-add_library(catch STATIC ${SRC})
+add_library(catch ${SRC})
 target_link_libraries(catch symengine)

--- a/symengine/utilities/teuchos/CMakeLists.txt
+++ b/symengine/utilities/teuchos/CMakeLists.txt
@@ -45,7 +45,7 @@ configure_file(Teuchos_config.h.in Teuchos_config.h)
 # Include the config file:
 include_directories(BEFORE ${teuchos_BINARY_DIR})
 
-add_library(teuchos STATIC ${SRC})
+add_library(teuchos ${SRC})
 
 
 include(GNUInstallDirs)


### PR DESCRIPTION
When building SymEngine as a shared library on MacOS, specifically with the following CMake configuration
```
cmake \
-DCMAKE_C_COMPILER="$SPACK_VIEW_DIR/bin/mpicc" \
-DCMAKE_CXX_COMPILER="$SPACK_VIEW_DIR/bin/mpicxx" \
-DCMAKE_BUILD_TYPE=Debug \
-DINTEGER_CLASS:STRING=boostmp \
-DBoost_INCLUDE_DIR=$SPACK_VIEW_DIR/include \
-DWITH_LLVM=ON \
-DWITH_COTIRE=OFF \
-DBUILD_SHARED_LIBS:BOOL=on \
-DBUILD_TESTS=TRUE \
-DBUILD_BENCHMARKS=TRUE \
-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=on \
-DCMAKE_INSTALL_PREFIX=<path> \
../
```
there are issues when linking in the `Teuchos` library and later `Catch` for the tests. The associated error messages are as follows:

- `Teuchos`
```
$ make
[  4%] Built target teuchos
[  4%] Linking CXX shared library libsymengine.dylib
ld: warning: ignoring file utilities/teuchos/libteuchos.a, file was built for archive which is not the architecture being linked (x86_64): utilities/teuchos/libteuchos.a
Undefined symbols for architecture x86_64:
  "Teuchos::demangleName(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      Teuchos::TypeNameTraits<Teuchos::RCP<SymEngine::Basic const> >::concreteName(Teuchos::RCP<SymEngine::Basic const> const&) in add.cpp.o
      Teuchos::TypeNameTraits<Teuchos::RCP<SymEngine::Number const> >::concreteName(Teuchos::RCP<SymEngine::Number const> const&) in add.cpp.o
      Teuchos::TypeNameTraits<Teuchos::RCP<SymEngine::Number const> >::name() in add.cpp.o
      Teuchos::TypeNameTraits<Teuchos::Ptr<Teuchos::RCP<SymEngine::Number const> > >::concreteName(Teuchos::Ptr<Teuchos::RCP<SymEngine::Number const> > const&) in add.cpp.o
      Teuchos::TypeNameTraits<Teuchos::RCP<SymEngine::Integer const> >::concreteName(Teuchos::RCP<SymEngine::Integer const> const&) in add.cpp.o
      Teuchos::TypeNameTraits<Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> > >::concreteName(Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> > const&) in add.cpp.o
      Teuchos::TypeNameTraits<SymEngine::Mul const>::name() in add.cpp.o
      ...
  "Teuchos::RCPNodeHandle::unbindOne()", referenced from:
      Teuchos::RCPNodeHandle::unbind() in add.cpp.o
      Teuchos::RCPNodeHandle::unbind() in basic.cpp.o
      Teuchos::RCPNodeHandle::unbind() in complex.cpp.o
      Teuchos::RCPNodeHandle::unbind() in complex_double.cpp.o
      Teuchos::RCPNodeHandle::unbind() in constants.cpp.o
      Teuchos::RCPNodeHandle::unbind() in cse.cpp.o
      Teuchos::RCPNodeHandle::unbind() in cwrapper.cpp.o
      ...
  "Teuchos::RCPNodeTracer::addNewRCPNode(Teuchos::RCPNode*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Mul const>(Teuchos::RCPNode*, SymEngine::Mul const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Add const>(Teuchos::RCPNode*, SymEngine::Add const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in basic.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Pow>(Teuchos::RCPNode*, SymEngine::Pow*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in basic.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Subs const>(Teuchos::RCPNode*, SymEngine::Subs const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in basic.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Derivative const>(Teuchos::RCPNode*, SymEngine::Derivative const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in basic.cpp.o
      ...
  "Teuchos::RCPNodeTracer::isTracingActiveRCPNodes()", referenced from:
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Mul const>(Teuchos::RCPNode*, SymEngine::Mul const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Add const>(Teuchos::RCPNode*, SymEngine::Add const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in basic.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Pow>(Teuchos::RCPNode*, SymEngine::Pow*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in basic.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Subs const>(Teuchos::RCPNode*, SymEngine::Subs const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in basic.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Derivative const>(Teuchos::RCPNode*, SymEngine::Derivative const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in basic.cpp.o
      ...
  "Teuchos::RCPNodeTracer::getCommonDebugNotesString()", referenced from:
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Pow, Teuchos::DeallocDelete<SymEngine::Pow> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in basic.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Subs const, Teuchos::DeallocDelete<SymEngine::Subs const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in basic.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Derivative const, Teuchos::DeallocDelete<SymEngine::Derivative const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in basic.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Integer const, Teuchos::DeallocDelete<SymEngine::Integer const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in complex.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Complex const, Teuchos::DeallocDelete<SymEngine::Complex const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in complex.cpp.o
      ...
  "Teuchos::RCPNodeTracer::getExistingRCPNodeGivenLookupKey(void const*)", referenced from:
      Teuchos::RCPNode* Teuchos::RCPNodeTracer::getExistingRCPNode<SymEngine::Mul const>(SymEngine::Mul const*) in add.cpp.o
      Teuchos::RCPNode* Teuchos::RCPNodeTracer::getExistingRCPNode<SymEngine::Add const>(SymEngine::Add const*) in add.cpp.o
      Teuchos::RCPNode* Teuchos::RCPNodeTracer::getExistingRCPNode<SymEngine::Pow>(SymEngine::Pow*) in basic.cpp.o
      Teuchos::RCPNode* Teuchos::RCPNodeTracer::getExistingRCPNode<SymEngine::Subs const>(SymEngine::Subs const*) in basic.cpp.o
      Teuchos::RCPNode* Teuchos::RCPNodeTracer::getExistingRCPNode<SymEngine::Derivative const>(SymEngine::Derivative const*) in basic.cpp.o
      Teuchos::RCPNode* Teuchos::RCPNodeTracer::getExistingRCPNode<SymEngine::Integer const>(SymEngine::Integer const*) in complex.cpp.o
      Teuchos::RCPNode* Teuchos::RCPNodeTracer::getExistingRCPNode<SymEngine::Complex const>(SymEngine::Complex const*) in complex.cpp.o
      ...
  "Teuchos::store_stacktrace()", referenced from:
      Teuchos::debugAssertStrength(Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::~RCPNodeTmpl() in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Mul const>(Teuchos::RCPNode*, SymEngine::Mul const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::~RCPNodeTmpl() in add.cpp.o
      ...
  "Teuchos::ActiveRCPNodesSetup::ActiveRCPNodesSetup()", referenced from:
      ___cxx_global_var_init in add.cpp.o
      ___cxx_global_var_init in basic.cpp.o
      ___cxx_global_var_init in complex.cpp.o
      ___cxx_global_var_init in complex_double.cpp.o
      ___cxx_global_var_init in constants.cpp.o
      ___cxx_global_var_init in cse.cpp.o
      ___cxx_global_var_init in cwrapper.cpp.o
      ...
  "Teuchos::ActiveRCPNodesSetup::~ActiveRCPNodesSetup()", referenced from:
      ___cxx_global_var_init in add.cpp.o
      ___cxx_global_var_init in basic.cpp.o
      ___cxx_global_var_init in complex.cpp.o
      ___cxx_global_var_init in complex_double.cpp.o
      ___cxx_global_var_init in constants.cpp.o
      ___cxx_global_var_init in cse.cpp.o
      ___cxx_global_var_init in cwrapper.cpp.o
      ...
  "Teuchos::throw_null_ptr_error(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      Teuchos::RCP<SymEngine::Basic const>::assert_not_null() const in add.cpp.o
      Teuchos::RCP<SymEngine::Number const>::assert_not_null() const in add.cpp.o
      Teuchos::RCP<SymEngine::Mul const>::assert_not_null() const in add.cpp.o
      Teuchos::RCP<SymEngine::Add const>::assert_not_null() const in add.cpp.o
      Teuchos::RCP<SymEngine::Integer const>::assert_not_null() const in add.cpp.o
      Teuchos::RCP<SymEngine::Basic const>::assert_not_null() const in basic.cpp.o
      Teuchos::RCP<SymEngine::Integer const>::assert_not_null() const in basic.cpp.o
      ...
  "Teuchos::PtrPrivateUtilityPack::throw_null(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      Teuchos::Ptr<Teuchos::RCP<SymEngine::Number const> >::assert_not_null() const in add.cpp.o
      Teuchos::Ptr<Teuchos::RCP<SymEngine::Basic const> >::assert_not_null() const in add.cpp.o
      Teuchos::Ptr<Teuchos::RCP<SymEngine::Number const> >::assert_not_null() const in basic.cpp.o
      Teuchos::Ptr<Teuchos::RCP<SymEngine::Number const> >::assert_not_null() const in dense_matrix.cpp.o
      Teuchos::Ptr<Teuchos::RCP<SymEngine::Number const> >::assert_not_null() const in derivative.cpp.o
      Teuchos::Ptr<Teuchos::RCP<SymEngine::Basic const> >::assert_not_null() const in derivative.cpp.o
      Teuchos::Ptr<Teuchos::RCP<SymEngine::Number const> >::assert_not_null() const in expand.cpp.o
      ...
  "Teuchos::TestForException_break(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      Teuchos::debugAssertStrength(Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::~RCPNodeTmpl() in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Mul const>(Teuchos::RCPNode*, SymEngine::Mul const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::~RCPNodeTmpl() in add.cpp.o
      ...
  "Teuchos::print_stack_on_segfault()", referenced from:
      _symengine_print_stack_on_segfault in cwrapper.cpp.o
  "Teuchos::dyn_cast_throw_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      SymEngine::Number const& Teuchos::dyn_cast<SymEngine::Number const, SymEngine::Basic const>(SymEngine::Basic const&) in add.cpp.o
      SymEngine::Number const& Teuchos::dyn_cast<SymEngine::Number const, SymEngine::Basic const>(SymEngine::Basic const&) in basic.cpp.o
      SymEngine::Mul const& Teuchos::dyn_cast<SymEngine::Mul const, SymEngine::Basic const>(SymEngine::Basic const&) in basic.cpp.o
      SymEngine::Symbol const& Teuchos::dyn_cast<SymEngine::Symbol const, SymEngine::Basic const>(SymEngine::Basic const&) in basic.cpp.o
      SymEngine::Set const& Teuchos::dyn_cast<SymEngine::Set const, SymEngine::Basic const>(SymEngine::Basic const&) in basic.cpp.o
      SymEngine::Boolean const& Teuchos::dyn_cast<SymEngine::Boolean const, SymEngine::Basic const>(SymEngine::Basic const&) in basic.cpp.o
      SymEngine::Basic const& Teuchos::dyn_cast<SymEngine::Basic const, SymEngine::Basic>(SymEngine::Basic&) in basic.cpp.o
      ...
  "Teuchos::TestForException_getThrowNumber()", referenced from:
      Teuchos::debugAssertStrength(Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::~RCPNodeTmpl() in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Mul const>(Teuchos::RCPNode*, SymEngine::Mul const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::~RCPNodeTmpl() in add.cpp.o
      ...
  "Teuchos::TestForException_incrThrowNumber()", referenced from:
      Teuchos::debugAssertStrength(Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::~RCPNodeTmpl() in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Mul const>(Teuchos::RCPNode*, SymEngine::Mul const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::~RCPNodeTmpl() in add.cpp.o
      ...
  "Teuchos::TestForException_getEnableStacktrace()", referenced from:
      Teuchos::debugAssertStrength(Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle(Teuchos::RCPNode*, Teuchos::ERCPStrength, bool) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Mul const, Teuchos::DeallocDelete<SymEngine::Mul const> >::~RCPNodeTmpl() in add.cpp.o
      Teuchos::RCPNodeHandle::RCPNodeHandle<SymEngine::Mul const>(Teuchos::RCPNode*, SymEngine::Mul const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, Teuchos::ERCPStrength) in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::throw_invalid_obj_exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, void const*, Teuchos::RCPNode const*, void const*) const in add.cpp.o
      Teuchos::RCPNodeTmpl<SymEngine::Add const, Teuchos::DeallocDelete<SymEngine::Add const> >::~RCPNodeTmpl() in add.cpp.o
      ...
  "Teuchos::RCPNode::impl_pre_delete_extra_data()", referenced from:
      Teuchos::RCPNode::pre_delete_extra_data() in add.cpp.o
      Teuchos::RCPNode::pre_delete_extra_data() in basic.cpp.o
      Teuchos::RCPNode::pre_delete_extra_data() in complex.cpp.o
      Teuchos::RCPNode::pre_delete_extra_data() in complex_double.cpp.o
      Teuchos::RCPNode::pre_delete_extra_data() in constants.cpp.o
      Teuchos::RCPNode::pre_delete_extra_data() in cse.cpp.o
      Teuchos::RCPNode::pre_delete_extra_data() in cwrapper.cpp.o
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [symengine/libsymengine.0.3.0.dylib] Error 1
make[1]: *** [symengine/CMakeFiles/symengine.dir/all] Error 2
make: *** [all] Error 2
```
- `Catch`
```
...
[ 60%] Linking CXX executable test_basic
ld: warning: ignoring file ../../utilities/catch/libcatch.a, file was built for archive which is not the architecture being linked (x86_64): ../../utilities/catch/libcatch.a
Undefined symbols for architecture x86_64:
  "Catch::ResultBuilder::captureResult(Catch::ResultWas::OfType)", referenced from:
      ____C_A_T_C_H____T_E_S_T____16() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____18() in test_basic.cpp.o
  "Catch::ResultBuilder::endExpression(Catch::DecomposedExpression const&)", referenced from:
      Catch::BinaryExpression<int const&, (Catch::Internal::Operator)0, int const&>::endExpression() const in test_basic.cpp.o
      Catch::ExpressionLhs<bool>::endExpression() in test_basic.cpp.o
      Catch::BinaryExpression<unsigned long const&, (Catch::Internal::Operator)0, unsigned long const&>::endExpression() const in test_basic.cpp.o
      Catch::BinaryExpression<unsigned long const&, (Catch::Internal::Operator)2, unsigned long const&>::endExpression() const in test_basic.cpp.o
      Catch::BinaryExpression<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, (Catch::Internal::Operator)0, char const (&) [3]>::endExpression() const in test_basic.cpp.o
      Catch::BinaryExpression<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, (Catch::Internal::Operator)0, char const (&) [7]>::endExpression() const in test_basic.cpp.o
      Catch::BinaryExpression<int const&, (Catch::Internal::Operator)1, int const&>::endExpression() const in test_basic.cpp.o
      ...
  "Catch::ResultBuilder::setResultType(bool)", referenced from:
      Catch::BinaryExpression<int const&, (Catch::Internal::Operator)0, int const&>::endExpression() const in test_basic.cpp.o
      Catch::ExpressionLhs<bool>::endExpression() in test_basic.cpp.o
      Catch::BinaryExpression<unsigned long const&, (Catch::Internal::Operator)0, unsigned long const&>::endExpression() const in test_basic.cpp.o
      Catch::BinaryExpression<unsigned long const&, (Catch::Internal::Operator)2, unsigned long const&>::endExpression() const in test_basic.cpp.o
      Catch::BinaryExpression<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, (Catch::Internal::Operator)0, char const (&) [3]>::endExpression() const in test_basic.cpp.o
      Catch::BinaryExpression<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, (Catch::Internal::Operator)0, char const (&) [7]>::endExpression() const in test_basic.cpp.o
      Catch::BinaryExpression<int const&, (Catch::Internal::Operator)1, int const&>::endExpression() const in test_basic.cpp.o
      ...
  "Catch::ResultBuilder::useActiveException(Catch::ResultDisposition::Flags)", referenced from:
      ____C_A_T_C_H____T_E_S_T____0() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____2() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____4() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____6() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____8() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____10() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____12() in test_basic.cpp.o
      ...
  "Catch::ResultBuilder::react()", referenced from:
      ____C_A_T_C_H____T_E_S_T____0() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____2() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____4() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____6() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____8() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____10() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____12() in test_basic.cpp.o
      ...
  "Catch::ResultBuilder::ResultBuilder(char const*, Catch::SourceLineInfo const&, char const*, Catch::ResultDisposition::Flags, char const*)", referenced from:
      ____C_A_T_C_H____T_E_S_T____0() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____2() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____4() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____6() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____8() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____10() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____12() in test_basic.cpp.o
      ...
  "Catch::ResultBuilder::~ResultBuilder()", referenced from:
      ____C_A_T_C_H____T_E_S_T____0() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____2() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____4() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____6() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____8() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____10() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____12() in test_basic.cpp.o
      ...
  "Catch::SourceLineInfo::SourceLineInfo(char const*, unsigned long)", referenced from:
      ____C_A_T_C_H____T_E_S_T____0() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____2() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____4() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____6() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____8() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____10() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____12() in test_basic.cpp.o
      ...
  "Catch::isDebuggerActive()", referenced from:
      ____C_A_T_C_H____T_E_S_T____0() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____2() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____4() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____6() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____8() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____10() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____12() in test_basic.cpp.o
      ...
  "Catch::Detail::unprintableString", referenced from:
      Catch::Detail::EnumStringMaker<std::__1::__hash_map_const_iterator<std::__1::__hash_const_iterator<std::__1::__hash_node<std::__1::__hash_value_type<Teuchos::RCP<SymEngine::Basic const>, Teuchos::RCP<SymEngine::Number const> >, void*>*> >, false>::convert(std::__1::__hash_map_const_iterator<std::__1::__hash_const_iterator<std::__1::__hash_node<std::__1::__hash_value_type<Teuchos::RCP<SymEngine::Basic const>, Teuchos::RCP<SymEngine::Number const> >, void*>*> > const&) in test_basic.cpp.o
      Catch::Detail::EnumStringMaker<std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<Teuchos::RCP<SymEngine::Basic const>, Teuchos::RCP<SymEngine::Basic const> >, std::__1::__tree_node<std::__1::__value_type<Teuchos::RCP<SymEngine::Basic const>, Teuchos::RCP<SymEngine::Basic const> >, void*>*, long> >, false>::convert(std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<Teuchos::RCP<SymEngine::Basic const>, Teuchos::RCP<SymEngine::Basic const> >, std::__1::__tree_node<std::__1::__value_type<Teuchos::RCP<SymEngine::Basic const>, Teuchos::RCP<SymEngine::Basic const> >, void*>*, long> > const&) in test_basic.cpp.o
  "Catch::AutoReg::AutoReg(void (*)(), Catch::SourceLineInfo const&, Catch::NameAndDesc const&)", referenced from:
      ___cxx_global_var_init.1 in test_basic.cpp.o
      ___cxx_global_var_init.4 in test_basic.cpp.o
      ___cxx_global_var_init.6 in test_basic.cpp.o
      ___cxx_global_var_init.8 in test_basic.cpp.o
      ___cxx_global_var_init.10 in test_basic.cpp.o
      ___cxx_global_var_init.12 in test_basic.cpp.o
      ___cxx_global_var_init.14 in test_basic.cpp.o
      ...
  "Catch::AutoReg::~AutoReg()", referenced from:
      ___cxx_global_var_init.1 in test_basic.cpp.o
      ___cxx_global_var_init.4 in test_basic.cpp.o
      ___cxx_global_var_init.6 in test_basic.cpp.o
      ___cxx_global_var_init.8 in test_basic.cpp.o
      ___cxx_global_var_init.10 in test_basic.cpp.o
      ___cxx_global_var_init.12 in test_basic.cpp.o
      ___cxx_global_var_init.14 in test_basic.cpp.o
      ...
  "Catch::toString(char const*)", referenced from:
      Catch::BinaryExpression<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, (Catch::Internal::Operator)0, char const (&) [3]>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, (Catch::Internal::Operator)0, char const (&) [7]>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
  "Catch::toString(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      Catch::ExpressionLhs<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, (Catch::Internal::Operator)0, char const (&) [3]>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, (Catch::Internal::Operator)0, char const (&) [7]>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
  "Catch::toString(bool)", referenced from:
      Catch::ExpressionLhs<bool>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
  "Catch::toString(int)", referenced from:
      Catch::ExpressionLhs<int const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<int const&, (Catch::Internal::Operator)0, int const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<int const&, (Catch::Internal::Operator)1, int const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<int const&, (Catch::Internal::Operator)3, int const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<unsigned long const&, (Catch::Internal::Operator)0, int const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
  "Catch::toString(unsigned long)", referenced from:
      Catch::ExpressionLhs<unsigned long const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<unsigned long const&, (Catch::Internal::Operator)0, unsigned long const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<unsigned long const&, (Catch::Internal::Operator)2, unsigned long const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
      Catch::BinaryExpression<unsigned long const&, (Catch::Internal::Operator)0, int const&>::reconstructExpression(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) const in test_basic.cpp.o
  "Catch::ResultBuilder::allowThrows() const", referenced from:
      ____C_A_T_C_H____T_E_S_T____16() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____18() in test_basic.cpp.o
  "Catch::ResultBuilder::shouldDebugBreak() const", referenced from:
      ____C_A_T_C_H____T_E_S_T____0() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____2() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____4() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____6() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____8() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____10() in test_basic.cpp.o
      ____C_A_T_C_H____T_E_S_T____12() in test_basic.cpp.o
      ...
  "_main", referenced from:
     implicit entry/start for main executable
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [symengine/tests/basic/test_basic] Error 1
make[1]: *** [symengine/tests/basic/CMakeFiles/test_basic.dir/all] Error 2
make: *** [all] Error 2
```

By allowing CMake to build these libraries as shared libraries (i.e. with the same configuration as SymEngine itself), these linker issues are removed.