### PR TITLE
Tidy up assertions header + add an assertion with an error message

### DIFF
--- a/symengine/symengine_assert.h
+++ b/symengine/symengine_assert.h
@@ -3,8 +3,9 @@
 
 // SYMENGINE_ASSERT uses internal functions to perform as assert
 // so that there is no effect with NDEBUG
-#if !defined(SYMENGINE_ASSERT)
 #if defined(WITH_SYMENGINE_ASSERT)
+
+#if !defined(SYMENGINE_ASSERT)
 #define stringize(s) #s
 #define XSTR(s) stringize(s)
 #define SYMENGINE_ASSERT(cond)                                                 \
@@ -17,14 +18,17 @@
             abort();                                                           \
         }                                                                      \
     }
-#else
+#endif // !defined(SYMENGINE_ASSERT)
+
+#else // defined(WITH_SYMENGINE_ASSERT)
+
 #define SYMENGINE_ASSERT(cond)
-#endif
-#endif
+
+#endif // defined(WITH_SYMENGINE_ASSERT)
 
 #define SYMENGINE_ERROR(description)                                           \
     std::cerr << description;                                                  \
     std::cerr << "\n";                                                         \
     abort();
 
-#endif
+#endif // SYMENGINE_ASSERT_H

--- a/symengine/symengine_assert.h
+++ b/symengine/symengine_assert.h
@@ -20,9 +20,25 @@
     }
 #endif // !defined(SYMENGINE_ASSERT)
 
+#if !defined(SYMENGINE_ASSERT_MSG)
+#define SYMENGINE_ASSERT_MSG(cond, msg)                                        \
+    {                                                                          \
+        if (!(cond)) {                                                         \
+            std::cerr << "SYMENGINE_ASSERT failed: " << __FILE__               \
+                      << "\nfunction " << __func__ << "(), line number "       \
+                      << __LINE__ << " at \n"                                  \
+                      << XSTR(cond) << "\n"                                    \
+                      << "ERROR MESSAGE:\n"                                    \
+                      << msg << "\n";                                          \
+            abort();                                                           \
+        }                                                                      \
+    }
+#endif // !defined(SYMENGINE_ASSERT_MSG)
+
 #else // defined(WITH_SYMENGINE_ASSERT)
 
 #define SYMENGINE_ASSERT(cond)
+#define SYMENGINE_ASSERT_MSG(cond, msg)
 
 #endif // defined(WITH_SYMENGINE_ASSERT)
 


### PR DESCRIPTION
This PR rearranges the header in which the assertions are defined in order to make it a bit more understandable and to make the addition of further assertions easier. It also adds an assertion that takes an addition argument which is outputted as an error message to the console.