### PR TITLE
Run clang-format on code base

### DIFF
--- a/benchmarks/matrix_add2.cpp
+++ b/benchmarks/matrix_add2.cpp
@@ -14,13 +14,15 @@ int main(int argc, char *argv[])
 {
     SymEngine::print_stack_on_segfault();
 
-    DenseMatrix A = DenseMatrix(3, 3, {symbol("a"), symbol("b"), symbol("c"),
-                                       symbol("d"), symbol("e"), symbol("f"),
-                                       symbol("g"), symbol("h"), symbol("i")});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {symbol("a"), symbol("b"), symbol("c"),
+                                 symbol("d"), symbol("e"), symbol("f"),
+                                 symbol("g"), symbol("h"), symbol("i")});
 
-    DenseMatrix B = DenseMatrix(3, 3, {symbol("x"), symbol("y"), symbol("z"),
-                                       symbol("p"), symbol("q"), symbol("r"),
-                                       symbol("u"), symbol("v"), symbol("w")});
+    DenseMatrix B = DenseMatrix(3, 3,
+                                {symbol("x"), symbol("y"), symbol("z"),
+                                 symbol("p"), symbol("q"), symbol("r"),
+                                 symbol("u"), symbol("v"), symbol("w")});
 
     DenseMatrix C(3, 3);
 

--- a/benchmarks/matrix_mul1.cpp
+++ b/benchmarks/matrix_mul1.cpp
@@ -15,17 +15,19 @@ int main(int argc, char *argv[])
 {
     SymEngine::print_stack_on_segfault();
 
-    DenseMatrix A = DenseMatrix(
-        4, 4, {integer(-23), integer(67), integer(3), integer(4), integer(54),
-               integer(61), integer(7), integer(8), integer(32), integer(15),
-               integer(12), integer(13), integer(100), integer(17), integer(15),
-               integer(178)});
+    DenseMatrix A
+        = DenseMatrix(4, 4,
+                      {integer(-23), integer(67), integer(3), integer(4),
+                       integer(54), integer(61), integer(7), integer(8),
+                       integer(32), integer(15), integer(12), integer(13),
+                       integer(100), integer(17), integer(15), integer(178)});
 
     DenseMatrix B
-        = DenseMatrix(4, 4, {integer(12), integer(22), integer(30), integer(40),
-                             integer(45), integer(6), integer(37), integer(80),
-                             integer(91), integer(10), integer(16), integer(52),
-                             integer(45), integer(14), integer(2), integer(6)});
+        = DenseMatrix(4, 4,
+                      {integer(12), integer(22), integer(30), integer(40),
+                       integer(45), integer(6), integer(37), integer(80),
+                       integer(91), integer(10), integer(16), integer(52),
+                       integer(45), integer(14), integer(2), integer(6)});
 
     DenseMatrix C(4, 4);
 

--- a/benchmarks/matrix_mul2.cpp
+++ b/benchmarks/matrix_mul2.cpp
@@ -14,13 +14,15 @@ int main(int argc, char *argv[])
 {
     SymEngine::print_stack_on_segfault();
 
-    DenseMatrix A = DenseMatrix(3, 3, {symbol("a"), symbol("b"), symbol("c"),
-                                       symbol("d"), symbol("e"), symbol("f"),
-                                       symbol("g"), symbol("h"), symbol("i")});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {symbol("a"), symbol("b"), symbol("c"),
+                                 symbol("d"), symbol("e"), symbol("f"),
+                                 symbol("g"), symbol("h"), symbol("i")});
 
-    DenseMatrix B = DenseMatrix(3, 3, {symbol("x"), symbol("y"), symbol("z"),
-                                       symbol("p"), symbol("q"), symbol("r"),
-                                       symbol("u"), symbol("v"), symbol("w")});
+    DenseMatrix B = DenseMatrix(3, 3,
+                                {symbol("x"), symbol("y"), symbol("z"),
+                                 symbol("p"), symbol("q"), symbol("r"),
+                                 symbol("u"), symbol("v"), symbol("w")});
 
     DenseMatrix C(3, 3);
 

--- a/cmake/checkcxx11.cpp
+++ b/cmake/checkcxx11.cpp
@@ -3,109 +3,175 @@
 #include <cstddef>
 #include <stdexcept>
 
-template<class T>
-class Ptr {
+template <class T>
+class Ptr
+{
 public:
-    inline explicit Ptr( T *ptr ) : ptr_(ptr) {
+    inline explicit Ptr(T *ptr) : ptr_(ptr)
+    {
     }
-    inline Ptr(const Ptr<T>& ptr) : ptr_(ptr.ptr_) {}
-    template<class T2> inline Ptr(const Ptr<T2>& ptr) : ptr_(ptr.get()) {}
-    Ptr<T>& operator=(const Ptr<T>& ptr) { ptr_ = ptr.get(); return *this; }
-//    Ptr(Ptr&&) = default;
-//    Ptr<T>& operator=(Ptr&&) = default;
-    inline T* operator->() const { return ptr_; }
-    inline T& operator*() const { return *ptr_; }
-    inline T* get() const { return ptr_; }
-    inline T* getRawPtr() const { return get(); }
-    inline const Ptr<T> ptr() const { return *this; }
+    inline Ptr(const Ptr<T> &ptr) : ptr_(ptr.ptr_)
+    {
+    }
+    template <class T2>
+    inline Ptr(const Ptr<T2> &ptr) : ptr_(ptr.get())
+    {
+    }
+    Ptr<T> &operator=(const Ptr<T> &ptr)
+    {
+        ptr_ = ptr.get();
+        return *this;
+    }
+    //    Ptr(Ptr&&) = default;
+    //    Ptr<T>& operator=(Ptr&&) = default;
+    inline T *operator->() const
+    {
+        return ptr_;
+    }
+    inline T &operator*() const
+    {
+        return *ptr_;
+    }
+    inline T *get() const
+    {
+        return ptr_;
+    }
+    inline T *getRawPtr() const
+    {
+        return get();
+    }
+    inline const Ptr<T> ptr() const
+    {
+        return *this;
+    }
+
 private:
     T *ptr_;
 };
 
-template<typename T> inline
-Ptr<T> outArg( T& arg )
+template <typename T>
+inline Ptr<T> outArg(T &arg)
 {
     return Ptr<T>(&arg);
 }
 
 enum ENull { null };
 
-template<class T>
-class RCP {
+template <class T>
+class RCP
+{
 public:
-    RCP(ENull null_arg = null) : ptr_(NULL) {}
-    explicit RCP(T *p) : ptr_(p) {
+    RCP(ENull null_arg = null) : ptr_(NULL)
+    {
+    }
+    explicit RCP(T *p) : ptr_(p)
+    {
         (ptr_->refcount_)++;
     }
-    RCP(const RCP<T> &rp) : ptr_(rp.ptr_) {
-        if (!is_null()) (ptr_->refcount_)++;
+    RCP(const RCP<T> &rp) : ptr_(rp.ptr_)
+    {
+        if (!is_null())
+            (ptr_->refcount_)++;
     }
-    template<class T2> RCP(const RCP<T2>& r_ptr) : ptr_(r_ptr.get()) {
-        if (!is_null()) (ptr_->refcount_)++;
+    template <class T2>
+    RCP(const RCP<T2> &r_ptr) : ptr_(r_ptr.get())
+    {
+        if (!is_null())
+            (ptr_->refcount_)++;
     }
-    RCP(RCP<T> &&rp) : ptr_(rp.ptr_) {
+    RCP(RCP<T> &&rp) : ptr_(rp.ptr_)
+    {
         rp.ptr_ = NULL;
     }
-    template<class T2> RCP(RCP<T2>&& r_ptr) : ptr_(r_ptr.get()) {
+    template <class T2>
+    RCP(RCP<T2> &&r_ptr) : ptr_(r_ptr.get())
+    {
         r_ptr._set_null();
     }
-    ~RCP() {
-        if (ptr_ != NULL && --(ptr_->refcount_) == 0) delete ptr_;
+    ~RCP()
+    {
+        if (ptr_ != NULL && --(ptr_->refcount_) == 0)
+            delete ptr_;
     }
-    T* operator->() const {
+    T *operator->() const
+    {
         return ptr_;
     }
-    T& operator*() const {
+    T &operator*() const
+    {
         return *ptr_;
     }
-    T* get() const { return ptr_; }
-    Ptr<T> ptr() const { return Ptr<T>(get()); }
-    bool is_null() const { return ptr_ == NULL; }
-    template<class T2> bool operator==(const RCP<T2> &p2) {
+    T *get() const
+    {
+        return ptr_;
+    }
+    Ptr<T> ptr() const
+    {
+        return Ptr<T>(get());
+    }
+    bool is_null() const
+    {
+        return ptr_ == NULL;
+    }
+    template <class T2>
+    bool operator==(const RCP<T2> &p2)
+    {
         return ptr_ == p2.ptr_;
     }
-    template<class T2> bool operator!=(const RCP<T2> &p2) {
+    template <class T2>
+    bool operator!=(const RCP<T2> &p2)
+    {
         return ptr_ != p2.ptr_;
     }
-    RCP<T>& operator=(const RCP<T> &r_ptr) {
+    RCP<T> &operator=(const RCP<T> &r_ptr)
+    {
         T *r_ptr_ptr_ = r_ptr.ptr_;
-        if (!r_ptr.is_null()) (r_ptr_ptr_->refcount_)++;
-        if (!is_null() && --(ptr_->refcount_) == 0) delete ptr_;
+        if (!r_ptr.is_null())
+            (r_ptr_ptr_->refcount_)++;
+        if (!is_null() && --(ptr_->refcount_) == 0)
+            delete ptr_;
         ptr_ = r_ptr_ptr_;
         return *this;
     }
-    RCP<T>& operator=(RCP<T> &&r_ptr) {
+    RCP<T> &operator=(RCP<T> &&r_ptr)
+    {
         std::swap(ptr_, r_ptr.ptr_);
         return *this;
     }
-    void reset() {
-        if (!is_null() && --(ptr_->refcount_) == 0) delete ptr_;
+    void reset()
+    {
+        if (!is_null() && --(ptr_->refcount_) == 0)
+            delete ptr_;
         ptr_ = NULL;
     }
-    void _set_null() { ptr_ = NULL; }
+    void _set_null()
+    {
+        ptr_ = NULL;
+    }
+
 private:
     T *ptr_;
 };
 
-template<class T>
-inline RCP<T> rcp(T* p)
+template <class T>
+inline RCP<T> rcp(T *p)
 {
     return RCP<T>(p);
 }
 
-template<class T2, class T1>
-inline RCP<T2> rcp_static_cast(const RCP<T1>& p1)
+template <class T2, class T1>
+inline RCP<T2> rcp_static_cast(const RCP<T1> &p1)
 {
-    T2 *check = static_cast<T2*>(p1.get());
+    T2 *check = static_cast<T2 *>(p1.get());
     return RCP<T2>(check);
 }
 
-template<class T2, class T1>
-inline RCP<T2> rcp_dynamic_cast(const RCP<T1>& p1)
+template <class T2, class T1>
+inline RCP<T2> rcp_dynamic_cast(const RCP<T1> &p1)
 {
     if (!p1.is_null()) {
         T2 *p = NULL;
-        p = dynamic_cast<T2*>(p1.get());
+        p = dynamic_cast<T2 *>(p1.get());
         if (p) {
             return RCP<T2>(p);
         }
@@ -113,41 +179,43 @@ inline RCP<T2> rcp_dynamic_cast(const RCP<T1>& p1)
     throw std::runtime_error("rcp_dynamic_cast: cannot convert.");
 }
 
-template<class T2, class T1>
-inline RCP<T2> rcp_const_cast(const RCP<T1>& p1)
+template <class T2, class T1>
+inline RCP<T2> rcp_const_cast(const RCP<T1> &p1)
 {
-  T2 *check = const_cast<T2*>(p1.get());
-  return RCP<T2>(check);
+    T2 *check = const_cast<T2 *>(p1.get());
+    return RCP<T2>(check);
 }
 
-
-template<class T>
+template <class T>
 inline bool operator==(const RCP<T> &p, ENull)
 {
-  return p.get() == NULL;
+    return p.get() == NULL;
 }
 
-
-template<typename T>
+template <typename T>
 std::string typeName(const T &t)
 {
     return "RCP<>";
 }
 
-long double operator "" _mul2(long double x) {
-    return 2*x;
+long double operator"" _mul2(long double x)
+{
+    return 2 * x;
 }
 
-class A {
+class A
+{
 public:
     virtual void print();
 };
 
-class B : public A {
+class B : public A
+{
 public:
     virtual void print() override;
 };
 
-int main() {
+int main()
+{
     return 0;
 }

--- a/cmake/checkgmpxx.cpp
+++ b/cmake/checkgmpxx.cpp
@@ -2,7 +2,8 @@
 #include <iostream>
 #include <gmpxx.h>
 
-int main() {
+int main()
+{
     mpz_class m = 1;
     std::cout << m;
 }

--- a/cmake/checkstdtostring.cpp
+++ b/cmake/checkstdtostring.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <iostream>
-int main() {
-   std::cout << std::to_string(0) << std::endl;
+int main()
+{
+    std::cout << std::to_string(0) << std::endl;
 }

--- a/symengine/complex_mpc.cpp
+++ b/symengine/complex_mpc.cpp
@@ -11,12 +11,10 @@
 namespace SymEngine
 {
 
-ComplexMPC::ComplexMPC(mpc_class i) : i{std::move(i)}
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+ComplexMPC::ComplexMPC(mpc_class i)
+    : i{std::move(i)} {SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t ComplexMPC::__hash__() const
+      hash_t ComplexMPC::__hash__() const
 {
     hash_t seed = COMPLEX_MPC;
     hash_combine_impl(seed, mpc_realref(i.get_mpc_t()));

--- a/symengine/constants.cpp
+++ b/symengine/constants.cpp
@@ -7,12 +7,10 @@
 namespace SymEngine
 {
 
-Constant::Constant(const std::string &name) : name_{name}
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+Constant::Constant(const std::string &name)
+    : name_{name} {SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t Constant::__hash__() const
+      hash_t Constant::__hash__() const
 {
     hash_t seed = CONSTANT;
     hash_combine<std::string>(seed, name_);

--- a/symengine/cse.cpp
+++ b/symengine/cse.cpp
@@ -300,9 +300,10 @@ void match_common_args(const std::string &func_class, const vec_basic &funcs_,
             }
         }
         if (std::find(changed.begin(), changed.end(), i) != changed.end()) {
-            opt_subs[funcs[i].first] = function_symbol(
-                func_class, arg_tracker.get_args_in_value_order(
-                                arg_tracker.func_to_argset[i]));
+            opt_subs[funcs[i].first]
+                = function_symbol(func_class,
+                                  arg_tracker.get_args_in_value_order(
+                                      arg_tracker.func_to_argset[i]));
         }
         arg_tracker.stop_arg_tracking(i);
     }

--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -25,12 +25,9 @@ DenseMatrix::DenseMatrix(unsigned row, unsigned col) : row_(row), col_(col)
 }
 
 DenseMatrix::DenseMatrix(unsigned row, unsigned col, const vec_basic &l)
-    : m_{l}, row_(row), col_(col)
-{
-    SYMENGINE_ASSERT(m_.size() == row * col)
-}
+    : m_{l}, row_(row), col_(col){SYMENGINE_ASSERT(m_.size() == row * col)}
 
-DenseMatrix::DenseMatrix(const vec_basic &column_elements)
+      DenseMatrix::DenseMatrix(const vec_basic &column_elements)
     : m_(column_elements), row_(static_cast<unsigned>(column_elements.size())),
       col_(1)
 {

--- a/symengine/derivative.cpp
+++ b/symengine/derivative.cpp
@@ -268,11 +268,12 @@ public:
             t = p.second->diff(x);
             if (neq(*t, *zero)) {
                 if (is_a<Symbol>(*p.first)) {
-                    diff = add(diff,
-                               mul(t, self.get_arg()
-                                          ->diff(rcp_static_cast<const Symbol>(
-                                              p.first))
-                                          ->subs(self.get_dict())));
+                    diff = add(
+                        diff,
+                        mul(t,
+                            self.get_arg()
+                                ->diff(rcp_static_cast<const Symbol>(p.first))
+                                ->subs(self.get_dict())));
                 } else {
                     return Derivative::create(self.rcp_from_this(), {x});
                 }

--- a/symengine/diophantine.cpp
+++ b/symengine/diophantine.cpp
@@ -101,8 +101,9 @@ void homogeneous_lde(std::vector<DenseMatrix> &basis, const DenseMatrix &A)
 
                 if (i > 0) {
                     SYMENGINE_ASSERT(is_a<Integer>(*T.get(0, i - 1)));
-                    T.set(0, i - 1, down_cast<const Integer &>(*T.get(0, i - 1))
-                                        .subint(*one));
+                    T.set(0, i - 1,
+                          down_cast<const Integer &>(*T.get(0, i - 1))
+                              .subint(*one));
                 }
 
                 dot = zero;

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1706,13 +1706,11 @@ RCP<const Basic> lambertw(const RCP<const Basic> &arg)
 }
 
 FunctionSymbol::FunctionSymbol(std::string name, const RCP<const Basic> &arg)
-    : MultiArgFunction({arg}), name_{name}
-{
-    SYMENGINE_ASSIGN_TYPEID()
-    SYMENGINE_ASSERT(is_canonical(get_vec()))
-}
+    : MultiArgFunction({arg}), name_{name} {SYMENGINE_ASSIGN_TYPEID()
+                                                SYMENGINE_ASSERT(
+                                                    is_canonical(get_vec()))}
 
-FunctionSymbol::FunctionSymbol(std::string name, const vec_basic &arg)
+      FunctionSymbol::FunctionSymbol(std::string name, const vec_basic &arg)
     : MultiArgFunction(arg), name_{name}
 {
     SYMENGINE_ASSIGN_TYPEID()
@@ -1769,20 +1767,15 @@ RCP<const Basic> function_symbol(std::string name, const RCP<const Basic> &arg)
 }
 
 FunctionWrapper::FunctionWrapper(std::string name, const RCP<const Basic> &arg)
-    : FunctionSymbol(name, arg)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+    : FunctionSymbol(name, arg){SYMENGINE_ASSIGN_TYPEID()}
 
-FunctionWrapper::FunctionWrapper(std::string name, const vec_basic &vec)
-    : FunctionSymbol(name, vec)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+      FunctionWrapper::FunctionWrapper(std::string name, const vec_basic &vec)
+    : FunctionSymbol(name, vec){SYMENGINE_ASSIGN_TYPEID()}
 
-/* ---------------------------- */
+      /* ---------------------------- */
 
-Derivative::Derivative(const RCP<const Basic> &arg, const multiset_basic &x)
+      Derivative::Derivative(const RCP<const Basic> &arg,
+                             const multiset_basic &x)
     : arg_{arg}, x_{x}
 {
     SYMENGINE_ASSIGN_TYPEID()
@@ -2622,13 +2615,11 @@ RCP<const Basic> levi_civita(const vec_basic &arg)
 }
 
 Zeta::Zeta(const RCP<const Basic> &s, const RCP<const Basic> &a)
-    : TwoArgFunction(s, a)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-    SYMENGINE_ASSERT(is_canonical(s, a))
-}
+    : TwoArgFunction(s, a){SYMENGINE_ASSIGN_TYPEID()
+                               SYMENGINE_ASSERT(is_canonical(s, a))}
 
-Zeta::Zeta(const RCP<const Basic> &s) : TwoArgFunction(s, one)
+      Zeta::Zeta(const RCP<const Basic> &s)
+    : TwoArgFunction(s, one)
 {
     SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(s, one))

--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -25,11 +25,9 @@ public:
     IMPLEMENT_TYPEID(INTEGER)
     //! Constructor of Integer using `integer_class`
     // explicit Integer(integer_class i);
-    Integer(const integer_class &_i) : i(_i)
-    {
-        SYMENGINE_ASSIGN_TYPEID()
-    }
-    Integer(integer_class &&_i) : i(std::move(_i))
+    Integer(const integer_class &_i)
+        : i(_i){SYMENGINE_ASSIGN_TYPEID()} Integer(integer_class && _i)
+        : i(std::move(_i))
     {
         SYMENGINE_ASSIGN_TYPEID()
     }

--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -8,12 +8,10 @@ RCP<const Boolean> Boolean::logical_not() const
     return make_rcp<const Not>(this->rcp_from_this_cast<const Boolean>());
 }
 
-BooleanAtom::BooleanAtom(bool b) : b_{b}
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+BooleanAtom::BooleanAtom(bool b)
+    : b_{b} {SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t BooleanAtom::__hash__() const
+      hash_t BooleanAtom::__hash__() const
 {
     hash_t seed = BOOLEAN_ATOM;
     if (b_)
@@ -56,12 +54,9 @@ RCP<const BooleanAtom> boolTrue = make_rcp<BooleanAtom>(true);
 RCP<const BooleanAtom> boolFalse = make_rcp<BooleanAtom>(false);
 
 Contains::Contains(const RCP<const Basic> &expr, const RCP<const Set> &set)
-    : expr_{expr}, set_{set}
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+    : expr_{expr}, set_{set} {SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t Contains::__hash__() const
+      hash_t Contains::__hash__() const
 {
     hash_t seed = CONTAINS;
     hash_combine<Basic>(seed, *expr_);
@@ -120,12 +115,10 @@ RCP<const Boolean> contains(const RCP<const Basic> &expr,
     }
 }
 
-Piecewise::Piecewise(PiecewiseVec &&vec) : vec_(vec)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+Piecewise::Piecewise(PiecewiseVec &&vec)
+    : vec_(vec){SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t Piecewise::__hash__() const
+      hash_t Piecewise::__hash__() const
 {
     hash_t seed = this->get_type_code();
     for (auto &p : vec_) {

--- a/symengine/nan.cpp
+++ b/symengine/nan.cpp
@@ -4,10 +4,7 @@
 namespace SymEngine
 {
 
-NaN::NaN()
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+NaN::NaN(){SYMENGINE_ASSIGN_TYPEID()}
 
 hash_t NaN::__hash__() const
 {

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -137,14 +137,11 @@ inline bool is_a_Number(const Basic &b)
 class NumberWrapper : public Number
 {
 public:
-    NumberWrapper()
-    {
-        SYMENGINE_ASSIGN_TYPEID()
-    }
+    NumberWrapper(){SYMENGINE_ASSIGN_TYPEID()}
 
     IMPLEMENT_TYPEID(NUMBER_WRAPPER)
 
-    virtual std::string __str__() const
+        virtual std::string __str__() const
     {
         throw NotImplementedError("Not Implemented.");
     };

--- a/symengine/polys/basic_conversions.h
+++ b/symengine/polys/basic_conversions.h
@@ -261,8 +261,10 @@ public:
     {
         if (is_a<const Integer>(x))
             this->dict = Poly::container_from_dict(
-                this->gen, {{pow, rational_class(static_cast<const Integer &>(x)
-                                                     .as_integer_class())}});
+                this->gen,
+                {{pow,
+                  rational_class(
+                      static_cast<const Integer &>(x).as_integer_class())}});
         else if (is_a<const Rational>(x))
             this->dict = Poly::container_from_dict(
                 this->gen,

--- a/symengine/polys/msymenginepoly.h
+++ b/symengine/polys/msymenginepoly.h
@@ -460,14 +460,11 @@ class MIntPoly : public MSymEnginePoly<MIntDict, MIntPoly>
 {
 public:
     MIntPoly(const set_basic &vars, MIntDict &&dict)
-        : MSymEnginePoly(vars, std::move(dict))
-    {
-        SYMENGINE_ASSIGN_TYPEID()
-    }
+        : MSymEnginePoly(vars, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()}
 
-    IMPLEMENT_TYPEID(MINTPOLY)
+          IMPLEMENT_TYPEID(MINTPOLY)
 
-    hash_t __hash__() const;
+              hash_t __hash__() const;
     RCP<const Basic> as_symbolic() const;
 
     integer_class eval(
@@ -478,14 +475,11 @@ class MExprPoly : public MSymEnginePoly<MExprDict, MExprPoly>
 {
 public:
     MExprPoly(const set_basic &vars, MExprDict &&dict)
-        : MSymEnginePoly(vars, std::move(dict))
-    {
-        SYMENGINE_ASSIGN_TYPEID()
-    }
+        : MSymEnginePoly(vars, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()}
 
-    IMPLEMENT_TYPEID(MEXPRPOLY)
+          IMPLEMENT_TYPEID(MEXPRPOLY)
 
-    hash_t __hash__() const;
+              hash_t __hash__() const;
     RCP<const Basic> as_symbolic() const;
     Expression
     eval(std::map<RCP<const Basic>, Expression, RCPBasicKeyLess> &vals) const;

--- a/symengine/polys/uexprpoly.cpp
+++ b/symengine/polys/uexprpoly.cpp
@@ -4,13 +4,11 @@ namespace SymEngine
 {
 
 UExprPoly::UExprPoly(const RCP<const Basic> &var, UExprDict &&dict)
-    : USymEnginePoly(var, std::move(dict))
-{
-    SYMENGINE_ASSIGN_TYPEID()
-    SYMENGINE_ASSERT(is_canonical(get_poly()))
-}
+    : USymEnginePoly(
+          var, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()
+                                    SYMENGINE_ASSERT(is_canonical(get_poly()))}
 
-hash_t UExprPoly::__hash__() const
+      hash_t UExprPoly::__hash__() const
 {
     hash_t seed = UEXPRPOLY;
 

--- a/symengine/polys/uintpoly.cpp
+++ b/symengine/polys/uintpoly.cpp
@@ -4,13 +4,11 @@ namespace SymEngine
 {
 
 UIntPoly::UIntPoly(const RCP<const Basic> &var, UIntDict &&dict)
-    : USymEnginePoly(var, std::move(dict))
-{
-    SYMENGINE_ASSIGN_TYPEID()
-    SYMENGINE_ASSERT(is_canonical(get_poly()))
-}
+    : USymEnginePoly(
+          var, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()
+                                    SYMENGINE_ASSERT(is_canonical(get_poly()))}
 
-hash_t UIntPoly::__hash__() const
+      hash_t UIntPoly::__hash__() const
 {
     hash_t seed = UINTPOLY;
 

--- a/symengine/polys/uintpoly_flint.cpp
+++ b/symengine/polys/uintpoly_flint.cpp
@@ -5,12 +5,9 @@ namespace SymEngine
 {
 
 UIntPolyFlint::UIntPolyFlint(const RCP<const Basic> &var, fzp_t &&dict)
-    : UFlintPoly(var, std::move(dict))
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+    : UFlintPoly(var, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t UIntPolyFlint::__hash__() const
+      hash_t UIntPolyFlint::__hash__() const
 {
     std::hash<std::string> str_hash;
     hash_t seed = UINTPOLYFLINT;
@@ -21,12 +18,9 @@ hash_t UIntPolyFlint::__hash__() const
 }
 
 URatPolyFlint::URatPolyFlint(const RCP<const Basic> &var, fqp_t &&dict)
-    : UFlintPoly(var, std::move(dict))
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+    : UFlintPoly(var, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t URatPolyFlint::__hash__() const
+      hash_t URatPolyFlint::__hash__() const
 {
     std::hash<std::string> str_hash;
     hash_t seed = URATPOLYFLINT;

--- a/symengine/polys/uintpoly_piranha.cpp
+++ b/symengine/polys/uintpoly_piranha.cpp
@@ -6,12 +6,9 @@ namespace SymEngine
 {
 
 UIntPolyPiranha::UIntPolyPiranha(const RCP<const Basic> &var, pintpoly &&dict)
-    : UPiranhaPoly(var, std::move(dict))
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+    : UPiranhaPoly(var, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t UIntPolyPiranha::__hash__() const
+      hash_t UIntPolyPiranha::__hash__() const
 {
     hash_t seed = UINTPOLYPIRANHA;
     seed += get_poly().hash();
@@ -20,12 +17,9 @@ hash_t UIntPolyPiranha::__hash__() const
 }
 
 URatPolyPiranha::URatPolyPiranha(const RCP<const Basic> &var, pratpoly &&dict)
-    : UPiranhaPoly(var, std::move(dict))
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+    : UPiranhaPoly(var, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t URatPolyPiranha::__hash__() const
+      hash_t URatPolyPiranha::__hash__() const
 {
     hash_t seed = URATPOLYPIRANHA;
     seed += get_poly().hash();

--- a/symengine/polys/uratpoly.cpp
+++ b/symengine/polys/uratpoly.cpp
@@ -4,13 +4,11 @@ namespace SymEngine
 {
 
 URatPoly::URatPoly(const RCP<const Basic> &var, URatDict &&dict)
-    : USymEnginePoly(var, std::move(dict))
-{
-    SYMENGINE_ASSIGN_TYPEID()
-    SYMENGINE_ASSERT(is_canonical(get_poly()))
-}
+    : USymEnginePoly(
+          var, std::move(dict)){SYMENGINE_ASSIGN_TYPEID()
+                                    SYMENGINE_ASSERT(is_canonical(get_poly()))}
 
-hash_t URatPoly::__hash__() const
+      hash_t URatPoly::__hash__() const
 {
     hash_t seed = URATPOLY;
 

--- a/symengine/printers/strprinter.cpp
+++ b/symengine/printers/strprinter.cpp
@@ -428,10 +428,10 @@ void StrPrinter::bvisit(const RealMPFR &x)
 {
     mpfr_exp_t ex;
     // mpmath.libmp.libmpf.prec_to_dps
-    long digits
-        = std::max(long(1), std::lround(static_cast<double>(x.i.get_prec())
-                                        / 3.3219280948873626)
-                                - 1);
+    long digits = std::max(
+        long(1),
+        std::lround(static_cast<double>(x.i.get_prec()) / 3.3219280948873626)
+            - 1);
     char *c
         = mpfr_get_str(nullptr, &ex, 10, digits, x.i.get_mpfr_t(), MPFR_RNDN);
     std::ostringstream s;

--- a/symengine/real_mpfr.cpp
+++ b/symengine/real_mpfr.cpp
@@ -11,12 +11,10 @@
 namespace SymEngine
 {
 
-RealMPFR::RealMPFR(mpfr_class i) : i{std::move(i)}
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+RealMPFR::RealMPFR(mpfr_class i)
+    : i{std::move(i)} {SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t RealMPFR::__hash__() const
+      hash_t RealMPFR::__hash__() const
 {
     hash_t seed = REAL_MPFR;
     hash_combine_impl(seed, i.get_mpfr_t());

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -6,13 +6,11 @@ namespace SymEngine
 
 URatPSeriesFlint::URatPSeriesFlint(fqp_t p, const std::string varname,
                                    const unsigned degree)
-    : SeriesBase(std::move(p), varname, degree)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
-RCP<const URatPSeriesFlint> URatPSeriesFlint::series(const RCP<const Basic> &t,
-                                                     const std::string &x,
-                                                     unsigned int prec)
+    : SeriesBase(
+          std::move(p), varname,
+          degree){SYMENGINE_ASSIGN_TYPEID()} RCP<const URatPSeriesFlint> URatPSeriesFlint::
+          series(const RCP<const Basic> &t, const std::string &x,
+                 unsigned int prec)
 {
     fqp_t p("2  0 1");
     SeriesVisitor<fqp_t, fmpq_wrapper, URatPSeriesFlint> visitor(p, x, prec);

--- a/symengine/series_piranha.cpp
+++ b/symengine/series_piranha.cpp
@@ -5,13 +5,11 @@ namespace SymEngine
 
 URatPSeriesPiranha::URatPSeriesPiranha(pp_t p, const std::string varname,
                                        const unsigned degree)
-    : SeriesBase(std::move(p), varname, degree)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
-RCP<const URatPSeriesPiranha>
-URatPSeriesPiranha::series(const RCP<const Basic> &t, const std::string &x,
-                           unsigned int prec)
+    : SeriesBase(
+          std::move(p), varname,
+          degree){SYMENGINE_ASSIGN_TYPEID()} RCP<const URatPSeriesPiranha> URatPSeriesPiranha::
+          series(const RCP<const Basic> &t, const std::string &x,
+                 unsigned int prec)
 {
     SeriesVisitor<pp_t, piranha::rational, URatPSeriesPiranha> visitor(pp_t(x),
                                                                        x, prec);
@@ -179,14 +177,10 @@ pp_t URatPSeriesPiranha::subs(const pp_t &s, const pp_t &var, const pp_t &r,
 
 UPSeriesPiranha::UPSeriesPiranha(p_expr p, const std::string varname,
                                  const unsigned degree)
-    : SeriesBase(std::move(p), varname, degree)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+    : SeriesBase(std::move(p), varname, degree){SYMENGINE_ASSIGN_TYPEID()}
 
-RCP<const UPSeriesPiranha> UPSeriesPiranha::series(const RCP<const Basic> &t,
-                                                   const std::string &x,
-                                                   unsigned int prec)
+      RCP<const UPSeriesPiranha> UPSeriesPiranha::series(
+          const RCP<const Basic> &t, const std::string &x, unsigned int prec)
 {
     SeriesVisitor<p_expr, Expression, UPSeriesPiranha> visitor(p_expr(x), x,
                                                                prec);

--- a/symengine/sets.cpp
+++ b/symengine/sets.cpp
@@ -514,13 +514,11 @@ RCP<const Set> FiniteSet::create(const set_basic &container) const
     return finiteset(container);
 }
 
-Union::Union(const set_set &in) : container_(in)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-    SYMENGINE_ASSERT(Union::is_canonical(in))
-}
+Union::Union(const set_set &in)
+    : container_(in){SYMENGINE_ASSIGN_TYPEID()
+                         SYMENGINE_ASSERT(Union::is_canonical(in))}
 
-hash_t Union::__hash__() const
+      hash_t Union::__hash__() const
 {
     hash_t seed = UNION;
     for (const auto &a : container_)
@@ -621,12 +619,9 @@ vec_basic Union::get_args() const
 
 Complement::Complement(const RCP<const Set> &universe,
                        const RCP<const Set> &container)
-    : universe_(universe), container_(container)
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+    : universe_(universe), container_(container){SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t Complement::__hash__() const
+      hash_t Complement::__hash__() const
 {
     hash_t seed = COMPLEMENT;
     hash_combine<Basic>(seed, *universe_);

--- a/symengine/sets.h
+++ b/symengine/sets.h
@@ -51,14 +51,13 @@ public:
 class EmptySet : public Set
 {
 public:
-    EmptySet()
-    {
-        SYMENGINE_ASSIGN_TYPEID()
-    }
+    EmptySet(){SYMENGINE_ASSIGN_TYPEID()}
 
     IMPLEMENT_TYPEID(EMPTYSET)
-    // EmptySet(EmptySet const&) = delete;
-    void operator=(EmptySet const &) = delete;
+        // EmptySet(EmptySet const&) = delete;
+        void
+        operator=(EmptySet const &)
+        = delete;
     const static RCP<const EmptySet> &getInstance();
     virtual hash_t __hash__() const;
     virtual bool __eq__(const Basic &o) const;

--- a/symengine/symbol.cpp
+++ b/symengine/symbol.cpp
@@ -4,12 +4,10 @@
 namespace SymEngine
 {
 
-Symbol::Symbol(const std::string &name) : name_{name}
-{
-    SYMENGINE_ASSIGN_TYPEID()
-}
+Symbol::Symbol(const std::string &name)
+    : name_{name} {SYMENGINE_ASSIGN_TYPEID()}
 
-hash_t Symbol::__hash__() const
+      hash_t Symbol::__hash__() const
 {
     hash_t seed = 0;
     hash_combine(seed, name_);

--- a/symengine/tests/basic/test_arit.cpp
+++ b/symengine/tests/basic/test_arit.cpp
@@ -1276,8 +1276,9 @@ TEST_CASE("Expand2: arit", "[arit]")
     r1 = mul(i3, pow(i5, div(im1, i2)));
     r2 = mul(i4, pow(i5, div(im1, i2)));
     r2 = expand(pow(add(add(r1, r2), integer(1)), i2));
-    REQUIRE(eq(*r2, *add(div(integer(54), i5),
-                         mul(integer(14), pow(i5, div(im1, i2))))));
+    REQUIRE(eq(
+        *r2,
+        *add(div(integer(54), i5), mul(integer(14), pow(i5, div(im1, i2))))));
 
     r1 = pow(add(mul(I, x), i2), i2);
     r1 = expand(r1);

--- a/symengine/tests/basic/test_as_real_imag.cpp
+++ b/symengine/tests/basic/test_as_real_imag.cpp
@@ -167,24 +167,28 @@ TEST_CASE("RealImag: Trigonometric functions", "[as_real_imag]")
     REQUIRE(eq(*im, *zero));
 
     as_real_imag(csc(add(i2, I)), outArg(re), outArg(im));
-    REQUIRE(eq(*re, *div(mul(sin(i2), cosh(one)),
-                         add(mul(pow(cos(i2), i2), pow(sinh(one), i2)),
-                             mul(pow(sin(i2), i2), pow(cosh(one), i2))))));
-    REQUIRE(eq(*im, *div(mul({minus_one, cos(i2), sinh(one)}),
-                         add(mul(pow(cos(i2), i2), pow(sinh(one), i2)),
-                             mul(pow(sin(i2), i2), pow(cosh(one), i2))))));
+    REQUIRE(eq(*re,
+               *div(mul(sin(i2), cosh(one)),
+                    add(mul(pow(cos(i2), i2), pow(sinh(one), i2)),
+                        mul(pow(sin(i2), i2), pow(cosh(one), i2))))));
+    REQUIRE(eq(*im,
+               *div(mul({minus_one, cos(i2), sinh(one)}),
+                    add(mul(pow(cos(i2), i2), pow(sinh(one), i2)),
+                        mul(pow(sin(i2), i2), pow(cosh(one), i2))))));
 
     as_real_imag(sec(i2), outArg(re), outArg(im));
     REQUIRE(eq(*re, *div(one, cos(i2))));
     REQUIRE(eq(*im, *zero));
 
     as_real_imag(sec(add(i2, I)), outArg(re), outArg(im));
-    REQUIRE(eq(*re, *div(mul(cos(i2), cosh(one)),
-                         add(mul(pow(cos(i2), i2), pow(cosh(one), i2)),
-                             mul(pow(sin(i2), i2), pow(sinh(one), i2))))));
-    REQUIRE(eq(*im, *div(mul(sin(i2), sinh(one)),
-                         add(mul(pow(cos(i2), i2), pow(cosh(one), i2)),
-                             mul(pow(sin(i2), i2), pow(sinh(one), i2))))));
+    REQUIRE(eq(*re,
+               *div(mul(cos(i2), cosh(one)),
+                    add(mul(pow(cos(i2), i2), pow(cosh(one), i2)),
+                        mul(pow(sin(i2), i2), pow(sinh(one), i2))))));
+    REQUIRE(eq(*im,
+               *div(mul(sin(i2), sinh(one)),
+                    add(mul(pow(cos(i2), i2), pow(cosh(one), i2)),
+                        mul(pow(sin(i2), i2), pow(sinh(one), i2))))));
 
     as_real_imag(cot(i2), outArg(re), outArg(im));
     REQUIRE(eq(*re, *cot(i2)));
@@ -216,44 +220,52 @@ TEST_CASE("RealImag: Trigonometric functions", "[as_real_imag]")
     REQUIRE(eq(*im, *zero));
 
     as_real_imag(tanh(add(i2, I)), outArg(re), outArg(im));
-    REQUIRE(eq(*re, *div(mul(sinh(i2), cosh(i2)),
-                         add(pow(cos(one), i2), pow(sinh(i2), i2)))));
-    REQUIRE(eq(*im, *div(mul(sin(one), cos(one)),
-                         add(pow(cos(one), i2), pow(sinh(i2), i2)))));
+    REQUIRE(eq(*re,
+               *div(mul(sinh(i2), cosh(i2)),
+                    add(pow(cos(one), i2), pow(sinh(i2), i2)))));
+    REQUIRE(eq(*im,
+               *div(mul(sin(one), cos(one)),
+                    add(pow(cos(one), i2), pow(sinh(i2), i2)))));
 
     as_real_imag(csch(i2), outArg(re), outArg(im));
     REQUIRE(eq(*re, *div(one, sinh(i2))));
     REQUIRE(eq(*im, *zero));
 
     as_real_imag(csch(add(i2, I)), outArg(re), outArg(im));
-    REQUIRE(eq(*re, *div(mul(sinh(i2), cos(one)),
-                         add(mul(pow(cosh(i2), i2), pow(sin(one), i2)),
-                             mul(pow(sinh(i2), i2), pow(cos(one), i2))))));
-    REQUIRE(eq(*im, *div(mul({minus_one, cosh(i2), sin(one)}),
-                         add(mul(pow(cosh(i2), i2), pow(sin(one), i2)),
-                             mul(pow(sinh(i2), i2), pow(cos(one), i2))))));
+    REQUIRE(eq(*re,
+               *div(mul(sinh(i2), cos(one)),
+                    add(mul(pow(cosh(i2), i2), pow(sin(one), i2)),
+                        mul(pow(sinh(i2), i2), pow(cos(one), i2))))));
+    REQUIRE(eq(*im,
+               *div(mul({minus_one, cosh(i2), sin(one)}),
+                    add(mul(pow(cosh(i2), i2), pow(sin(one), i2)),
+                        mul(pow(sinh(i2), i2), pow(cos(one), i2))))));
 
     as_real_imag(sech(i2), outArg(re), outArg(im));
     REQUIRE(eq(*re, *div(one, cosh(i2))));
     REQUIRE(eq(*im, *zero));
 
     as_real_imag(sech(add(i2, I)), outArg(re), outArg(im));
-    REQUIRE(eq(*re, *div(mul(cosh(i2), cos(one)),
-                         add(mul(pow(cosh(i2), i2), pow(cos(one), i2)),
-                             mul(pow(sinh(i2), i2), pow(sin(one), i2))))));
-    REQUIRE(eq(*im, *div(mul({minus_one, sin(one), sinh(i2)}),
-                         add(mul(pow(cosh(i2), i2), pow(cos(one), i2)),
-                             mul(pow(sinh(i2), i2), pow(sin(one), i2))))));
+    REQUIRE(eq(*re,
+               *div(mul(cosh(i2), cos(one)),
+                    add(mul(pow(cosh(i2), i2), pow(cos(one), i2)),
+                        mul(pow(sinh(i2), i2), pow(sin(one), i2))))));
+    REQUIRE(eq(*im,
+               *div(mul({minus_one, sin(one), sinh(i2)}),
+                    add(mul(pow(cosh(i2), i2), pow(cos(one), i2)),
+                        mul(pow(sinh(i2), i2), pow(sin(one), i2))))));
 
     as_real_imag(coth(i2), outArg(re), outArg(im));
     REQUIRE(eq(*re, *coth(i2)));
     REQUIRE(eq(*im, *zero));
 
     as_real_imag(coth(add(i2, I)), outArg(re), outArg(im));
-    REQUIRE(eq(*re, *div(mul(sinh(i2), cosh(i2)),
-                         add(pow(sin(one), i2), pow(sinh(i2), i2)))));
-    REQUIRE(eq(*im, *div(mul({minus_one, sin(one), cos(one)}),
-                         add(pow(sin(one), i2), pow(sinh(i2), i2)))));
+    REQUIRE(eq(*re,
+               *div(mul(sinh(i2), cosh(i2)),
+                    add(pow(sin(one), i2), pow(sinh(i2), i2)))));
+    REQUIRE(eq(*im,
+               *div(mul({minus_one, sin(one), cos(one)}),
+                    add(pow(sin(one), i2), pow(sinh(i2), i2)))));
 
     CHECK_THROWS_AS(as_real_imag(asin(i2), outArg(re), outArg(im)),
                     SymEngineException &);

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -732,11 +732,12 @@ TEST_CASE("Complex: Basic", "[basic]")
 
     // Basic check for equality in Complex::from_two_nums and
     // Complex::from_two_rats
-    REQUIRE(eq(*c1, *Complex::from_two_rats(down_cast<const Rational &>(*r1),
-                                            down_cast<const Rational &>(*r2))));
-    REQUIRE(
-        neq(*c2, *Complex::from_two_rats(down_cast<const Rational &>(*r1),
-                                         down_cast<const Rational &>(*r2))));
+    REQUIRE(eq(*c1,
+               *Complex::from_two_rats(down_cast<const Rational &>(*r1),
+                                       down_cast<const Rational &>(*r2))));
+    REQUIRE(neq(*c2,
+                *Complex::from_two_rats(down_cast<const Rational &>(*r1),
+                                        down_cast<const Rational &>(*r2))));
 
     // Checks for complex addition
     // Final result is int

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -4260,13 +4260,15 @@ TEST_CASE("test_floor", "[Floor]")
     CHECK(eq(*r, *ceiling(x)));
 
     r = floor(add(add(integer(2), mul(integer(2), x)), mul(integer(3), y)));
-    CHECK(eq(*r, *add(integer(2),
-                      floor(add(mul(integer(2), x), mul(integer(3), y))))));
+    CHECK(eq(
+        *r,
+        *add(integer(2), floor(add(mul(integer(2), x), mul(integer(3), y))))));
 
     r = floor(add(add(Rational::from_two_ints(2, 3), mul(integer(2), x)),
                   mul(integer(3), y)));
-    CHECK(eq(*r, *floor(add(add(mul(integer(2), x), mul(integer(3), y)),
-                            Rational::from_two_ints(2, 3)))));
+    CHECK(eq(*r,
+             *floor(add(add(mul(integer(2), x), mul(integer(3), y)),
+                        Rational::from_two_ints(2, 3)))));
 
     CHECK_THROWS_AS(floor(Eq(integer(2), integer(3))), SymEngineException &);
 
@@ -4332,13 +4334,15 @@ TEST_CASE("test_ceiling", "[Ceiling]")
     CHECK(eq(*r, *ceiling(x)));
 
     r = ceiling(add(add(integer(2), mul(integer(2), x)), mul(integer(3), y)));
-    CHECK(eq(*r, *add(integer(2),
-                      ceiling(add(mul(integer(2), x), mul(integer(3), y))))));
+    CHECK(eq(*r,
+             *add(integer(2),
+                  ceiling(add(mul(integer(2), x), mul(integer(3), y))))));
 
     r = ceiling(add(add(Rational::from_two_ints(2, 3), mul(integer(2), x)),
                     mul(integer(3), y)));
-    CHECK(eq(*r, *ceiling(add(add(mul(integer(2), x), mul(integer(3), y)),
-                              Rational::from_two_ints(2, 3)))));
+    CHECK(eq(*r,
+             *ceiling(add(add(mul(integer(2), x), mul(integer(3), y)),
+                          Rational::from_two_ints(2, 3)))));
 
     CHECK_THROWS_AS(ceiling(Eq(integer(2), integer(3))), SymEngineException &);
 
@@ -4469,16 +4473,18 @@ TEST_CASE("test_conjugate", "[Conjugate]")
 
     r = conjugate(
         pow(Complex::from_two_nums(*integer(2), *integer(3)), integer(2)));
-    CHECK(eq(*r, *pow(Complex::from_two_nums(*integer(2), *integer(-3)),
-                      integer(2))));
+    CHECK(eq(
+        *r,
+        *pow(Complex::from_two_nums(*integer(2), *integer(-3)), integer(2))));
 
     r = conjugate(complex_double(std::complex<double>(0.0, 1.0)));
     CHECK(eq(*r, *complex_double(std::complex<double>(0.0, -1.0))));
 
     r = conjugate(
         pow(complex_double(std::complex<double>(2.0, 3.0)), integer(-2)));
-    CHECK(eq(*r, *pow(complex_double(std::complex<double>(2.0, -3.0)),
-                      integer(-2))));
+    CHECK(
+        eq(*r,
+           *pow(complex_double(std::complex<double>(2.0, -3.0)), integer(-2))));
 
     r = conjugate(pow(y, integer(2)));
     CHECK(eq(*r, *pow(conjugate(y), integer(2))));

--- a/symengine/tests/basic/test_parser.cpp
+++ b/symengine/tests/basic/test_parser.cpp
@@ -253,8 +253,9 @@ TEST_CASE("Parsing: functions", "[parser]")
 
     s = "beta(sin(x+3), gamma(2**y+sin(y)))";
     res = parse(s);
-    REQUIRE(eq(*res, *beta(sin(add(x, integer(3))),
-                           gamma(add(sin(y), pow(integer(2), y))))));
+    REQUIRE(eq(*res,
+               *beta(sin(add(x, integer(3))),
+                     gamma(add(sin(y), pow(integer(2), y))))));
 
     s = "y**(abs(sin(3) + x)) + sinh(2)";
     res = parse(s);
@@ -268,8 +269,9 @@ TEST_CASE("Parsing: functions", "[parser]")
 
     s = "2 + zeta(2, x) + zeta(ln(3))";
     res = parse(s);
-    REQUIRE(eq(*res, *add(integer(2),
-                          add(zeta(integer(2), x), zeta(log(integer(3)))))));
+    REQUIRE(
+        eq(*res,
+           *add(integer(2), add(zeta(integer(2), x), zeta(log(integer(3)))))));
 
     s = "sin(asin(x)) + y";
     res = parse(s);
@@ -488,8 +490,9 @@ TEST_CASE("Parsing: constants", "[parser]")
 
     s = "(3+4*I)/(5+cos(pi/2)*I)";
     res = parse(s);
-    REQUIRE(eq(*res, *div(Complex::from_two_nums(*integer(3), *integer(4)),
-                          integer(5))));
+    REQUIRE(
+        eq(*res,
+           *div(Complex::from_two_nums(*integer(3), *integer(4)), integer(5))));
 
     s = "(2*I +6*I)*3*I + 4*I";
     res = parse(s);
@@ -522,13 +525,15 @@ TEST_CASE("Parsing: function_symbols", "[parser]")
 
     s = "my_func(x, wt) + sin(f(y))";
     res = parse(s);
-    REQUIRE(eq(*res, *add(function_symbol("my_func", {x, z}),
-                          sin(function_symbol("f", y)))));
+    REQUIRE(eq(*res,
+               *add(function_symbol("my_func", {x, z}),
+                    sin(function_symbol("f", y)))));
 
     s = "func(x, y, wt) + f(sin(x))";
     res = parse(s);
-    REQUIRE(eq(*res, *add(function_symbol("func", {x, y, z}),
-                          function_symbol("f", sin(x)))));
+    REQUIRE(eq(*res,
+               *add(function_symbol("func", {x, y, z}),
+                    function_symbol("f", sin(x)))));
 
     s = "f(g(2**x))";
     res = parse(s);

--- a/symengine/tests/basic/test_solve.cpp
+++ b/symengine/tests/basic/test_solve.cpp
@@ -141,9 +141,9 @@ TEST_CASE("linear and quadratic polynomials", "[Solve]")
 
     poly = add(sqx, sub(mul(integer(8), x), integer(5)));
     soln = solve(poly, x);
-    REQUIRE(
-        eq(*soln, *finiteset({add(integer(-4), div(sqrt(integer(84)), i2)),
-                              sub(integer(-4), div(sqrt(integer(84)), i2))})));
+    REQUIRE(eq(*soln,
+               *finiteset({add(integer(-4), div(sqrt(integer(84)), i2)),
+                           sub(integer(-4), div(sqrt(integer(84)), i2))})));
 
     poly = add(sqx, sub(integer(50), mul(integer(8), x)));
     soln = solve(poly, x);
@@ -194,8 +194,9 @@ TEST_CASE("cubic and quartic polynomials", "[Solve]")
 
     poly = Ne(add({cbx, mul(x, i3), mul(sqx, i3)}), neg(one));
     soln = solve(poly, x, reals);
-    REQUIRE(eq(*soln, *set_union({interval(NegInf, integer(-1), true, true),
-                                  interval(integer(-1), Inf, true, true)})));
+    REQUIRE(eq(*soln,
+               *set_union({interval(NegInf, integer(-1), true, true),
+                           interval(integer(-1), Inf, true, true)})));
 
     poly = Ge(add({cbx, mul(x, i3), mul(sqx, i3)}), one);
     soln = solve(poly, x, reals);
@@ -284,8 +285,9 @@ TEST_CASE("Higher order(degree >=5) polynomials", "[Solve]")
                 mul(cbx, integer(5015)), mul(sqx, integer(-13436)),
                 mul(x, integer(3700)), integer(14352)});
     soln = solve(poly, x);
-    REQUIRE(eq(*soln, *finiteset({i2, i3, rational(26, 3), rational(-4, 5),
-                                  integer(23)})));
+    REQUIRE(eq(
+        *soln,
+        *finiteset({i2, i3, rational(26, 3), rational(-4, 5), integer(23)})));
 
     poly = add({mul(qx, qx), mul({i3, qx, cbx}), mul({i2, qx, sqx}), mul(qx, x),
                 mul(i3, qx), mul(i2, cbx), sqx, mul(i3, x), i2});
@@ -361,9 +363,10 @@ TEST_CASE("solve_poly", "[Solve]")
     soln = solve_poly(p3, x);
     REQUIRE(eq(*soln, *finiteset({neg(one), neg(integer(2))})));
 
-    auto P3 = URatPolyFlint::from_dict(x, {{0, 1_q},
-                                           {1, rational_class(3_z, 2_z)},
-                                           {2, rational_class(1_z, 2_z)}});
+    auto P3 = URatPolyFlint::from_dict(x,
+                                       {{0, 1_q},
+                                        {1, rational_class(3_z, 2_z)},
+                                        {2, rational_class(1_z, 2_z)}});
     soln = solve_poly(P3, x);
     REQUIRE(eq(*soln, *finiteset({neg(one), neg(integer(2))})));
 #endif
@@ -373,9 +376,10 @@ TEST_CASE("solve_poly", "[Solve]")
     soln = solve_poly(p4, x);
     REQUIRE(eq(*soln, *finiteset({neg(one), neg(integer(2))})));
 
-    auto P4 = URatPolyPiranha::from_dict(x, {{0, 1_q},
-                                             {1, rational_class(3_z, 2_z)},
-                                             {2, rational_class(1_z, 2_z)}});
+    auto P4 = URatPolyPiranha::from_dict(x,
+                                         {{0, 1_q},
+                                          {1, rational_class(3_z, 2_z)},
+                                          {2, rational_class(1_z, 2_z)}});
     soln = solve_poly(P4, x);
     REQUIRE(eq(*soln, *finiteset({neg(one), neg(integer(2))})));
 #endif
@@ -475,10 +479,10 @@ TEST_CASE("linear_eqns_to_matrix", "[Solve]")
          add({mul(integer(2), x), mul(integer(2), y), mul(integer(3), z)}),
          add({mul(integer(3), x), mul(integer(3), y), mul(integer(3), z)})},
         {x, y, z});
-    REQUIRE(solns.first
-            == DenseMatrix(3, 3, {integer(1), integer(2), integer(3),
-                                  integer(2), integer(2), integer(3),
-                                  integer(3), integer(3), integer(3)}));
+    REQUIRE(solns.first == DenseMatrix(3, 3,
+                                       {integer(1), integer(2), integer(3),
+                                        integer(2), integer(2), integer(3),
+                                        integer(3), integer(3), integer(3)}));
     REQUIRE(solns.second == DenseMatrix(3, 1, {zero, zero, zero}));
 
     solns = linear_eqns_to_matrix(
@@ -487,10 +491,10 @@ TEST_CASE("linear_eqns_to_matrix", "[Solve]")
          add({mul(integer(3), x), mul(integer(3), y), mul(integer(3), z)})},
         {y, x, z});
 
-    REQUIRE(solns.first
-            == DenseMatrix(3, 3, {integer(2), integer(1), integer(3),
-                                  integer(2), integer(2), integer(3),
-                                  integer(3), integer(3), integer(3)}));
+    REQUIRE(solns.first == DenseMatrix(3, 3,
+                                       {integer(2), integer(1), integer(3),
+                                        integer(2), integer(2), integer(3),
+                                        integer(3), integer(3), integer(3)}));
     REQUIRE(solns.second == DenseMatrix(3, 1, {zero, zero, zero}));
 
     solns = linear_eqns_to_matrix(
@@ -507,14 +511,15 @@ TEST_CASE("linear_eqns_to_matrix", "[Solve]")
                  mul(integer(6), t)}),
             integer(30))},
         {y, z, t, x});
-    REQUIRE(
-        solns.first
-        == DenseMatrix(4, 4, {integer(2), integer(3), integer(4), integer(1),
-                              integer(2), integer(3), integer(4), integer(2),
-                              integer(3), integer(3), integer(4), integer(3),
-                              integer(8), integer(7), integer(6), integer(9)}));
-    REQUIRE(solns.second == DenseMatrix(4, 1, {integer(10), integer(11),
-                                               integer(13), integer(30)}));
+    REQUIRE(solns.first
+            == DenseMatrix(4, 4,
+                           {integer(2), integer(3), integer(4), integer(1),
+                            integer(2), integer(3), integer(4), integer(2),
+                            integer(3), integer(3), integer(4), integer(3),
+                            integer(8), integer(7), integer(6), integer(9)}));
+    REQUIRE(solns.second
+            == DenseMatrix(
+                   4, 1, {integer(10), integer(11), integer(13), integer(30)}));
 }
 
 TEST_CASE("is_a_LinearArgTrigEquation", "[Solve]")

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -148,30 +148,34 @@ TEST_CASE("test_dense_dense_addition(): matrices", "[matrices]")
     B = DenseMatrix(2, 2, {symbol("c"), integer(2), integer(-3), integer(0)});
     add_dense_dense(A, B, C);
 
-    REQUIRE(C == DenseMatrix(2, 2, {add(integer(1), symbol("c")),
-                                    add(symbol("a"), integer(2)), integer(-3),
-                                    symbol("b")}));
+    REQUIRE(C == DenseMatrix(2, 2,
+                             {add(integer(1), symbol("c")),
+                              add(symbol("a"), integer(2)), integer(-3),
+                              symbol("b")}));
 
     C = DenseMatrix(1, 4);
     A = DenseMatrix(1, 4, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     B = DenseMatrix(1, 4, {integer(3), integer(2), integer(-3), integer(0)});
     add_dense_dense(A, B, C);
 
-    REQUIRE(C
-            == DenseMatrix(1, 4, {add(integer(3), symbol("a")),
-                                  add(symbol("b"), integer(2)),
-                                  add(symbol("c"), integer(-3)), symbol("d")}));
+    REQUIRE(C == DenseMatrix(1, 4,
+                             {add(integer(3), symbol("a")),
+                              add(symbol("b"), integer(2)),
+                              add(symbol("c"), integer(-3)), symbol("d")}));
 
     C = DenseMatrix(2, 3);
-    A = DenseMatrix(2, 3, {integer(7), integer(4), integer(-3), integer(-5),
-                           symbol("a"), symbol("b")});
-    B = DenseMatrix(2, 3, {integer(10), integer(13), integer(5), integer(-7),
-                           symbol("c"), symbol("d")});
+    A = DenseMatrix(2, 3,
+                    {integer(7), integer(4), integer(-3), integer(-5),
+                     symbol("a"), symbol("b")});
+    B = DenseMatrix(2, 3,
+                    {integer(10), integer(13), integer(5), integer(-7),
+                     symbol("c"), symbol("d")});
     add_dense_dense(A, B, C);
 
-    REQUIRE(C == DenseMatrix(2, 3, {integer(17), integer(17), integer(2),
-                                    integer(-12), add(symbol("a"), symbol("c")),
-                                    add(symbol("b"), symbol("d"))}));
+    REQUIRE(C == DenseMatrix(2, 3,
+                             {integer(17), integer(17), integer(2),
+                              integer(-12), add(symbol("a"), symbol("c")),
+                              add(symbol("b"), symbol("d"))}));
 }
 
 TEST_CASE("test_add_dense_scalar(): matrices", "[matrices]")
@@ -211,28 +215,30 @@ TEST_CASE("test_dense_dense_multiplication(): matrices", "[matrices]")
     C = DenseMatrix(4, 3);
     mul_dense_dense(A, B, C);
 
-    REQUIRE(C
-            == DenseMatrix(4, 3, {integer(110), integer(200), integer(120),
-                                  integer(-33), integer(-60), integer(-36),
-                                  integer(77), integer(140), integer(84),
-                                  integer(-55), integer(-100), integer(-60)}));
+    REQUIRE(C == DenseMatrix(4, 3,
+                             {integer(110), integer(200), integer(120),
+                              integer(-33), integer(-60), integer(-36),
+                              integer(77), integer(140), integer(84),
+                              integer(-55), integer(-100), integer(-60)}));
 
-    A = DenseMatrix(3, 3, {symbol("a"), symbol("b"), symbol("c"), symbol("p"),
-                           symbol("q"), symbol("r"), symbol("u"), symbol("v"),
-                           symbol("w")});
+    A = DenseMatrix(3, 3,
+                    {symbol("a"), symbol("b"), symbol("c"), symbol("p"),
+                     symbol("q"), symbol("r"), symbol("u"), symbol("v"),
+                     symbol("w")});
     B = DenseMatrix(3, 1, {symbol("x"), symbol("y"), symbol("z")});
     C = DenseMatrix(3, 1);
     mul_dense_dense(A, B, C);
 
-    REQUIRE(C == DenseMatrix(3, 1, {add(add(mul(symbol("a"), symbol("x")),
-                                            mul(symbol("b"), symbol("y"))),
-                                        mul(symbol("c"), symbol("z"))),
-                                    add(add(mul(symbol("p"), symbol("x")),
-                                            mul(symbol("q"), symbol("y"))),
-                                        mul(symbol("r"), symbol("z"))),
-                                    add(add(mul(symbol("u"), symbol("x")),
-                                            mul(symbol("v"), symbol("y"))),
-                                        mul(symbol("w"), symbol("z")))}));
+    REQUIRE(C == DenseMatrix(3, 1,
+                             {add(add(mul(symbol("a"), symbol("x")),
+                                      mul(symbol("b"), symbol("y"))),
+                                  mul(symbol("c"), symbol("z"))),
+                              add(add(mul(symbol("p"), symbol("x")),
+                                      mul(symbol("q"), symbol("y"))),
+                                  mul(symbol("r"), symbol("z"))),
+                              add(add(mul(symbol("u"), symbol("x")),
+                                      mul(symbol("v"), symbol("y"))),
+                                  mul(symbol("w"), symbol("z")))}));
 }
 
 TEST_CASE("test_mul_dense_scalar(): matrices", "[matrices]")
@@ -259,15 +265,17 @@ TEST_CASE("test_transpose_dense(): matrices", "[matrices]")
     REQUIRE(B == DenseMatrix(2, 2,
                              {integer(1), integer(3), integer(2), integer(4)}));
 
-    A = DenseMatrix(3, 3, {symbol("a"), symbol("b"), symbol("c"), symbol("p"),
-                           symbol("q"), symbol("r"), symbol("u"), symbol("v"),
-                           symbol("w")});
+    A = DenseMatrix(3, 3,
+                    {symbol("a"), symbol("b"), symbol("c"), symbol("p"),
+                     symbol("q"), symbol("r"), symbol("u"), symbol("v"),
+                     symbol("w")});
     B = DenseMatrix(3, 3);
     transpose_dense(A, B);
 
-    REQUIRE(B == DenseMatrix(3, 3, {symbol("a"), symbol("p"), symbol("u"),
-                                    symbol("b"), symbol("q"), symbol("v"),
-                                    symbol("c"), symbol("r"), symbol("w")}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {symbol("a"), symbol("p"), symbol("u"),
+                              symbol("b"), symbol("q"), symbol("v"),
+                              symbol("c"), symbol("r"), symbol("w")}));
 
     RCP<const Basic> x = symbol("x");
     RCP<const Basic> y = symbol("y");
@@ -282,25 +290,29 @@ TEST_CASE("test_transpose_dense(): matrices", "[matrices]")
 
 TEST_CASE("test_submatrix_dense(): matrices", "[matrices]")
 {
-    DenseMatrix A = DenseMatrix(3, 3, {symbol("a"), symbol("b"), symbol("c"),
-                                       symbol("p"), symbol("q"), symbol("r"),
-                                       symbol("u"), symbol("v"), symbol("w")});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {symbol("a"), symbol("b"), symbol("c"),
+                                 symbol("p"), symbol("q"), symbol("r"),
+                                 symbol("u"), symbol("v"), symbol("w")});
     DenseMatrix B = DenseMatrix(3, 2);
     submatrix_dense(A, B, 0, 1, 2, 2);
 
-    REQUIRE(B == DenseMatrix(3, 2, {symbol("b"), symbol("c"), symbol("q"),
-                                    symbol("r"), symbol("v"), symbol("w")}));
+    REQUIRE(B == DenseMatrix(3, 2,
+                             {symbol("b"), symbol("c"), symbol("q"),
+                              symbol("r"), symbol("v"), symbol("w")}));
 
-    A = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(5), integer(6), integer(7), integer(8),
-                           integer(9), integer(10), integer(11), integer(12),
-                           integer(13), integer(14), integer(15), integer(16)});
+    A = DenseMatrix(4, 4,
+                    {integer(1), integer(2), integer(3), integer(4), integer(5),
+                     integer(6), integer(7), integer(8), integer(9),
+                     integer(10), integer(11), integer(12), integer(13),
+                     integer(14), integer(15), integer(16)});
     B = DenseMatrix(3, 3);
     submatrix_dense(A, B, 1, 1, 3, 3);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(6), integer(7), integer(8),
-                                    integer(10), integer(11), integer(12),
-                                    integer(14), integer(15), integer(16)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(6), integer(7), integer(8), integer(10),
+                              integer(11), integer(12), integer(14),
+                              integer(15), integer(16)}));
 }
 
 TEST_CASE("test_row_join(): matrices", "[matrices]")
@@ -309,8 +321,9 @@ TEST_CASE("test_row_join(): matrices", "[matrices]")
         2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     DenseMatrix B = DenseMatrix(2, 1, {symbol("e"), symbol("f")});
     A.row_join(B);
-    REQUIRE(A == DenseMatrix(2, 3, {symbol("a"), symbol("b"), symbol("e"),
-                                    symbol("c"), symbol("d"), symbol("f")}));
+    REQUIRE(A == DenseMatrix(2, 3,
+                             {symbol("a"), symbol("b"), symbol("e"),
+                              symbol("c"), symbol("d"), symbol("f")}));
 }
 
 TEST_CASE("test_col_join(): matrices", "[matrices]")
@@ -319,8 +332,9 @@ TEST_CASE("test_col_join(): matrices", "[matrices]")
         2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     DenseMatrix B = DenseMatrix(1, 2, {symbol("e"), symbol("f")});
     A.col_join(B);
-    REQUIRE(A == DenseMatrix(3, 2, {symbol("a"), symbol("b"), symbol("c"),
-                                    symbol("d"), symbol("e"), symbol("f")}));
+    REQUIRE(A == DenseMatrix(3, 2,
+                             {symbol("a"), symbol("b"), symbol("c"),
+                              symbol("d"), symbol("e"), symbol("f")}));
 }
 
 TEST_CASE("test_row_insert(): matrices", "[matrices]")
@@ -329,18 +343,21 @@ TEST_CASE("test_row_insert(): matrices", "[matrices]")
         2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     DenseMatrix B = DenseMatrix(1, 2, {symbol("e"), symbol("f")});
     A.row_insert(B, 0);
-    CHECK(A == DenseMatrix(3, 2, {symbol("e"), symbol("f"), symbol("a"),
-                                  symbol("b"), symbol("c"), symbol("d")}));
+    CHECK(A == DenseMatrix(3, 2,
+                           {symbol("e"), symbol("f"), symbol("a"), symbol("b"),
+                            symbol("c"), symbol("d")}));
     DenseMatrix C = DenseMatrix(
         2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     C.row_insert(B, 1);
-    CHECK(C == DenseMatrix(3, 2, {symbol("a"), symbol("b"), symbol("e"),
-                                  symbol("f"), symbol("c"), symbol("d")}));
+    CHECK(C == DenseMatrix(3, 2,
+                           {symbol("a"), symbol("b"), symbol("e"), symbol("f"),
+                            symbol("c"), symbol("d")}));
     DenseMatrix D = DenseMatrix(
         2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     D.row_insert(B, 2);
-    CHECK(D == DenseMatrix(3, 2, {symbol("a"), symbol("b"), symbol("c"),
-                                  symbol("d"), symbol("e"), symbol("f")}));
+    CHECK(D == DenseMatrix(3, 2,
+                           {symbol("a"), symbol("b"), symbol("c"), symbol("d"),
+                            symbol("e"), symbol("f")}));
 }
 
 TEST_CASE("test_col_insert(): matrices", "[matrices]")
@@ -349,18 +366,21 @@ TEST_CASE("test_col_insert(): matrices", "[matrices]")
         2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     DenseMatrix B = DenseMatrix(2, 1, {symbol("e"), symbol("f")});
     A.col_insert(B, 0);
-    CHECK(A == DenseMatrix(2, 3, {symbol("e"), symbol("a"), symbol("b"),
-                                  symbol("f"), symbol("c"), symbol("d")}));
+    CHECK(A == DenseMatrix(2, 3,
+                           {symbol("e"), symbol("a"), symbol("b"), symbol("f"),
+                            symbol("c"), symbol("d")}));
     DenseMatrix C = DenseMatrix(
         2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     C.col_insert(B, 1);
-    CHECK(C == DenseMatrix(2, 3, {symbol("a"), symbol("e"), symbol("b"),
-                                  symbol("c"), symbol("f"), symbol("d")}));
+    CHECK(C == DenseMatrix(2, 3,
+                           {symbol("a"), symbol("e"), symbol("b"), symbol("c"),
+                            symbol("f"), symbol("d")}));
     DenseMatrix D = DenseMatrix(
         2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     D.col_insert(B, 2);
-    CHECK(D == DenseMatrix(2, 3, {symbol("a"), symbol("b"), symbol("e"),
-                                  symbol("c"), symbol("d"), symbol("f")}));
+    CHECK(D == DenseMatrix(2, 3,
+                           {symbol("a"), symbol("b"), symbol("e"), symbol("c"),
+                            symbol("d"), symbol("f")}));
 }
 
 TEST_CASE("test_row_del(): matrices", "[matrices]")
@@ -385,12 +405,14 @@ TEST_CASE("test_col_del(): matrices", "[matrices]")
 
 TEST_CASE("test_column_exchange_dense(): matrices", "[matrices]")
 {
-    DenseMatrix A = DenseMatrix(3, 3, {symbol("a"), symbol("b"), symbol("c"),
-                                       symbol("p"), symbol("q"), symbol("r"),
-                                       symbol("u"), symbol("v"), symbol("w")});
-    DenseMatrix B = DenseMatrix(3, 3, {symbol("c"), symbol("b"), symbol("a"),
-                                       symbol("r"), symbol("q"), symbol("p"),
-                                       symbol("w"), symbol("v"), symbol("u")});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {symbol("a"), symbol("b"), symbol("c"),
+                                 symbol("p"), symbol("q"), symbol("r"),
+                                 symbol("u"), symbol("v"), symbol("w")});
+    DenseMatrix B = DenseMatrix(3, 3,
+                                {symbol("c"), symbol("b"), symbol("a"),
+                                 symbol("r"), symbol("q"), symbol("p"),
+                                 symbol("w"), symbol("v"), symbol("u")});
     column_exchange_dense(A, 0, 2);
     REQUIRE(A == B);
 }
@@ -410,18 +432,19 @@ TEST_CASE("test_pivoted_gaussian_elimination(): matrices", "[matrices]")
     B = DenseMatrix(2, 2);
     pivoted_gaussian_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(2, 2, {integer(1), div(integer(3), integer(2)),
-                                    integer(0), div(minus_one, integer(2))}));
+    REQUIRE(B == DenseMatrix(2, 2,
+                             {integer(1), div(integer(3), integer(2)),
+                              integer(0), div(minus_one, integer(2))}));
 
     A = DenseMatrix(2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     B = DenseMatrix(2, 2);
     pivoted_gaussian_elimination(A, B, pl);
 
-    REQUIRE(
-        B == DenseMatrix(
-                 2, 2, {integer(1), div(symbol("b"), symbol("a")), integer(0),
-                        sub(symbol("d"),
-                            mul(symbol("c"), div(symbol("b"), symbol("a"))))}));
+    REQUIRE(B == DenseMatrix(
+                     2, 2,
+                     {integer(1), div(symbol("b"), symbol("a")), integer(0),
+                      sub(symbol("d"),
+                          mul(symbol("c"), div(symbol("b"), symbol("a"))))}));
 
     A = DenseMatrix(3, 3,
                     {integer(1), integer(1), integer(1), integer(2), integer(2),
@@ -429,9 +452,10 @@ TEST_CASE("test_pivoted_gaussian_elimination(): matrices", "[matrices]")
     B = DenseMatrix(3, 3);
     pivoted_gaussian_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(1), integer(1),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(0)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(1), integer(1), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(0)}));
 
     A = DenseMatrix(3, 3,
                     {integer(1), integer(1), integer(1), integer(2), integer(2),
@@ -439,9 +463,10 @@ TEST_CASE("test_pivoted_gaussian_elimination(): matrices", "[matrices]")
     B = DenseMatrix(3, 3);
     pivoted_gaussian_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(1), integer(1),
-                                    integer(0), integer(1), integer(2),
-                                    integer(0), integer(0), integer(3)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(1), integer(1), integer(0),
+                              integer(1), integer(2), integer(0), integer(0),
+                              integer(3)}));
 }
 
 TEST_CASE("test_fraction_free_gaussian_elimination(): matrices", "[matrices]")
@@ -469,23 +494,26 @@ TEST_CASE("test_fraction_free_gaussian_elimination(): matrices", "[matrices]")
     A = DenseMatrix(2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
     fraction_free_gaussian_elimination(A, B);
 
-    REQUIRE(B == DenseMatrix(2, 2, {symbol("a"), symbol("b"), integer(0),
-                                    sub(mul(symbol("a"), symbol("d")),
-                                        mul(symbol("b"), symbol("c")))}));
+    REQUIRE(B == DenseMatrix(2, 2,
+                             {symbol("a"), symbol("b"), integer(0),
+                              sub(mul(symbol("a"), symbol("d")),
+                                  mul(symbol("b"), symbol("c")))}));
 
     // Test case taken from :
     // Fraction-Free Algorithms for Linear and Polynomial Equations, George C
     // Nakos,
     // Peter R Turner et. al.
-    A = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(2), integer(2), integer(3), integer(4),
-                           integer(3), integer(3), integer(3), integer(4),
-                           integer(9), integer(8), integer(7), integer(6)});
+    A = DenseMatrix(4, 4,
+                    {integer(1), integer(2), integer(3), integer(4), integer(2),
+                     integer(2), integer(3), integer(4), integer(3), integer(3),
+                     integer(3), integer(4), integer(9), integer(8), integer(7),
+                     integer(6)});
     B = DenseMatrix(4, 4);
     fraction_free_gaussian_elimination(A, B);
 
-    REQUIRE(B == DenseMatrix(
-                     4, 4, {integer(1), integer(2), integer(3), integer(4),
+    REQUIRE(B
+            == DenseMatrix(4, 4,
+                           {integer(1), integer(2), integer(3), integer(4),
                             integer(0), integer(-2), integer(-3), integer(-4),
                             integer(0), integer(0), integer(3), integer(4),
                             integer(0), integer(0), integer(0), integer(-10)}));
@@ -493,10 +521,11 @@ TEST_CASE("test_fraction_free_gaussian_elimination(): matrices", "[matrices]")
     // Test case taken from :
     // A SIMPLIFIED FRACTION-FREE INTEGER GAUSS ELIMINATION ALGORITHM
     // Peter R. Turner
-    A = DenseMatrix(4, 4, {integer(8), integer(7), integer(4), integer(1),
-                           integer(4), integer(6), integer(7), integer(3),
-                           integer(6), integer(3), integer(4), integer(6),
-                           integer(4), integer(5), integer(8), integer(2)});
+    A = DenseMatrix(4, 4,
+                    {integer(8), integer(7), integer(4), integer(1), integer(4),
+                     integer(6), integer(7), integer(3), integer(6), integer(3),
+                     integer(4), integer(6), integer(4), integer(5), integer(8),
+                     integer(2)});
     B = DenseMatrix(4, 4);
     fraction_free_gaussian_elimination(A, B);
 
@@ -509,26 +538,30 @@ TEST_CASE("test_fraction_free_gaussian_elimination(): matrices", "[matrices]")
 
     // Below two test cases are taken from:
     // http://www.mathworks.in/help/symbolic/mupad_ref/linalg-gausselim.html
-    A = DenseMatrix(3, 3, {integer(1), integer(2), integer(-1), integer(1),
-                           integer(0), integer(1), integer(2), integer(-1),
-                           integer(4)});
+    A = DenseMatrix(3, 3,
+                    {integer(1), integer(2), integer(-1), integer(1),
+                     integer(0), integer(1), integer(2), integer(-1),
+                     integer(4)});
     B = DenseMatrix(3, 3);
     fraction_free_gaussian_elimination(A, B);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(2), integer(-1),
-                                    integer(0), integer(-2), integer(2),
-                                    integer(0), integer(0), integer(-2)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(2), integer(-1), integer(0),
+                              integer(-2), integer(2), integer(0), integer(0),
+                              integer(-2)}));
 
-    A = DenseMatrix(3, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(-1), integer(0), integer(1), integer(0),
-                           integer(3), integer(5), integer(6), integer(9)});
+    A = DenseMatrix(3, 4,
+                    {integer(1), integer(2), integer(3), integer(4),
+                     integer(-1), integer(0), integer(1), integer(0),
+                     integer(3), integer(5), integer(6), integer(9)});
     B = DenseMatrix(3, 4);
     fraction_free_gaussian_elimination(A, B);
 
-    REQUIRE(B == DenseMatrix(3, 4, {integer(1), integer(2), integer(3),
-                                    integer(4), integer(0), integer(2),
-                                    integer(4), integer(4), integer(0),
-                                    integer(0), integer(-2), integer(-2)}));
+    REQUIRE(B
+            == DenseMatrix(3, 4,
+                           {integer(1), integer(2), integer(3), integer(4),
+                            integer(0), integer(2), integer(4), integer(4),
+                            integer(0), integer(0), integer(-2), integer(-2)}));
 }
 
 TEST_CASE("test_pivoted_fraction_free_gaussian_elimination(): matrices",
@@ -543,29 +576,33 @@ TEST_CASE("test_pivoted_fraction_free_gaussian_elimination(): matrices",
     REQUIRE(B == DenseMatrix(
                      2, 2, {integer(1), integer(2), integer(0), integer(-2)}));
 
-    A = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(2), integer(2), integer(3), integer(4),
-                           integer(3), integer(3), integer(3), integer(4),
-                           integer(9), integer(8), integer(7), integer(6)});
+    A = DenseMatrix(4, 4,
+                    {integer(1), integer(2), integer(3), integer(4), integer(2),
+                     integer(2), integer(3), integer(4), integer(3), integer(3),
+                     integer(3), integer(4), integer(9), integer(8), integer(7),
+                     integer(6)});
     B = DenseMatrix(4, 4);
     pivoted_fraction_free_gaussian_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(
-                     4, 4, {integer(1), integer(2), integer(3), integer(4),
+    REQUIRE(B
+            == DenseMatrix(4, 4,
+                           {integer(1), integer(2), integer(3), integer(4),
                             integer(0), integer(-2), integer(-3), integer(-4),
                             integer(0), integer(0), integer(3), integer(4),
                             integer(0), integer(0), integer(0), integer(-10)}));
 
-    A = DenseMatrix(3, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(-1), integer(0), integer(1), integer(0),
-                           integer(3), integer(5), integer(6), integer(9)});
+    A = DenseMatrix(3, 4,
+                    {integer(1), integer(2), integer(3), integer(4),
+                     integer(-1), integer(0), integer(1), integer(0),
+                     integer(3), integer(5), integer(6), integer(9)});
     B = DenseMatrix(3, 4);
     pivoted_fraction_free_gaussian_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 4, {integer(1), integer(2), integer(3),
-                                    integer(4), integer(0), integer(2),
-                                    integer(4), integer(4), integer(0),
-                                    integer(0), integer(-2), integer(-2)}));
+    REQUIRE(B
+            == DenseMatrix(3, 4,
+                           {integer(1), integer(2), integer(3), integer(4),
+                            integer(0), integer(2), integer(4), integer(4),
+                            integer(0), integer(0), integer(-2), integer(-2)}));
 
     A = DenseMatrix(3, 3,
                     {integer(1), integer(1), integer(1), integer(2), integer(2),
@@ -573,9 +610,10 @@ TEST_CASE("test_pivoted_fraction_free_gaussian_elimination(): matrices",
     B = DenseMatrix(3, 3);
     pivoted_fraction_free_gaussian_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(1), integer(1),
-                                    integer(0), integer(0), integer(0),
-                                    integer(0), integer(0), integer(0)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(1), integer(1), integer(0),
+                              integer(0), integer(0), integer(0), integer(0),
+                              integer(0)}));
 
     // These tests won't work with fraction_free_gaussian_elimination
     A = DenseMatrix(3, 3,
@@ -584,9 +622,10 @@ TEST_CASE("test_pivoted_fraction_free_gaussian_elimination(): matrices",
     B = DenseMatrix(3, 3);
     pivoted_fraction_free_gaussian_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(1), integer(1),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(0)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(1), integer(1), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(0)}));
 
     A = DenseMatrix(3, 3,
                     {integer(1), integer(1), integer(1), integer(2), integer(2),
@@ -594,9 +633,10 @@ TEST_CASE("test_pivoted_fraction_free_gaussian_elimination(): matrices",
     B = DenseMatrix(3, 3);
     pivoted_fraction_free_gaussian_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(1), integer(1),
-                                    integer(0), integer(2), integer(4),
-                                    integer(0), integer(0), integer(6)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(1), integer(1), integer(0),
+                              integer(2), integer(4), integer(0), integer(0),
+                              integer(6)}));
 }
 
 TEST_CASE("test_pivoted_gauss_jordan_elimination(): matrices", "[matrices]")
@@ -641,23 +681,27 @@ TEST_CASE("test_pivoted_gauss_jordan_elimination(): matrices", "[matrices]")
     REQUIRE(B == DenseMatrix(2, 2,
                              {integer(1), integer(0), integer(0), integer(0)}));
 
-    A = DenseMatrix(3, 3, {integer(1), integer(2), integer(3), integer(-1),
-                           integer(7), integer(6), integer(4), integer(5),
-                           integer(2)});
+    A = DenseMatrix(3, 3,
+                    {integer(1), integer(2), integer(3), integer(-1),
+                     integer(7), integer(6), integer(4), integer(5),
+                     integer(2)});
     B = DenseMatrix(3, 3);
     pivoted_gauss_jordan_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(1)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(1)}));
 
-    A = DenseMatrix(3, 2, {integer(-9), integer(4), integer(3), integer(-1),
-                           integer(7), integer(6)});
+    A = DenseMatrix(3, 2,
+                    {integer(-9), integer(4), integer(3), integer(-1),
+                     integer(7), integer(6)});
     B = DenseMatrix(3, 2);
     pivoted_gauss_jordan_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 2, {integer(1), integer(0), integer(0),
-                                    integer(1), integer(0), integer(0)}));
+    REQUIRE(B == DenseMatrix(3, 2,
+                             {integer(1), integer(0), integer(0), integer(1),
+                              integer(0), integer(0)}));
 
     // These tests won't work with gauss_jordan_elimination
     A = DenseMatrix(3, 3,
@@ -666,9 +710,10 @@ TEST_CASE("test_pivoted_gauss_jordan_elimination(): matrices", "[matrices]")
     B = DenseMatrix(3, 3);
     pivoted_gauss_jordan_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(0), integer(1),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(0)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(1), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(0)}));
 
     A = DenseMatrix(3, 3,
                     {integer(1), integer(1), integer(1), integer(2), integer(2),
@@ -676,9 +721,10 @@ TEST_CASE("test_pivoted_gauss_jordan_elimination(): matrices", "[matrices]")
     B = DenseMatrix(3, 3);
     pivoted_gauss_jordan_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(1)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(1)}));
 }
 
 TEST_CASE("test_fraction_free_gauss_jordan_elimination(): matrices",
@@ -692,23 +738,26 @@ TEST_CASE("test_fraction_free_gauss_jordan_elimination(): matrices",
     REQUIRE(B == DenseMatrix(
                      2, 2, {integer(-2), integer(0), integer(0), integer(-2)}));
 
-    A = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(2), integer(2), integer(3), integer(4),
-                           integer(3), integer(3), integer(3), integer(4),
-                           integer(9), integer(8), integer(7), integer(6)});
+    A = DenseMatrix(4, 4,
+                    {integer(1), integer(2), integer(3), integer(4), integer(2),
+                     integer(2), integer(3), integer(4), integer(3), integer(3),
+                     integer(3), integer(4), integer(9), integer(8), integer(7),
+                     integer(6)});
     B = DenseMatrix(4, 4);
     fraction_free_gauss_jordan_elimination(A, B);
 
-    REQUIRE(B == DenseMatrix(
-                     4, 4, {integer(-10), integer(0), integer(0), integer(0),
+    REQUIRE(B
+            == DenseMatrix(4, 4,
+                           {integer(-10), integer(0), integer(0), integer(0),
                             integer(0), integer(-10), integer(0), integer(0),
                             integer(0), integer(0), integer(-10), integer(0),
                             integer(0), integer(0), integer(0), integer(-10)}));
 
-    A = DenseMatrix(4, 4, {integer(1), integer(7), integer(5), integer(4),
-                           integer(7), integer(2), integer(2), integer(4),
-                           integer(3), integer(6), integer(3), integer(4),
-                           integer(9), integer(5), integer(7), integer(5)});
+    A = DenseMatrix(4, 4,
+                    {integer(1), integer(7), integer(5), integer(4), integer(7),
+                     integer(2), integer(2), integer(4), integer(3), integer(6),
+                     integer(3), integer(4), integer(9), integer(5), integer(7),
+                     integer(5)});
     fraction_free_gauss_jordan_elimination(A, B);
 
     REQUIRE(
@@ -724,15 +773,17 @@ TEST_CASE("test_pivoted_fraction_free_gauss_jordan_elimination(): matrices",
 {
     // These tests won't work with fraction_free_gauss_jordan_elimination
     permutelist pl;
-    DenseMatrix A = DenseMatrix(3, 3, {integer(1), integer(1), integer(1),
-                                       integer(2), integer(2), integer(2),
-                                       integer(3), integer(4), integer(3)});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {integer(1), integer(1), integer(1), integer(2),
+                                 integer(2), integer(2), integer(3), integer(4),
+                                 integer(3)});
     DenseMatrix B = DenseMatrix(3, 3);
     pivoted_fraction_free_gauss_jordan_elimination(A, B, pl);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(0), integer(1),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(0)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(1), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(0)}));
 
     A = DenseMatrix(3, 3,
                     {integer(1), integer(1), integer(1), integer(2), integer(2),
@@ -742,13 +793,15 @@ TEST_CASE("test_pivoted_fraction_free_gauss_jordan_elimination(): matrices",
 
     // Here the diagonal entry is 6 although the det(A) = -6, this because we
     // have interchanged two rows
-    REQUIRE(B == DenseMatrix(3, 3, {integer(6), integer(0), integer(0),
-                                    integer(0), integer(6), integer(0),
-                                    integer(0), integer(0), integer(6)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(6), integer(0), integer(0), integer(0),
+                              integer(6), integer(0), integer(0), integer(0),
+                              integer(6)}));
 
-    A = DenseMatrix(3, 4, {integer(1), integer(1), integer(1), integer(6),
-                           integer(1), integer(1), integer(1), integer(8),
-                           integer(4), integer(6), integer(8), integer(18)});
+    A = DenseMatrix(3, 4,
+                    {integer(1), integer(1), integer(1), integer(6), integer(1),
+                     integer(1), integer(1), integer(8), integer(4), integer(6),
+                     integer(8), integer(18)});
     B = DenseMatrix(3, 4);
     pivoted_fraction_free_gauss_jordan_elimination(A, B, pl);
     REQUIRE(B == DenseMatrix(3, 4,
@@ -760,20 +813,23 @@ TEST_CASE("test_pivoted_fraction_free_gauss_jordan_elimination(): matrices",
 TEST_CASE("reduced_row_echelon_form(): matrices", "[matrices]")
 {
     SymEngine::vec_uint pivots;
-    DenseMatrix A = DenseMatrix(3, 3, {integer(1), integer(1), integer(1),
-                                       integer(2), integer(2), integer(2),
-                                       integer(3), integer(4), integer(3)});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {integer(1), integer(1), integer(1), integer(2),
+                                 integer(2), integer(2), integer(3), integer(4),
+                                 integer(3)});
     DenseMatrix B = DenseMatrix(3, 3);
     reduced_row_echelon_form(A, B, pivots);
 
-    REQUIRE(B == DenseMatrix(3, 3, {integer(1), integer(0), integer(1),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(0)}));
+    REQUIRE(B == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(1), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(0)}));
     pivots.clear();
 
-    A = DenseMatrix(3, 4, {integer(1), integer(1), integer(1), integer(6),
-                           integer(1), integer(1), integer(1), integer(8),
-                           integer(4), integer(6), integer(8), integer(18)});
+    A = DenseMatrix(3, 4,
+                    {integer(1), integer(1), integer(1), integer(6), integer(1),
+                     integer(1), integer(1), integer(8), integer(4), integer(6),
+                     integer(8), integer(18)});
     B = DenseMatrix(3, 4);
     reduced_row_echelon_form(A, B, pivots);
     REQUIRE(B == DenseMatrix(3, 4,
@@ -784,9 +840,10 @@ TEST_CASE("reduced_row_echelon_form(): matrices", "[matrices]")
     REQUIRE(SymEngine::unified_eq(pivots, {0, 1, 3}));
     pivots.clear();
 
-    A = DenseMatrix(3, 4, {integer(0), integer(1), integer(1), integer(6),
-                           integer(0), integer(1), integer(1), integer(8),
-                           integer(0), integer(6), integer(8), integer(18)});
+    A = DenseMatrix(3, 4,
+                    {integer(0), integer(1), integer(1), integer(6), integer(0),
+                     integer(1), integer(1), integer(8), integer(0), integer(6),
+                     integer(8), integer(18)});
     B = DenseMatrix(3, 4);
     reduced_row_echelon_form(A, B, pivots);
     REQUIRE(B == DenseMatrix(3, 4,
@@ -808,10 +865,11 @@ TEST_CASE("test_fraction_free_gaussian_elimination_solve(): matrices",
 
     REQUIRE(x == DenseMatrix(2, 1, {integer(4), integer(1)}));
 
-    A = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(2), integer(2), integer(3), integer(4),
-                           integer(3), integer(3), integer(3), integer(4),
-                           integer(9), integer(8), integer(7), integer(6)});
+    A = DenseMatrix(4, 4,
+                    {integer(1), integer(2), integer(3), integer(4), integer(2),
+                     integer(2), integer(3), integer(4), integer(3), integer(3),
+                     integer(3), integer(4), integer(9), integer(8), integer(7),
+                     integer(6)});
     b = DenseMatrix(4, 1, {integer(10), integer(11), integer(13), integer(30)});
     x = DenseMatrix(4, 1);
     fraction_free_gaussian_elimination_solve(A, b, x);
@@ -837,8 +895,9 @@ TEST_CASE("test_fraction_free_gaussian_elimination_solve(): matrices",
     // simplified. See: https://github.com/sympy/symengine/issues/183
     A = DenseMatrix(2, 2, {symbol("a"), symbol("b"), symbol("b"), symbol("a")});
     b = DenseMatrix(
-        2, 1, {add(pow(symbol("a"), integer(2)), pow(symbol("b"), integer(2))),
-               mul(integer(2), mul(symbol("a"), symbol("b")))});
+        2, 1,
+        {add(pow(symbol("a"), integer(2)), pow(symbol("b"), integer(2))),
+         mul(integer(2), mul(symbol("a"), symbol("b")))});
     x = DenseMatrix(2, 1);
     fraction_free_gaussian_elimination_solve(A, b, x);
 
@@ -873,10 +932,11 @@ TEST_CASE("test_fraction_free_gauss_jordan_solve(): matrices", "[matrices]")
 
     REQUIRE(x == DenseMatrix(2, 1, {integer(4), integer(1)}));
 
-    A = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(2), integer(2), integer(3), integer(4),
-                           integer(3), integer(3), integer(3), integer(4),
-                           integer(9), integer(8), integer(7), integer(6)});
+    A = DenseMatrix(4, 4,
+                    {integer(1), integer(2), integer(3), integer(4), integer(2),
+                     integer(2), integer(3), integer(4), integer(3), integer(3),
+                     integer(3), integer(4), integer(9), integer(8), integer(7),
+                     integer(6)});
     b = DenseMatrix(4, 1, {integer(10), integer(11), integer(13), integer(30)});
     x = DenseMatrix(4, 1);
     fraction_free_gauss_jordan_solve(A, b, x);
@@ -900,21 +960,21 @@ TEST_CASE("test_fraction_free_LU(): matrices", "[matrices]")
     // Example 3, page 14, Nakos, G. C., Turner, P. R., Williams, R. M. (1997).
     // Fraction-free algorithms for linear and polynomial equations.
     // ACM SIGSAM Bulletin, 31(3), 11–19. doi:10.1145/271130.271133.
-    DenseMatrix A
-        = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                             integer(2), integer(2), integer(3), integer(4),
-                             integer(3), integer(3), integer(3), integer(4),
-                             integer(9), integer(8), integer(7), integer(6)});
+    DenseMatrix A = DenseMatrix(
+        4, 4,
+        {integer(1), integer(2), integer(3), integer(4), integer(2), integer(2),
+         integer(3), integer(4), integer(3), integer(3), integer(3), integer(4),
+         integer(9), integer(8), integer(7), integer(6)});
     DenseMatrix LU = DenseMatrix(4, 4);
     DenseMatrix U = DenseMatrix(4, 4);
     fraction_free_LU(A, LU);
 
-    REQUIRE(
-        LU == DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                                 integer(2), integer(-2), integer(-3),
-                                 integer(-4), integer(3), integer(-3),
-                                 integer(3), integer(4), integer(9),
-                                 integer(-10), integer(10), integer(-10)}));
+    REQUIRE(LU == DenseMatrix(4, 4,
+                              {integer(1), integer(2), integer(3), integer(4),
+                               integer(2), integer(-2), integer(-3),
+                               integer(-4), integer(3), integer(-3), integer(3),
+                               integer(4), integer(9), integer(-10),
+                               integer(10), integer(-10)}));
 
     DenseMatrix b = DenseMatrix(
         4, 1, {integer(10), integer(11), integer(13), integer(30)});
@@ -925,8 +985,9 @@ TEST_CASE("test_fraction_free_LU(): matrices", "[matrices]")
     // modified b from forward substitution. This will find the solutions.
     forward_substitution(LU, b, x);
 
-    REQUIRE(x == DenseMatrix(4, 1, {integer(10), integer(-9), integer(7),
-                                    integer(-10)}));
+    REQUIRE(
+        x == DenseMatrix(4, 1,
+                         {integer(10), integer(-9), integer(7), integer(-10)}));
 
     back_substitution(LU, x, b);
 
@@ -936,36 +997,41 @@ TEST_CASE("test_fraction_free_LU(): matrices", "[matrices]")
 
 TEST_CASE("test_LU(): matrices", "[matrices]")
 {
-    DenseMatrix A = DenseMatrix(3, 3, {integer(1), integer(3), integer(5),
-                                       integer(2), integer(5), integer(6),
-                                       integer(8), integer(3), integer(1)});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {integer(1), integer(3), integer(5), integer(2),
+                                 integer(5), integer(6), integer(8), integer(3),
+                                 integer(1)});
     DenseMatrix L = DenseMatrix(3, 3);
     DenseMatrix U = DenseMatrix(3, 3);
     LU(A, L, U);
 
-    REQUIRE(L == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(2), integer(1), integer(0),
-                                    integer(8), integer(21), integer(1)}));
-    REQUIRE(U == DenseMatrix(3, 3, {integer(1), integer(3), integer(5),
-                                    integer(0), integer(-1), integer(-4),
-                                    integer(0), integer(0), integer(45)}));
+    REQUIRE(L == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(2),
+                              integer(1), integer(0), integer(8), integer(21),
+                              integer(1)}));
+    REQUIRE(U == DenseMatrix(3, 3,
+                             {integer(1), integer(3), integer(5), integer(0),
+                              integer(-1), integer(-4), integer(0), integer(0),
+                              integer(45)}));
 
-    A = DenseMatrix(4, 4, {integer(1), integer(2), integer(6), integer(3),
-                           integer(3), integer(5), integer(6), integer(-5),
-                           integer(2), integer(4), integer(5), integer(6),
-                           integer(6), integer(-10), integer(2), integer(-30)});
+    A = DenseMatrix(4, 4,
+                    {integer(1), integer(2), integer(6), integer(3), integer(3),
+                     integer(5), integer(6), integer(-5), integer(2),
+                     integer(4), integer(5), integer(6), integer(6),
+                     integer(-10), integer(2), integer(-30)});
     L = DenseMatrix(4, 4);
     U = DenseMatrix(4, 4);
     LU(A, L, U);
 
-    REQUIRE(
-        L == DenseMatrix(4, 4, {integer(1), integer(0), integer(0), integer(0),
-                                integer(3), integer(1), integer(0), integer(0),
-                                integer(2), integer(0), integer(1), integer(0),
-                                integer(6), integer(22),
-                                div(integer(-230), integer(7)), integer(1)}));
-    REQUIRE(U == DenseMatrix(
-                     4, 4, {integer(1), integer(2), integer(6), integer(3),
+    REQUIRE(L == DenseMatrix(4, 4,
+                             {integer(1), integer(0), integer(0), integer(0),
+                              integer(3), integer(1), integer(0), integer(0),
+                              integer(2), integer(0), integer(1), integer(0),
+                              integer(6), integer(22),
+                              div(integer(-230), integer(7)), integer(1)}));
+    REQUIRE(U
+            == DenseMatrix(4, 4,
+                           {integer(1), integer(2), integer(6), integer(3),
                             integer(0), integer(-1), integer(-12), integer(-14),
                             integer(0), integer(0), integer(-7), integer(0),
                             integer(0), integer(0), integer(0), integer(260)}));
@@ -982,21 +1048,24 @@ TEST_CASE("test_LU(): matrices", "[matrices]")
 
 TEST_CASE("test_pivoted_LU(): matrices", "[matrices]")
 {
-    DenseMatrix A = DenseMatrix(3, 3, {integer(1), integer(3), integer(5),
-                                       integer(2), integer(6), integer(6),
-                                       integer(8), integer(3), integer(1)});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {integer(1), integer(3), integer(5), integer(2),
+                                 integer(6), integer(6), integer(8), integer(3),
+                                 integer(1)});
     DenseMatrix L = DenseMatrix(3, 3);
     DenseMatrix U = DenseMatrix(3, 3);
     permutelist pl;
     pivoted_LU(A, L, U, pl);
     REQUIRE(pl == permutelist({{2, 1}}));
 
-    REQUIRE(L == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(8), integer(1), integer(0),
-                                    integer(2), integer(0), integer(1)}));
-    REQUIRE(U == DenseMatrix(3, 3, {integer(1), integer(3), integer(5),
-                                    integer(0), integer(-21), integer(-39),
-                                    integer(0), integer(0), integer(-4)}));
+    REQUIRE(L == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(8),
+                              integer(1), integer(0), integer(2), integer(0),
+                              integer(1)}));
+    REQUIRE(U == DenseMatrix(3, 3,
+                             {integer(1), integer(3), integer(5), integer(0),
+                              integer(-21), integer(-39), integer(0),
+                              integer(0), integer(-4)}));
 
     pl.clear();
 
@@ -1008,12 +1077,14 @@ TEST_CASE("test_pivoted_LU(): matrices", "[matrices]")
 
     REQUIRE(pl == permutelist({{1, 0}, {2, 1}}));
 
-    REQUIRE(L == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(4), integer(1), integer(0),
-                                    integer(0), integer(0), integer(1)}));
-    REQUIRE(U == DenseMatrix(3, 3, {integer(2), integer(6), integer(6),
-                                    integer(0), integer(-21), integer(-23),
-                                    integer(0), integer(0), integer(5)}));
+    REQUIRE(L == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(4),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(1)}));
+    REQUIRE(U == DenseMatrix(3, 3,
+                             {integer(2), integer(6), integer(6), integer(0),
+                              integer(-21), integer(-23), integer(0),
+                              integer(0), integer(5)}));
 
     A = DenseMatrix(3, 3,
                     {integer(0), integer(0), integer(0), integer(0), integer(0),
@@ -1028,20 +1099,24 @@ TEST_CASE("test_fraction_free_LDU(): matrices", "[matrices]")
     DenseMatrix D = DenseMatrix(3, 3);
     DenseMatrix U = DenseMatrix(3, 3);
 
-    A = DenseMatrix(3, 3, {integer(1), integer(2), integer(3), integer(5),
-                           integer(-3), integer(2), integer(6), integer(2),
-                           integer(1)});
+    A = DenseMatrix(3, 3,
+                    {integer(1), integer(2), integer(3), integer(5),
+                     integer(-3), integer(2), integer(6), integer(2),
+                     integer(1)});
     fraction_free_LDU(A, L, D, U);
 
-    REQUIRE(L == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(5), integer(-13), integer(0),
-                                    integer(6), integer(-10), integer(1)}));
-    REQUIRE(D == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(0), integer(-13), integer(0),
-                                    integer(0), integer(0), integer(-13)}));
-    REQUIRE(U == DenseMatrix(3, 3, {integer(1), integer(2), integer(3),
-                                    integer(0), integer(-13), integer(-13),
-                                    integer(0), integer(0), integer(91)}));
+    REQUIRE(L == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(5),
+                              integer(-13), integer(0), integer(6),
+                              integer(-10), integer(1)}));
+    REQUIRE(D == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(0),
+                              integer(-13), integer(0), integer(0), integer(0),
+                              integer(-13)}));
+    REQUIRE(U == DenseMatrix(3, 3,
+                             {integer(1), integer(2), integer(3), integer(0),
+                              integer(-13), integer(-13), integer(0),
+                              integer(0), integer(91)}));
 
     A = DenseMatrix(3, 3,
                     {integer(1), integer(2), mul(integer(3), symbol("a")),
@@ -1050,15 +1125,16 @@ TEST_CASE("test_fraction_free_LDU(): matrices", "[matrices]")
                      mul(integer(2), symbol("b")), integer(1)});
     fraction_free_LDU(A, L, D, U);
 
-    REQUIRE(
-        L == DenseMatrix(3, 3, {integer(1), integer(0), integer(0), integer(5),
-                                sub(mul(integer(-3), symbol("a")), integer(10)),
-                                integer(0), mul(integer(6), symbol("a")),
-                                add(mul(integer(-12), symbol("a")),
-                                    mul(integer(2), symbol("b"))),
-                                integer(1)}));
-    REQUIRE(D == DenseMatrix(
-                     3, 3, {integer(1), integer(0), integer(0), integer(0),
+    REQUIRE(L == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(5),
+                              sub(mul(integer(-3), symbol("a")), integer(10)),
+                              integer(0), mul(integer(6), symbol("a")),
+                              add(mul(integer(-12), symbol("a")),
+                                  mul(integer(2), symbol("b"))),
+                              integer(1)}));
+    REQUIRE(D
+            == DenseMatrix(3, 3,
+                           {integer(1), integer(0), integer(0), integer(0),
                             sub(mul(integer(-3), symbol("a")), integer(10)),
                             integer(0), integer(0), integer(0),
                             sub(mul(integer(-3), symbol("a")), integer(10))}));
@@ -1075,20 +1151,24 @@ TEST_CASE("test_fraction_free_LDU(): matrices", "[matrices]")
                             add(mul(integer(-18), pow(symbol("a"), integer(2))),
                                 integer(1))))}));
 
-    A = DenseMatrix(3, 3, {integer(5), integer(3), integer(1), integer(-1),
-                           integer(4), integer(6), integer(-10), integer(-2),
-                           integer(9)});
+    A = DenseMatrix(3, 3,
+                    {integer(5), integer(3), integer(1), integer(-1),
+                     integer(4), integer(6), integer(-10), integer(-2),
+                     integer(9)});
     fraction_free_LDU(A, L, D, U);
 
-    REQUIRE(L == DenseMatrix(3, 3, {integer(5), integer(0), integer(0),
-                                    integer(-1), integer(23), integer(0),
-                                    integer(-10), integer(20), integer(1)}));
-    REQUIRE(D == DenseMatrix(3, 3, {integer(5), integer(0), integer(0),
-                                    integer(0), integer(115), integer(0),
-                                    integer(0), integer(0), integer(23)}));
-    REQUIRE(U == DenseMatrix(3, 3, {integer(5), integer(3), integer(1),
-                                    integer(0), integer(23), integer(31),
-                                    integer(0), integer(0), integer(129)}));
+    REQUIRE(L == DenseMatrix(3, 3,
+                             {integer(5), integer(0), integer(0), integer(-1),
+                              integer(23), integer(0), integer(-10),
+                              integer(20), integer(1)}));
+    REQUIRE(D == DenseMatrix(3, 3,
+                             {integer(5), integer(0), integer(0), integer(0),
+                              integer(115), integer(0), integer(0), integer(0),
+                              integer(23)}));
+    REQUIRE(U == DenseMatrix(3, 3,
+                             {integer(5), integer(3), integer(1), integer(0),
+                              integer(23), integer(31), integer(0), integer(0),
+                              integer(129)}));
 }
 
 TEST_CASE("test_QR(): matrices", "[matrices]")
@@ -1097,41 +1177,48 @@ TEST_CASE("test_QR(): matrices", "[matrices]")
     DenseMatrix Q = DenseMatrix(3, 3);
     DenseMatrix R = DenseMatrix(3, 3);
 
-    A = DenseMatrix(3, 3, {integer(12), integer(-51), integer(4), integer(6),
-                           integer(167), integer(-68), integer(-4), integer(24),
-                           integer(-41)});
+    A = DenseMatrix(3, 3,
+                    {integer(12), integer(-51), integer(4), integer(6),
+                     integer(167), integer(-68), integer(-4), integer(24),
+                     integer(-41)});
     QR(A, Q, R);
 }
 
 TEST_CASE("test_LDL(): matrices", "[matrices]")
 {
-    DenseMatrix A = DenseMatrix(
-        3, 3, {integer(4), integer(12), integer(-16), integer(12), integer(37),
-               integer(-43), integer(-16), integer(-43), integer(98)});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {integer(4), integer(12), integer(-16),
+                                 integer(12), integer(37), integer(-43),
+                                 integer(-16), integer(-43), integer(98)});
     DenseMatrix L = DenseMatrix(3, 3);
     DenseMatrix D = DenseMatrix(3, 3);
 
     LDL(A, L, D);
 
-    REQUIRE(L == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(3), integer(1), integer(0),
-                                    integer(-4), integer(5), integer(1)}));
-    REQUIRE(D == DenseMatrix(3, 3, {integer(4), integer(0), integer(0),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(9)}));
+    REQUIRE(L == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(3),
+                              integer(1), integer(0), integer(-4), integer(5),
+                              integer(1)}));
+    REQUIRE(D == DenseMatrix(3, 3,
+                             {integer(4), integer(0), integer(0), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(9)}));
 
-    A = DenseMatrix(3, 3, {integer(25), integer(15), integer(-5), integer(15),
-                           integer(18), integer(0), integer(-5), integer(0),
-                           integer(11)});
+    A = DenseMatrix(3, 3,
+                    {integer(25), integer(15), integer(-5), integer(15),
+                     integer(18), integer(0), integer(-5), integer(0),
+                     integer(11)});
     LDL(A, L, D);
 
-    REQUIRE(L == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    div(integer(3), integer(5)), integer(1),
-                                    integer(0), div(integer(-1), integer(5)),
-                                    div(integer(1), integer(3)), integer(1)}));
-    REQUIRE(D == DenseMatrix(3, 3, {integer(25), integer(0), integer(0),
-                                    integer(0), integer(9), integer(0),
-                                    integer(0), integer(0), integer(9)}));
+    REQUIRE(L == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0),
+                              div(integer(3), integer(5)), integer(1),
+                              integer(0), div(integer(-1), integer(5)),
+                              div(integer(1), integer(3)), integer(1)}));
+    REQUIRE(D == DenseMatrix(3, 3,
+                             {integer(25), integer(0), integer(0), integer(0),
+                              integer(9), integer(0), integer(0), integer(0),
+                              integer(9)}));
 }
 
 /*TEST_CASE("test_cholesky(): matrices", "[matrices]")
@@ -1160,8 +1247,9 @@ TEST_CASE("test_determinant(): matrices", "[matrices]")
     REQUIRE(eq(*det_bareis(M), *integer(-1)));
     REQUIRE(eq(*det_berkowitz(M), *integer(-1)));
 
-    M = DenseMatrix(2, 2, {symbol("x"), integer(1), symbol("y"),
-                           mul(integer(2), symbol("y"))});
+    M = DenseMatrix(
+        2, 2,
+        {symbol("x"), integer(1), symbol("y"), mul(integer(2), symbol("y"))});
     REQUIRE(
         eq(*det_bareis(M),
            *sub(mul(integer(2), mul(symbol("x"), symbol("y"))), symbol("y"))));
@@ -1172,17 +1260,19 @@ TEST_CASE("test_determinant(): matrices", "[matrices]")
     REQUIRE(eq(*det_bareis(M), *integer(1)));
     REQUIRE(eq(*det_berkowitz(M), *integer(1)));
 
-    M = DenseMatrix(4, 4, {integer(3), integer(-2), integer(0), integer(5),
-                           integer(-2), integer(1), integer(-2), integer(2),
-                           integer(0), integer(-2), integer(5), integer(0),
-                           integer(5), integer(0), integer(3), integer(4)});
+    M = DenseMatrix(4, 4,
+                    {integer(3), integer(-2), integer(0), integer(5),
+                     integer(-2), integer(1), integer(-2), integer(2),
+                     integer(0), integer(-2), integer(5), integer(0),
+                     integer(5), integer(0), integer(3), integer(4)});
     REQUIRE(eq(*det_bareis(M), *integer(-289)));
     REQUIRE(eq(*det_berkowitz(M), *integer(-289)));
 
-    M = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                           integer(5), integer(6), integer(7), integer(8),
-                           integer(9), integer(10), integer(11), integer(12),
-                           integer(13), integer(14), integer(15), integer(16)});
+    M = DenseMatrix(4, 4,
+                    {integer(1), integer(2), integer(3), integer(4), integer(5),
+                     integer(6), integer(7), integer(8), integer(9),
+                     integer(10), integer(11), integer(12), integer(13),
+                     integer(14), integer(15), integer(16)});
     REQUIRE(eq(*det_bareis(M), *integer(0)));
     REQUIRE(eq(*det_berkowitz(M), *integer(0)));
 
@@ -1252,12 +1342,13 @@ TEST_CASE("test_berkowitz(): matrices", "[matrices]")
                     {x, y, z, integer(1), integer(0), integer(0), y, z, x});
     berkowitz(M, polys);
 
-    REQUIRE(polys[2]
-            == DenseMatrix(4, 1, {integer(1), mul(integer(-2), x),
-                                  sub(sub(pow(x, integer(2)), mul(y, z)), y),
-                                  sub(mul(x, y), pow(z, integer(2)))}));
-    REQUIRE(polys[1] == DenseMatrix(3, 1, {integer(1), mul(integer(-1), x),
-                                           mul(integer(-1), y)}));
+    REQUIRE(polys[2] == DenseMatrix(4, 1,
+                                    {integer(1), mul(integer(-2), x),
+                                     sub(sub(pow(x, integer(2)), mul(y, z)), y),
+                                     sub(mul(x, y), pow(z, integer(2)))}));
+    REQUIRE(polys[1] == DenseMatrix(3, 1,
+                                    {integer(1), mul(integer(-1), x),
+                                     mul(integer(-1), y)}));
     REQUIRE(polys[0] == DenseMatrix(2, 1, {integer(1), mul(integer(-1), x)}));
 
     polys.clear();
@@ -1267,8 +1358,9 @@ TEST_CASE("test_berkowitz(): matrices", "[matrices]")
                      integer(3), integer(1), integer(3), integer(6)});
     berkowitz(M, polys);
 
-    REQUIRE(polys[2] == DenseMatrix(4, 1, {integer(1), integer(-9), integer(9),
-                                           integer(-1)}));
+    REQUIRE(polys[2]
+            == DenseMatrix(4, 1,
+                           {integer(1), integer(-9), integer(9), integer(-1)}));
     REQUIRE(polys[1]
             == DenseMatrix(3, 1, {integer(1), integer(-3), integer(1)}));
     REQUIRE(polys[0] == DenseMatrix(2, 1, {integer(1), integer(-1)}));
@@ -1276,11 +1368,11 @@ TEST_CASE("test_berkowitz(): matrices", "[matrices]")
 
 TEST_CASE("test_solve_functions(): matrices", "[matrices]")
 {
-    DenseMatrix A
-        = DenseMatrix(4, 4, {integer(1), integer(2), integer(3), integer(4),
-                             integer(2), integer(2), integer(3), integer(4),
-                             integer(3), integer(3), integer(3), integer(4),
-                             integer(9), integer(8), integer(7), integer(6)});
+    DenseMatrix A = DenseMatrix(
+        4, 4,
+        {integer(1), integer(2), integer(3), integer(4), integer(2), integer(2),
+         integer(3), integer(4), integer(3), integer(3), integer(3), integer(4),
+         integer(9), integer(8), integer(7), integer(6)});
     DenseMatrix b = DenseMatrix(
         4, 1, {integer(10), integer(11), integer(13), integer(30)});
     DenseMatrix x = DenseMatrix(4, 1);
@@ -1330,9 +1422,10 @@ TEST_CASE("test_char_poly(): matrices", "[matrices]")
     RCP<const Basic> z = symbol("z");
     RCP<const Basic> t = symbol("t");
 
-    DenseMatrix A = DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                       integer(0), integer(1), integer(0),
-                                       integer(0), integer(0), integer(1)});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {integer(1), integer(0), integer(0), integer(0),
+                                 integer(1), integer(0), integer(0), integer(0),
+                                 integer(1)});
     DenseMatrix B = DenseMatrix(4, 1);
     char_poly(A, B);
 
@@ -1355,10 +1448,10 @@ TEST_CASE("test_char_poly(): matrices", "[matrices]")
     B = DenseMatrix(3, 1);
     char_poly(A, B);
 
-    REQUIRE(
-        B == DenseMatrix(3, 1, {integer(1),
-                                add(mul(integer(-1), t), mul(integer(-1), x)),
-                                add(mul(integer(-1), mul(y, z)), mul(t, x))}));
+    REQUIRE(B == DenseMatrix(3, 1,
+                             {integer(1),
+                              add(mul(integer(-1), t), mul(integer(-1), x)),
+                              add(mul(integer(-1), mul(y, z)), mul(t, x))}));
 }
 
 TEST_CASE("test_inverse(): matrices", "[matrices]")
@@ -1397,9 +1490,10 @@ TEST_CASE("test_inverse(): matrices", "[matrices]")
     mul_dense_dense(A, B, C);
     REQUIRE(C == I3);
 
-    A = DenseMatrix(3, 3, {integer(48), integer(49), integer(31), integer(9),
-                           integer(71), integer(94), integer(59), integer(28),
-                           integer(65)});
+    A = DenseMatrix(3, 3,
+                    {integer(48), integer(49), integer(31), integer(9),
+                     integer(71), integer(94), integer(59), integer(28),
+                     integer(65)});
 
     inverse_fraction_free_LU(A, B);
     mul_dense_dense(A, B, C);
@@ -1443,8 +1537,9 @@ TEST_CASE("test_dot(): matrices", "[matrices]")
     CHECK(C == DenseMatrix(
                    1, 4, {integer(23), integer(31), integer(34), integer(46)}));
 
-    A = DenseMatrix(2, 3, {integer(1), integer(2), integer(3), integer(4),
-                           integer(5), integer(6)});
+    A = DenseMatrix(2, 3,
+                    {integer(1), integer(2), integer(3), integer(4), integer(5),
+                     integer(6)});
     B = DenseMatrix(2, 1, {integer(7), integer(8)});
     dot(A, B, C);
     CHECK(C == DenseMatrix(1, 3, {integer(39), integer(54), integer(69)}));
@@ -1471,9 +1566,10 @@ TEST_CASE("test_eigen_values(): matrices", "[matrices]")
     RCP<const Basic> z = symbol("z");
     RCP<const Basic> t = symbol("t");
 
-    DenseMatrix A = DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                       integer(0), integer(1), integer(0),
-                                       integer(0), integer(0), integer(1)});
+    DenseMatrix A = DenseMatrix(3, 3,
+                                {integer(1), integer(0), integer(0), integer(0),
+                                 integer(1), integer(0), integer(0), integer(0),
+                                 integer(1)});
     auto vals = eigen_values(A);
     REQUIRE(eq(*vals, *finiteset({one})));
 
@@ -1653,24 +1749,28 @@ TEST_CASE("test_eye(): matrices", "[matrices]")
     DenseMatrix A(3, 3);
     eye(A);
 
-    REQUIRE(A == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(1)}));
+    REQUIRE(A == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(0),
+                              integer(1), integer(0), integer(0), integer(0),
+                              integer(1)}));
 
     eye(A, 1);
-    REQUIRE(A == DenseMatrix(3, 3, {integer(0), integer(1), integer(0),
-                                    integer(0), integer(0), integer(1),
-                                    integer(0), integer(0), integer(0)}));
+    REQUIRE(A == DenseMatrix(3, 3,
+                             {integer(0), integer(1), integer(0), integer(0),
+                              integer(0), integer(1), integer(0), integer(0),
+                              integer(0)}));
 
     eye(A, -1);
-    REQUIRE(A == DenseMatrix(3, 3, {integer(0), integer(0), integer(0),
-                                    integer(1), integer(0), integer(0),
-                                    integer(0), integer(1), integer(0)}));
+    REQUIRE(A == DenseMatrix(3, 3,
+                             {integer(0), integer(0), integer(0), integer(1),
+                              integer(0), integer(0), integer(0), integer(1),
+                              integer(0)}));
 
     eye(A, -2);
-    REQUIRE(A == DenseMatrix(3, 3, {integer(0), integer(0), integer(0),
-                                    integer(0), integer(0), integer(0),
-                                    integer(1), integer(0), integer(0)}));
+    REQUIRE(A == DenseMatrix(3, 3,
+                             {integer(0), integer(0), integer(0), integer(0),
+                              integer(0), integer(0), integer(1), integer(0),
+                              integer(0)}));
 }
 
 TEST_CASE("test_diag(): matrices", "[matrices]")
@@ -1679,9 +1779,10 @@ TEST_CASE("test_diag(): matrices", "[matrices]")
     vec_basic d{integer(1), integer(2), integer(3)};
 
     diag(A, d);
-    REQUIRE(A == DenseMatrix(3, 3, {integer(1), integer(0), integer(0),
-                                    integer(0), integer(2), integer(0),
-                                    integer(0), integer(0), integer(3)}));
+    REQUIRE(A == DenseMatrix(3, 3,
+                             {integer(1), integer(0), integer(0), integer(0),
+                              integer(2), integer(0), integer(0), integer(0),
+                              integer(3)}));
 
     A = DenseMatrix(4, 4);
     diag(A, d, 1);
@@ -1708,18 +1809,21 @@ TEST_CASE("test_ones_zeros(): matrices", "[matrices]")
     DenseMatrix A(1, 5);
     ones(A);
 
-    REQUIRE(A == DenseMatrix(1, 5, {integer(1), integer(1), integer(1),
-                                    integer(1), integer(1)}));
+    REQUIRE(A == DenseMatrix(1, 5,
+                             {integer(1), integer(1), integer(1), integer(1),
+                              integer(1)}));
 
     A = DenseMatrix(2, 3);
     ones(A);
-    REQUIRE(A == DenseMatrix(2, 3, {integer(1), integer(1), integer(1),
-                                    integer(1), integer(1), integer(1)}));
+    REQUIRE(A == DenseMatrix(2, 3,
+                             {integer(1), integer(1), integer(1), integer(1),
+                              integer(1), integer(1)}));
 
     A = DenseMatrix(3, 2);
     zeros(A);
-    REQUIRE(A == DenseMatrix(3, 2, {integer(0), integer(0), integer(0),
-                                    integer(0), integer(0), integer(0)}));
+    REQUIRE(A == DenseMatrix(3, 2,
+                             {integer(0), integer(0), integer(0), integer(0),
+                              integer(0), integer(0)}));
 }
 
 TEST_CASE("Test Jacobian", "[matrices]")
@@ -1733,10 +1837,11 @@ TEST_CASE("Test Jacobian", "[matrices]")
     X = DenseMatrix(4, 1, {x, y, z, t});
     J = DenseMatrix(4, 4);
     jacobian(A, X, J);
-    const auto ref1 = DenseMatrix(
-        4, 4, {integer(1), integer(0), integer(1), integer(0), integer(0), z, y,
-               integer(0), z, integer(1), x, integer(1), integer(1), integer(1),
-               integer(0), integer(0)});
+    const auto ref1 = DenseMatrix(4, 4,
+                                  {integer(1), integer(0), integer(1),
+                                   integer(0), integer(0), z, y, integer(0), z,
+                                   integer(1), x, integer(1), integer(1),
+                                   integer(1), integer(0), integer(0)});
     REQUIRE(J == ref1);
     CSRMatrix Js = CSRMatrix::jacobian(A, X);
     std::vector<unsigned> Js_p1, Js_p2{{0, 2, 4, 8, 10}};
@@ -1760,9 +1865,10 @@ TEST_CASE("Test Jacobian", "[matrices]")
     X = DenseMatrix(3, 1, {x, y, z});
     J = DenseMatrix(4, 3);
     jacobian(A, X, J);
-    const auto ref2 = DenseMatrix(4, 3, {integer(1), integer(0), integer(1),
-                                         integer(0), z, y, z, integer(1), x,
-                                         integer(1), integer(1), integer(0)});
+    const auto ref2
+        = DenseMatrix(4, 3,
+                      {integer(1), integer(0), integer(1), integer(0), z, y, z,
+                       integer(1), x, integer(1), integer(1), integer(0)});
     REQUIRE(J == ref2);
     REQUIRE(CSRMatrix::jacobian(A, X) == ref2);
 
@@ -1806,13 +1912,15 @@ TEST_CASE("free_symbols: MatrixBase", "[matrices]")
     s = free_symbols(A);
     REQUIRE(s.size() == 1);
 
-    A = DenseMatrix(2, 2, {integer(2), mul(symbol("s"), integer(3)),
-                           sub(symbol("x"), symbol("y")), integer(4)});
+    A = DenseMatrix(2, 2,
+                    {integer(2), mul(symbol("s"), integer(3)),
+                     sub(symbol("x"), symbol("y")), integer(4)});
     s = free_symbols(A);
     REQUIRE(s.size() == 3);
 
-    A = DenseMatrix(2, 2, {integer(2), mul(symbol("x"), integer(3)),
-                           sub(symbol("x"), symbol("y")), integer(4)});
+    A = DenseMatrix(2, 2,
+                    {integer(2), mul(symbol("x"), integer(3)),
+                     sub(symbol("x"), symbol("y")), integer(4)});
     s = free_symbols(A);
     REQUIRE(s.size() == 2);
     REQUIRE(s.count(symbol("x")) == 1);

--- a/symengine/tests/ntheory/test_diophantine.cpp
+++ b/symengine/tests/ntheory/test_diophantine.cpp
@@ -42,9 +42,10 @@ TEST_CASE("test_homogeneous_lde()", "[diophantine]")
     // for Solving Systems of Linear Diophantine Equations. Information and
     // computation, 113(1):143-172, August 1994.
 
-    DenseMatrix A = DenseMatrix(2, 4, {integer(-1), integer(1), integer(2),
-                                       integer(-3), integer(-1), integer(3),
-                                       integer(-2), integer(-1)});
+    DenseMatrix A
+        = DenseMatrix(2, 4,
+                      {integer(-1), integer(1), integer(2), integer(-3),
+                       integer(-1), integer(3), integer(-2), integer(-1)});
     homogeneous_lde(basis, A);
     true_basis = std::vector<DenseMatrix>{
         DenseMatrix(1, 4, {integer(0), integer(1), integer(1), integer(1)}),

--- a/symengine/tests/polynomial/test_mexprpoly.cpp
+++ b/symengine/tests/polynomial/test_mexprpoly.cpp
@@ -60,10 +60,11 @@ TEST_CASE("Constructing MExprPoly", "[MExprPoly]")
         = MExprPoly::from_dict({x, y}, {{{0, 0}, Expression(integer(0))}});
     RCP<const MExprPoly> p4 = MExprPoly::from_dict(s, {{v, Expression(0)}});
     RCP<const MExprPoly> p5 = MExprPoly::from_dict(s, {{v, comp1}});
-    RCP<const MExprPoly> p6 = MExprPoly::from_dict({x, y}, {{{0, 0}, comp1},
-                                                            {{0, -1}, comp2},
-                                                            {{-2, 2}, comp3},
-                                                            {{-3, -3}, comp4}});
+    RCP<const MExprPoly> p6 = MExprPoly::from_dict({x, y},
+                                                   {{{0, 0}, comp1},
+                                                    {{0, -1}, comp2},
+                                                    {{-2, 2}, comp3},
+                                                    {{-3, -3}, comp4}});
 
     REQUIRE(eq(*p1->as_symbolic(),
                *add({mul(integer(2), mul(pow(x, integer(2)), y)),
@@ -158,20 +159,20 @@ TEST_CASE("Testing MExprPoly::eval", "[MExprPoly]")
     Expression why(mul(a, b));
     Expression zee(div(a, b));
 
-    RCP<const MExprPoly> p
-        = MExprPoly::from_dict({x, y, z}, {{{2, 0, 0}, expr1},
-                                           {{0, 2, 0}, expr2},
-                                           {{0, 0, 2}, expr3},
-                                           {{1, 1, 1}, expr4},
-                                           {{1, 1, 0}, expr1},
-                                           {{0, 1, 1}, expr2},
-                                           {{1, 0, 0}, expr1},
-                                           {{0, 1, 0}, expr2},
-                                           {{0, 0, 1}, expr3},
-                                           {{0, 0, 0}, expr4},
-                                           {{-1, -1, -1}, expr1},
-                                           {{-2, -2, -2}, expr2},
-                                           {{-2, 2, -2}, expr3}});
+    RCP<const MExprPoly> p = MExprPoly::from_dict({x, y, z},
+                                                  {{{2, 0, 0}, expr1},
+                                                   {{0, 2, 0}, expr2},
+                                                   {{0, 0, 2}, expr3},
+                                                   {{1, 1, 1}, expr4},
+                                                   {{1, 1, 0}, expr1},
+                                                   {{0, 1, 1}, expr2},
+                                                   {{1, 0, 0}, expr1},
+                                                   {{0, 1, 0}, expr2},
+                                                   {{0, 0, 1}, expr3},
+                                                   {{0, 0, 0}, expr4},
+                                                   {{-1, -1, -1}, expr1},
+                                                   {{-2, -2, -2}, expr2},
+                                                   {{-2, 2, -2}, expr3}});
     std::map<RCP<const Basic>, Expression, RCPBasicKeyLess> m1
         = {{x, Expression(0)}, {y, Expression(0)}, {z, Expression(0)}};
     std::map<RCP<const Basic>, Expression, RCPBasicKeyLess> m2
@@ -200,28 +201,29 @@ TEST_CASE("Testing derivative of MExprPoly", "[MExprPoly]")
     Expression expr2(sub(mul(two, a), b));
     Expression expr3(mul(a, c));
     Expression expr4(div(b, a));
-    RCP<const MExprPoly> p = MExprPoly::from_dict({x, y}, {{{2, 1}, expr1},
-                                                           {{1, 2}, expr2},
-                                                           {{2, 0}, expr3},
-                                                           {{0, 2}, expr4},
-                                                           {{1, 0}, expr1},
-                                                           {{0, 1}, expr2},
-                                                           {{0, 0}, expr3},
-                                                           {{-1, 0}, expr4},
-                                                           {{0, -2}, expr1}});
+    RCP<const MExprPoly> p = MExprPoly::from_dict({x, y},
+                                                  {{{2, 1}, expr1},
+                                                   {{1, 2}, expr2},
+                                                   {{2, 0}, expr3},
+                                                   {{0, 2}, expr4},
+                                                   {{1, 0}, expr1},
+                                                   {{0, 1}, expr2},
+                                                   {{0, 0}, expr3},
+                                                   {{-1, 0}, expr4},
+                                                   {{0, -2}, expr1}});
 
-    RCP<const MExprPoly> q1
-        = MExprPoly::from_dict({x, y}, {{{1, 1}, expr1 * 2},
-                                        {{0, 2}, expr2},
-                                        {{1, 0}, expr3 * 2},
-                                        {{0, 0}, expr1},
-                                        {{-2, 0}, expr4 * -1}});
-    RCP<const MExprPoly> q2
-        = MExprPoly::from_dict({x, y}, {{{2, 0}, expr1},
-                                        {{1, 1}, expr2 * 2},
-                                        {{0, 1}, expr4 * 2},
-                                        {{0, 0}, expr2},
-                                        {{0, -3}, expr1 * -2}});
+    RCP<const MExprPoly> q1 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 1}, expr1 * 2},
+                                                    {{0, 2}, expr2},
+                                                    {{1, 0}, expr3 * 2},
+                                                    {{0, 0}, expr1},
+                                                    {{-2, 0}, expr4 * -1}});
+    RCP<const MExprPoly> q2 = MExprPoly::from_dict({x, y},
+                                                   {{{2, 0}, expr1},
+                                                    {{1, 1}, expr2 * 2},
+                                                    {{0, 1}, expr4 * 2},
+                                                    {{0, 0}, expr2},
+                                                    {{0, -3}, expr1 * -2}});
     RCP<const MExprPoly> q3
         = MExprPoly::from_dict({x, y}, {{{0, 0}, Expression(0)}});
 
@@ -244,19 +246,21 @@ TEST_CASE("Testing MExprPoly::get_args()", "[MExprPoly]")
     Expression expr3(mul(a, c));
     Expression expr4(pow(b, a));
     RCP<const MExprPoly> p1
-        = MExprPoly::from_dict({x, y, z}, {{{0, 0, 0}, Expression(1)},
-                                           {{1, 1, 1}, Expression(2)},
-                                           {{0, 0, 2}, Expression(1)}});
-    RCP<const MExprPoly> p2
-        = MExprPoly::from_dict({x, y, z}, {{{0, 0, 0}, expr1},
-                                           {{1, 1, 1}, expr2},
-                                           {{0, 0, 2}, expr3},
-                                           {{0, 2, 0}, expr4},
-                                           {{-1, -1, -1}, expr2},
-                                           {{0, 0, -2}, expr3},
-                                           {{0, -2, 0}, expr4}});
-    REQUIRE(eq(*p1->as_symbolic(), *add({mul(integer(2), mul(x, mul(y, z))),
-                                         pow(z, integer(2)), one})));
+        = MExprPoly::from_dict({x, y, z},
+                               {{{0, 0, 0}, Expression(1)},
+                                {{1, 1, 1}, Expression(2)},
+                                {{0, 0, 2}, Expression(1)}});
+    RCP<const MExprPoly> p2 = MExprPoly::from_dict({x, y, z},
+                                                   {{{0, 0, 0}, expr1},
+                                                    {{1, 1, 1}, expr2},
+                                                    {{0, 0, 2}, expr3},
+                                                    {{0, 2, 0}, expr4},
+                                                    {{-1, -1, -1}, expr2},
+                                                    {{0, 0, -2}, expr3},
+                                                    {{0, -2, 0}, expr4}});
+    REQUIRE(eq(
+        *p1->as_symbolic(),
+        *add({mul(integer(2), mul(x, mul(y, z))), pow(z, integer(2)), one})));
     REQUIRE(
         eq(*p2->as_symbolic(),
            *add({mul(expr2.get_basic(), mul(x, mul(y, z))),
@@ -292,16 +296,16 @@ TEST_CASE("Testing MExprPoly negation"
     RCP<const MExprPoly> p3
         = MExprPoly::from_dict({x, y}, {{{0, 0}, Expression(integer(0))}});
 
-    RCP<const MExprPoly> q1
-        = MExprPoly::from_dict({x, y}, {{{1, 1}, a * -1},
-                                        {{1, -2}, negB * -1},
-                                        {{-2, 1}, num1 * -1},
-                                        {{0, 1}, negNum * -1}});
-    RCP<const MExprPoly> q2
-        = MExprPoly::from_dict({x, y}, {{{1, 0}, comp1 * -1},
-                                        {{0, 0}, comp2 * -1},
-                                        {{2, 2}, comp3 * -1},
-                                        {{3, 4}, comp4 * -1}});
+    RCP<const MExprPoly> q1 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 1}, a * -1},
+                                                    {{1, -2}, negB * -1},
+                                                    {{-2, 1}, num1 * -1},
+                                                    {{0, 1}, negNum * -1}});
+    RCP<const MExprPoly> q2 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 0}, comp1 * -1},
+                                                    {{0, 0}, comp2 * -1},
+                                                    {{2, 2}, comp3 * -1},
+                                                    {{3, 4}, comp4 * -1}});
     RCP<const MExprPoly> q3
         = MExprPoly::from_dict({x, y}, {{{0, 0}, Expression(integer(0))}});
 
@@ -331,35 +335,37 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const MExprPoly> p3
         = MExprPoly::from_dict({x, y}, {{{0, 0}, Expression(integer(0))}});
 
-    RCP<const MExprPoly> q1
-        = MExprPoly::from_dict({x, y}, {{{1, 1}, a},
-                                        {{1, 0}, negB + comp1},
-                                        {{2, -1}, num1},
-                                        {{0, 0}, comp4},
-                                        {{0, -1}, comp4 + negNum}});
+    RCP<const MExprPoly> q1 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 1}, a},
+                                                    {{1, 0}, negB + comp1},
+                                                    {{2, -1}, num1},
+                                                    {{0, 0}, comp4},
+                                                    {{0, -1}, comp4 + negNum}});
     RCP<const MExprPoly> q2
-        = MExprPoly::from_dict({x, y}, {{{2, -1}, num1},
-                                        {{1, 1}, a},
-                                        {{1, 0}, (-1 * comp1) + negB},
-                                        {{0, -1}, negNum - comp4},
-                                        {{0, 0}, comp4 * -1}});
-    RCP<const MExprPoly> q22
-        = MExprPoly::from_dict({x, y}, {{{2, -1}, -1 * num1},
-                                        {{1, 1}, -1 * a},
-                                        {{1, 0}, comp1 - negB},
-                                        {{0, -1}, comp4 - negNum},
-                                        {{0, 0}, comp4}});
-    RCP<const MExprPoly> q3 = MExprPoly::from_dict(
-        {x, y}, {{{2, 1}, a * comp1},
-                 {{1, 1}, a * comp4},
-                 {{1, 0}, a * comp4 + negB * comp4},
-                 {{2, 0}, negB * comp1},
-                 {{1, -1}, negB * comp4 + negNum * comp1},
-                 {{3, -1}, num1 * comp1},
-                 {{2, -1}, num1 * comp4},
-                 {{2, -2}, num1 * comp4},
-                 {{0, -1}, negNum * comp4},
-                 {{0, -2}, negNum * comp4}});
+        = MExprPoly::from_dict({x, y},
+                               {{{2, -1}, num1},
+                                {{1, 1}, a},
+                                {{1, 0}, (-1 * comp1) + negB},
+                                {{0, -1}, negNum - comp4},
+                                {{0, 0}, comp4 * -1}});
+    RCP<const MExprPoly> q22 = MExprPoly::from_dict({x, y},
+                                                    {{{2, -1}, -1 * num1},
+                                                     {{1, 1}, -1 * a},
+                                                     {{1, 0}, comp1 - negB},
+                                                     {{0, -1}, comp4 - negNum},
+                                                     {{0, 0}, comp4}});
+    RCP<const MExprPoly> q3
+        = MExprPoly::from_dict({x, y},
+                               {{{2, 1}, a * comp1},
+                                {{1, 1}, a * comp4},
+                                {{1, 0}, a * comp4 + negB * comp4},
+                                {{2, 0}, negB * comp1},
+                                {{1, -1}, negB * comp4 + negNum * comp1},
+                                {{3, -1}, num1 * comp1},
+                                {{2, -1}, num1 * comp4},
+                                {{2, -2}, num1 * comp4},
+                                {{0, -1}, negNum * comp4},
+                                {{0, -2}, negNum * comp4}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -393,31 +399,33 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const MExprPoly> p2
         = MExprPoly::from_dict({m, n}, {{{1, 0}, comp1}, {{2, -1}, comp4}});
 
-    RCP<const MExprPoly> q1
-        = MExprPoly::from_dict({m, n, x, y}, {{{0, 0, 1, 1}, a},
-                                              {{0, 0, -1, 0}, negB},
-                                              {{0, 0, 0, 0}, negNum},
-                                              {{1, 0, 0, 0}, comp1},
-                                              {{2, -1, 0, 0}, comp4}});
+    RCP<const MExprPoly> q1 = MExprPoly::from_dict({m, n, x, y},
+                                                   {{{0, 0, 1, 1}, a},
+                                                    {{0, 0, -1, 0}, negB},
+                                                    {{0, 0, 0, 0}, negNum},
+                                                    {{1, 0, 0, 0}, comp1},
+                                                    {{2, -1, 0, 0}, comp4}});
     RCP<const MExprPoly> q2
-        = MExprPoly::from_dict({m, n, x, y}, {{{0, 0, 1, 1}, a},
-                                              {{0, 0, -1, 0}, negB},
-                                              {{0, 0, 0, 0}, negNum},
-                                              {{1, 0, 0, 0}, comp1 * -1},
-                                              {{2, -1, 0, 0}, comp4 * -1}});
-    RCP<const MExprPoly> q3
-        = MExprPoly::from_dict({m, n, x, y}, {{{0, 0, 1, 1}, a * -1},
-                                              {{0, 0, -1, 0}, negB * -1},
-                                              {{0, 0, 0, 0}, negNum * -1},
-                                              {{1, 0, 0, 0}, comp1},
-                                              {{2, -1, 0, 0}, comp4}});
+        = MExprPoly::from_dict({m, n, x, y},
+                               {{{0, 0, 1, 1}, a},
+                                {{0, 0, -1, 0}, negB},
+                                {{0, 0, 0, 0}, negNum},
+                                {{1, 0, 0, 0}, comp1 * -1},
+                                {{2, -1, 0, 0}, comp4 * -1}});
+    RCP<const MExprPoly> q3 = MExprPoly::from_dict({m, n, x, y},
+                                                   {{{0, 0, 1, 1}, a * -1},
+                                                    {{0, 0, -1, 0}, negB * -1},
+                                                    {{0, 0, 0, 0}, negNum * -1},
+                                                    {{1, 0, 0, 0}, comp1},
+                                                    {{2, -1, 0, 0}, comp4}});
     RCP<const MExprPoly> q4
-        = MExprPoly::from_dict({m, n, x, y}, {{{2, -1, 1, 1}, a * comp4},
-                                              {{2, -1, -1, 0}, negB * comp4},
-                                              {{2, -1, 0, 0}, negNum * comp4},
-                                              {{1, 0, 1, 1}, a * comp1},
-                                              {{1, 0, -1, 0}, negB * comp1},
-                                              {{1, 0, 0, 0}, negNum * comp1}});
+        = MExprPoly::from_dict({m, n, x, y},
+                               {{{2, -1, 1, 1}, a * comp4},
+                                {{2, -1, -1, 0}, negB * comp4},
+                                {{2, -1, 0, 0}, negNum * comp4},
+                                {{1, 0, 1, 1}, a * comp1},
+                                {{1, 0, -1, 0}, negB * comp1},
+                                {{1, 0, 0, 0}, negNum * comp1}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -445,31 +453,32 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const MExprPoly> p2
         = MExprPoly::from_dict({y, z}, {{{1, 0}, comp1}, {{-2, 1}, comp4}});
 
-    RCP<const MExprPoly> q1
-        = MExprPoly::from_dict({x, y, z}, {{{1, -1, 0}, a},
-                                           {{1, 0, 0}, negB},
-                                           {{0, 0, 0}, negNum},
-                                           {{0, 1, 0}, comp1},
-                                           {{0, -2, 1}, comp4}});
-    RCP<const MExprPoly> q2
-        = MExprPoly::from_dict({x, y, z}, {{{1, -1, 0}, a},
-                                           {{1, 0, 0}, negB},
-                                           {{0, 0, 0}, negNum},
-                                           {{0, 1, 0}, comp1 * -1},
-                                           {{0, -2, 1}, comp4 * -1}});
-    RCP<const MExprPoly> q3
-        = MExprPoly::from_dict({x, y, z}, {{{1, -1, 0}, a * -1},
-                                           {{1, 0, 0}, negB * -1},
-                                           {{0, 0, 0}, negNum * -1},
-                                           {{0, 1, 0}, comp1},
-                                           {{0, -2, 1}, comp4}});
+    RCP<const MExprPoly> q1 = MExprPoly::from_dict({x, y, z},
+                                                   {{{1, -1, 0}, a},
+                                                    {{1, 0, 0}, negB},
+                                                    {{0, 0, 0}, negNum},
+                                                    {{0, 1, 0}, comp1},
+                                                    {{0, -2, 1}, comp4}});
+    RCP<const MExprPoly> q2 = MExprPoly::from_dict({x, y, z},
+                                                   {{{1, -1, 0}, a},
+                                                    {{1, 0, 0}, negB},
+                                                    {{0, 0, 0}, negNum},
+                                                    {{0, 1, 0}, comp1 * -1},
+                                                    {{0, -2, 1}, comp4 * -1}});
+    RCP<const MExprPoly> q3 = MExprPoly::from_dict({x, y, z},
+                                                   {{{1, -1, 0}, a * -1},
+                                                    {{1, 0, 0}, negB * -1},
+                                                    {{0, 0, 0}, negNum * -1},
+                                                    {{0, 1, 0}, comp1},
+                                                    {{0, -2, 1}, comp4}});
     RCP<const MExprPoly> q4
-        = MExprPoly::from_dict({x, y, z}, {{{1, 0, 0}, a * comp1},
-                                           {{1, -3, 1}, a * comp4},
-                                           {{1, 1, 0}, negB * comp1},
-                                           {{1, -2, 1}, negB * comp4},
-                                           {{0, 1, 0}, negNum * comp1},
-                                           {{0, -2, 1}, comp4 * negNum}});
+        = MExprPoly::from_dict({x, y, z},
+                               {{{1, 0, 0}, a * comp1},
+                                {{1, -3, 1}, a * comp4},
+                                {{1, 1, 0}, negB * comp1},
+                                {{1, -2, 1}, negB * comp4},
+                                {{0, 1, 0}, negNum * comp1},
+                                {{0, -2, 1}, comp4 * negNum}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -507,10 +516,11 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const MExprPoly> q3 = MExprPoly::from_dict(
         {x}, {{{0}, expr4 - expr3}, {{1}, expr1 - expr1}, {{2}, expr2 * -1}});
     RCP<const MExprPoly> q4
-        = MExprPoly::from_dict({x}, {{{3}, expr2 * expr1},
-                                     {{2}, expr2 * expr4 + expr1 * expr1},
-                                     {{1}, expr1 * expr4 + expr1 * expr3},
-                                     {{0}, expr3 * expr4}});
+        = MExprPoly::from_dict({x},
+                               {{{3}, expr2 * expr1},
+                                {{2}, expr2 * expr4 + expr1 * expr1},
+                                {{1}, expr1 * expr4 + expr1 * expr3},
+                                {{0}, expr3 * expr4}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -540,29 +550,29 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const MExprPoly> p2
         = MExprPoly::from_dict({y}, {{{0}, expr4}, {{1}, expr5}});
 
-    RCP<const MExprPoly> q1
-        = MExprPoly::from_dict({x, y}, {{{1, 0}, expr1},
-                                        {{2, 0}, expr2},
-                                        {{0, 0}, expr3 + expr4},
-                                        {{0, 0}, expr4},
-                                        {{0, 1}, expr5}});
-    RCP<const MExprPoly> q2
-        = MExprPoly::from_dict({x, y}, {{{1, 0}, expr1},
-                                        {{2, 0}, expr2},
-                                        {{0, 0}, expr3 - expr4},
-                                        {{0, 1}, expr5 * -1}});
-    RCP<const MExprPoly> q3
-        = MExprPoly::from_dict({x, y}, {{{1, 0}, expr1 * -1},
-                                        {{2, 0}, expr2 * -1},
-                                        {{0, 0}, expr4 - expr3},
-                                        {{0, 1}, expr5}});
-    RCP<const MExprPoly> q4
-        = MExprPoly::from_dict({x, y}, {{{2, 1}, expr2 * expr5},
-                                        {{2, 0}, expr2 * expr4},
-                                        {{1, 1}, expr1 * expr5},
-                                        {{1, 0}, expr1 * expr4},
-                                        {{0, 1}, expr3 * expr5},
-                                        {{0, 0}, expr3 * expr4}});
+    RCP<const MExprPoly> q1 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 0}, expr1},
+                                                    {{2, 0}, expr2},
+                                                    {{0, 0}, expr3 + expr4},
+                                                    {{0, 0}, expr4},
+                                                    {{0, 1}, expr5}});
+    RCP<const MExprPoly> q2 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 0}, expr1},
+                                                    {{2, 0}, expr2},
+                                                    {{0, 0}, expr3 - expr4},
+                                                    {{0, 1}, expr5 * -1}});
+    RCP<const MExprPoly> q3 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 0}, expr1 * -1},
+                                                    {{2, 0}, expr2 * -1},
+                                                    {{0, 0}, expr4 - expr3},
+                                                    {{0, 1}, expr5}});
+    RCP<const MExprPoly> q4 = MExprPoly::from_dict({x, y},
+                                                   {{{2, 1}, expr2 * expr5},
+                                                    {{2, 0}, expr2 * expr4},
+                                                    {{1, 1}, expr1 * expr5},
+                                                    {{1, 0}, expr1 * expr4},
+                                                    {{0, 1}, expr3 * expr5},
+                                                    {{0, 0}, expr3 * expr4}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -590,32 +600,34 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const MExprPoly> p2 = MExprPoly::from_dict(
         {y}, {{{0}, comp4}, {{1}, Expression(integer(2))}, {{2}, comp1}});
 
-    RCP<const MExprPoly> q1
-        = MExprPoly::from_dict({x, y}, {{{1, 1}, a},
-                                        {{0, 2}, comp1},
-                                        {{1, 0}, negB},
-                                        {{0, 1}, Expression(2)},
-                                        {{0, 0}, comp4 + negNum}});
+    RCP<const MExprPoly> q1 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 1}, a},
+                                                    {{0, 2}, comp1},
+                                                    {{1, 0}, negB},
+                                                    {{0, 1}, Expression(2)},
+                                                    {{0, 0}, comp4 + negNum}});
     RCP<const MExprPoly> q2
-        = MExprPoly::from_dict({x, y}, {{{1, 1}, a},
-                                        {{0, 2}, comp1 * -1},
-                                        {{1, 0}, negB},
-                                        {{0, 1}, Expression(-2)},
-                                        {{0, 0}, -1 * comp4 + negNum}});
-    RCP<const MExprPoly> q3
-        = MExprPoly::from_dict({x, y}, {{{1, 1}, a * -1},
-                                        {{0, 2}, comp1},
-                                        {{1, 0}, negB * -1},
-                                        {{0, 1}, Expression(2)},
-                                        {{0, 0}, comp4 - negNum}});
+        = MExprPoly::from_dict({x, y},
+                               {{{1, 1}, a},
+                                {{0, 2}, comp1 * -1},
+                                {{1, 0}, negB},
+                                {{0, 1}, Expression(-2)},
+                                {{0, 0}, -1 * comp4 + negNum}});
+    RCP<const MExprPoly> q3 = MExprPoly::from_dict({x, y},
+                                                   {{{1, 1}, a * -1},
+                                                    {{0, 2}, comp1},
+                                                    {{1, 0}, negB * -1},
+                                                    {{0, 1}, Expression(2)},
+                                                    {{0, 0}, comp4 - negNum}});
     RCP<const MExprPoly> q4
-        = MExprPoly::from_dict({x, y}, {{{1, 3}, a * comp1},
-                                        {{1, 2}, 2 * a + negB * comp1},
-                                        {{1, 1}, a * comp4 + negB * 2},
-                                        {{0, 2}, negNum * comp1},
-                                        {{1, 0}, negB * comp4},
-                                        {{0, 1}, 2 * negNum},
-                                        {{0, 0}, negNum * comp4}});
+        = MExprPoly::from_dict({x, y},
+                               {{{1, 3}, a * comp1},
+                                {{1, 2}, 2 * a + negB * comp1},
+                                {{1, 1}, a * comp4 + negB * 2},
+                                {{0, 2}, negNum * comp1},
+                                {{1, 0}, negB * comp4},
+                                {{0, 1}, 2 * negNum},
+                                {{0, 0}, negNum * comp4}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -645,33 +657,37 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
         {z}, {{{0}, comp4}, {{1}, Expression(integer(2))}, {{2}, comp1}});
 
     RCP<const MExprPoly> q1
-        = MExprPoly::from_dict({x, y, z}, {{{1, 1, 0}, a},
-                                           {{0, 0, 2}, comp1},
-                                           {{1, 0, 0}, negB},
-                                           {{0, 0, 1}, Expression(2)},
-                                           {{0, 0, 0}, negNum + comp4}});
+        = MExprPoly::from_dict({x, y, z},
+                               {{{1, 1, 0}, a},
+                                {{0, 0, 2}, comp1},
+                                {{1, 0, 0}, negB},
+                                {{0, 0, 1}, Expression(2)},
+                                {{0, 0, 0}, negNum + comp4}});
     RCP<const MExprPoly> q2
-        = MExprPoly::from_dict({x, y, z}, {{{1, 1, 0}, a},
-                                           {{0, 0, 2}, comp1 * -1},
-                                           {{1, 0, 0}, negB},
-                                           {{0, 0, 1}, Expression(-2)},
-                                           {{0, 0, 0}, negNum - comp4}});
+        = MExprPoly::from_dict({x, y, z},
+                               {{{1, 1, 0}, a},
+                                {{0, 0, 2}, comp1 * -1},
+                                {{1, 0, 0}, negB},
+                                {{0, 0, 1}, Expression(-2)},
+                                {{0, 0, 0}, negNum - comp4}});
     RCP<const MExprPoly> q3
-        = MExprPoly::from_dict({x, y, z}, {{{1, 1, 0}, a * -1},
-                                           {{0, 0, 2}, comp1},
-                                           {{1, 0, 0}, negB * -1},
-                                           {{0, 0, 1}, Expression(2)},
-                                           {{0, 0, 0}, -1 * negNum + comp4}});
+        = MExprPoly::from_dict({x, y, z},
+                               {{{1, 1, 0}, a * -1},
+                                {{0, 0, 2}, comp1},
+                                {{1, 0, 0}, negB * -1},
+                                {{0, 0, 1}, Expression(2)},
+                                {{0, 0, 0}, -1 * negNum + comp4}});
     RCP<const MExprPoly> q4
-        = MExprPoly::from_dict({x, y, z}, {{{1, 1, 2}, a * comp1},
-                                           {{1, 1, 1}, 2 * a},
-                                           {{1, 0, 2}, negB * comp1},
-                                           {{1, 1, 0}, a * comp4},
-                                           {{1, 0, 1}, 2 * negB},
-                                           {{0, 0, 2}, negNum * comp1},
-                                           {{1, 0, 0}, negB * comp4},
-                                           {{0, 0, 1}, 2 * negNum},
-                                           {{0, 0, 0}, negNum * comp4}});
+        = MExprPoly::from_dict({x, y, z},
+                               {{{1, 1, 2}, a * comp1},
+                                {{1, 1, 1}, 2 * a},
+                                {{1, 0, 2}, negB * comp1},
+                                {{1, 1, 0}, a * comp4},
+                                {{1, 0, 1}, 2 * negB},
+                                {{0, 0, 2}, negNum * comp1},
+                                {{1, 0, 0}, negB * comp4},
+                                {{0, 0, 1}, 2 * negNum},
+                                {{0, 0, 0}, negNum * comp4}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -709,10 +725,10 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const MExprPoly> q3 = MExprPoly::from_dict(
         {x, y},
         {{{0, 0}, expr1 - expr2}, {{0, 1}, -1 * expr3}, {{-1, 0}, -1 * expr4}});
-    RCP<const MExprPoly> q4
-        = MExprPoly::from_dict({x, y}, {{{0, 0}, expr2 * expr1},
-                                        {{0, 1}, expr3 * expr1},
-                                        {{-1, 0}, expr4 * expr1}});
+    RCP<const MExprPoly> q4 = MExprPoly::from_dict({x, y},
+                                                   {{{0, 0}, expr2 * expr1},
+                                                    {{0, 1}, expr3 * expr1},
+                                                    {{-1, 0}, expr4 * expr1}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));

--- a/symengine/tests/polynomial/test_mintpoly.cpp
+++ b/symengine/tests/polynomial/test_mintpoly.cpp
@@ -35,21 +35,23 @@ TEST_CASE("Constructing MIntPoly", "[MIntPoly]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
 
-    RCP<const MIntPoly> P = MIntPoly::from_dict({x, y}, {{{1, 2}, 1_z},
-                                                         {{1, 1}, 2_z},
-                                                         {{0, 1}, 2_z},
-                                                         {{1, 0}, 3_z},
-                                                         {{0, 0}, 0_z}});
+    RCP<const MIntPoly> P = MIntPoly::from_dict({x, y},
+                                                {{{1, 2}, 1_z},
+                                                 {{1, 1}, 2_z},
+                                                 {{0, 1}, 2_z},
+                                                 {{1, 0}, 3_z},
+                                                 {{0, 0}, 0_z}});
 
     REQUIRE(eq(*P->as_symbolic(),
                *add({mul(x, pow(y, integer(2))), mul(integer(2), mul(x, y)),
                      mul(integer(3), x), mul(integer(2), y)})));
 
-    RCP<const MIntPoly> Pprime = MIntPoly::from_dict({y, x}, {{{1, 2}, 1_z},
-                                                              {{1, 1}, 2_z},
-                                                              {{0, 1}, 2_z},
-                                                              {{1, 0}, 3_z},
-                                                              {{0, 0}, 0_z}});
+    RCP<const MIntPoly> Pprime = MIntPoly::from_dict({y, x},
+                                                     {{{1, 2}, 1_z},
+                                                      {{1, 1}, 2_z},
+                                                      {{0, 1}, 2_z},
+                                                      {{1, 0}, 3_z},
+                                                      {{0, 0}, 0_z}});
 
     REQUIRE(eq(*Pprime->as_symbolic(),
                *add({mul(pow(x, integer(2)), y), mul(integer(2), mul(x, y)),
@@ -129,16 +131,17 @@ TEST_CASE("Testing MIntPoly::eval((std::map<RCP<const "
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> z = symbol("z");
-    RCP<const MIntPoly> p = MIntPoly::from_dict({x, y, z}, {{{2, 0, 0}, 1_z},
-                                                            {{0, 2, 0}, 2_z},
-                                                            {{0, 0, 2}, 3_z},
-                                                            {{1, 1, 1}, 4_z},
-                                                            {{1, 1, 0}, 1_z},
-                                                            {{0, 1, 1}, 2_z},
-                                                            {{1, 0, 0}, 1_z},
-                                                            {{0, 1, 0}, 2_z},
-                                                            {{0, 0, 1}, 3_z},
-                                                            {{0, 0, 0}, 5_z}});
+    RCP<const MIntPoly> p = MIntPoly::from_dict({x, y, z},
+                                                {{{2, 0, 0}, 1_z},
+                                                 {{0, 2, 0}, 2_z},
+                                                 {{0, 0, 2}, 3_z},
+                                                 {{1, 1, 1}, 4_z},
+                                                 {{1, 1, 0}, 1_z},
+                                                 {{0, 1, 1}, 2_z},
+                                                 {{1, 0, 0}, 1_z},
+                                                 {{0, 1, 0}, 2_z},
+                                                 {{0, 0, 1}, 3_z},
+                                                 {{0, 0, 0}, 5_z}});
     std::map<RCP<const Basic>, integer_class, RCPBasicKeyLess> m1
         = {{x, 1_z}, {y, 2_z}, {z, 5_z}};
     std::map<RCP<const Basic>, integer_class, RCPBasicKeyLess> m2
@@ -173,35 +176,40 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> z = symbol("z");
-    RCP<const MIntPoly> p1 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, 1_z},
-                                                             {{3, 2, 1}, 2_z},
-                                                             {{4, 1, 0}, 3_z},
-                                                             {{0, 0, 0}, 4_z}});
-    RCP<const MIntPoly> p2 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, 1_z},
-                                                             {{3, 2, 1}, -2_z},
-                                                             {{0, 1, 2}, 1_z},
-                                                             {{0, 0, 0}, 3_z}});
+    RCP<const MIntPoly> p1 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, 1_z},
+                                                  {{3, 2, 1}, 2_z},
+                                                  {{4, 1, 0}, 3_z},
+                                                  {{0, 0, 0}, 4_z}});
+    RCP<const MIntPoly> p2 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, 1_z},
+                                                  {{3, 2, 1}, -2_z},
+                                                  {{0, 1, 2}, 1_z},
+                                                  {{0, 0, 0}, 3_z}});
 
-    RCP<const MIntPoly> q1 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, 2_z},
-                                                             {{4, 1, 0}, 3_z},
-                                                             {{0, 1, 2}, 1_z},
-                                                             {{0, 0, 0}, 7_z}});
-    RCP<const MIntPoly> q2 = MIntPoly::from_dict({x, y, z}, {{{3, 2, 1}, 4_z},
-                                                             {{4, 1, 0}, 3_z},
-                                                             {{0, 1, 2}, -1_z},
-                                                             {{0, 0, 0}, 1_z}});
-    RCP<const MIntPoly> q3 = MIntPoly::from_dict({x, y, z}, {{{2, 4, 6}, 1_z},
-                                                             {{5, 3, 3}, 3_z},
-                                                             {{6, 4, 2}, -4_z},
-                                                             {{7, 3, 1}, -6_z},
-                                                             {{1, 3, 5}, 1_z},
-                                                             {{3, 3, 3}, 2_z},
-                                                             {{4, 2, 2}, 3_z},
-                                                             {{0, 1, 2}, 4_z},
-                                                             {{4, 1, 0}, 9_z},
-                                                             {{0, 0, 0}, 12_z},
-                                                             {{3, 2, 1}, -2_z},
-                                                             {{1, 2, 3}, 7_z}});
+    RCP<const MIntPoly> q1 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, 2_z},
+                                                  {{4, 1, 0}, 3_z},
+                                                  {{0, 1, 2}, 1_z},
+                                                  {{0, 0, 0}, 7_z}});
+    RCP<const MIntPoly> q2 = MIntPoly::from_dict({x, y, z},
+                                                 {{{3, 2, 1}, 4_z},
+                                                  {{4, 1, 0}, 3_z},
+                                                  {{0, 1, 2}, -1_z},
+                                                  {{0, 0, 0}, 1_z}});
+    RCP<const MIntPoly> q3 = MIntPoly::from_dict({x, y, z},
+                                                 {{{2, 4, 6}, 1_z},
+                                                  {{5, 3, 3}, 3_z},
+                                                  {{6, 4, 2}, -4_z},
+                                                  {{7, 3, 1}, -6_z},
+                                                  {{1, 3, 5}, 1_z},
+                                                  {{3, 3, 3}, 2_z},
+                                                  {{4, 2, 2}, 3_z},
+                                                  {{0, 1, 2}, 4_z},
+                                                  {{4, 1, 0}, 9_z},
+                                                  {{0, 0, 0}, 12_z},
+                                                  {{3, 2, 1}, -2_z},
+                                                  {{1, 2, 3}, 7_z}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -220,59 +228,61 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> z = symbol("z");
-    RCP<const MIntPoly> p1 = MIntPoly::from_dict({a, b, c}, {{{1, 2, 3}, 1_z},
-                                                             {{3, 2, 1}, 2_z},
-                                                             {{4, 1, 0}, 3_z},
-                                                             {{0, 0, 0}, 4_z}});
-    RCP<const MIntPoly> p2 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, 1_z},
-                                                             {{3, 2, 1}, -2_z},
-                                                             {{0, 1, 2}, 1_z},
-                                                             {{0, 0, 0}, 3_z}});
+    RCP<const MIntPoly> p1 = MIntPoly::from_dict({a, b, c},
+                                                 {{{1, 2, 3}, 1_z},
+                                                  {{3, 2, 1}, 2_z},
+                                                  {{4, 1, 0}, 3_z},
+                                                  {{0, 0, 0}, 4_z}});
+    RCP<const MIntPoly> p2 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, 1_z},
+                                                  {{3, 2, 1}, -2_z},
+                                                  {{0, 1, 2}, 1_z},
+                                                  {{0, 0, 0}, 3_z}});
 
-    RCP<const MIntPoly> q1
-        = MIntPoly::from_dict({a, b, c, x, y, z}, {{{1, 2, 3, 0, 0, 0}, 1_z},
-                                                   {{3, 2, 1, 0, 0, 0}, 2_z},
-                                                   {{4, 1, 0, 0, 0, 0}, 3_z},
-                                                   {{0, 0, 0, 0, 0, 0}, 7_z},
-                                                   {{0, 0, 0, 1, 2, 3}, 1_z},
-                                                   {{0, 0, 0, 3, 2, 1}, -2_z},
-                                                   {{0, 0, 0, 0, 1, 2}, 1_z}});
-    RCP<const MIntPoly> q2
-        = MIntPoly::from_dict({a, b, c, x, y, z}, {{{1, 2, 3, 0, 0, 0}, 1_z},
-                                                   {{3, 2, 1, 0, 0, 0}, 2_z},
-                                                   {{4, 1, 0, 0, 0, 0}, 3_z},
-                                                   {{0, 0, 0, 0, 0, 0}, 1_z},
-                                                   {{0, 0, 0, 1, 2, 3}, -1_z},
-                                                   {{0, 0, 0, 3, 2, 1}, 2_z},
-                                                   {{0, 0, 0, 0, 1, 2}, -1_z}});
-    RCP<const MIntPoly> q3
-        = MIntPoly::from_dict({a, b, c, x, y, z}, {{{1, 2, 3, 0, 0, 0}, -1_z},
-                                                   {{3, 2, 1, 0, 0, 0}, -2_z},
-                                                   {{4, 1, 0, 0, 0, 0}, -3_z},
-                                                   {{0, 0, 0, 0, 0, 0}, -1_z},
-                                                   {{0, 0, 0, 1, 2, 3}, 1_z},
-                                                   {{0, 0, 0, 3, 2, 1}, -2_z},
-                                                   {{0, 0, 0, 0, 1, 2}, 1_z}});
-    RCP<const MIntPoly> q4
-        = MIntPoly::from_dict({a, b, c, x, y, z}, {{{1, 2, 3, 1, 2, 3}, 1_z},
-                                                   {{3, 2, 1, 1, 2, 3}, 2_z},
-                                                   {{4, 1, 0, 1, 2, 3}, 3_z},
-                                                   {{0, 0, 0, 1, 2, 3}, 4_z},
+    RCP<const MIntPoly> q1 = MIntPoly::from_dict({a, b, c, x, y, z},
+                                                 {{{1, 2, 3, 0, 0, 0}, 1_z},
+                                                  {{3, 2, 1, 0, 0, 0}, 2_z},
+                                                  {{4, 1, 0, 0, 0, 0}, 3_z},
+                                                  {{0, 0, 0, 0, 0, 0}, 7_z},
+                                                  {{0, 0, 0, 1, 2, 3}, 1_z},
+                                                  {{0, 0, 0, 3, 2, 1}, -2_z},
+                                                  {{0, 0, 0, 0, 1, 2}, 1_z}});
+    RCP<const MIntPoly> q2 = MIntPoly::from_dict({a, b, c, x, y, z},
+                                                 {{{1, 2, 3, 0, 0, 0}, 1_z},
+                                                  {{3, 2, 1, 0, 0, 0}, 2_z},
+                                                  {{4, 1, 0, 0, 0, 0}, 3_z},
+                                                  {{0, 0, 0, 0, 0, 0}, 1_z},
+                                                  {{0, 0, 0, 1, 2, 3}, -1_z},
+                                                  {{0, 0, 0, 3, 2, 1}, 2_z},
+                                                  {{0, 0, 0, 0, 1, 2}, -1_z}});
+    RCP<const MIntPoly> q3 = MIntPoly::from_dict({a, b, c, x, y, z},
+                                                 {{{1, 2, 3, 0, 0, 0}, -1_z},
+                                                  {{3, 2, 1, 0, 0, 0}, -2_z},
+                                                  {{4, 1, 0, 0, 0, 0}, -3_z},
+                                                  {{0, 0, 0, 0, 0, 0}, -1_z},
+                                                  {{0, 0, 0, 1, 2, 3}, 1_z},
+                                                  {{0, 0, 0, 3, 2, 1}, -2_z},
+                                                  {{0, 0, 0, 0, 1, 2}, 1_z}});
+    RCP<const MIntPoly> q4 = MIntPoly::from_dict({a, b, c, x, y, z},
+                                                 {{{1, 2, 3, 1, 2, 3}, 1_z},
+                                                  {{3, 2, 1, 1, 2, 3}, 2_z},
+                                                  {{4, 1, 0, 1, 2, 3}, 3_z},
+                                                  {{0, 0, 0, 1, 2, 3}, 4_z},
 
-                                                   {{1, 2, 3, 3, 2, 1}, -2_z},
-                                                   {{3, 2, 1, 3, 2, 1}, -4_z},
-                                                   {{4, 1, 0, 3, 2, 1}, -6_z},
-                                                   {{0, 0, 0, 3, 2, 1}, -8_z},
+                                                  {{1, 2, 3, 3, 2, 1}, -2_z},
+                                                  {{3, 2, 1, 3, 2, 1}, -4_z},
+                                                  {{4, 1, 0, 3, 2, 1}, -6_z},
+                                                  {{0, 0, 0, 3, 2, 1}, -8_z},
 
-                                                   {{1, 2, 3, 0, 1, 2}, 1_z},
-                                                   {{3, 2, 1, 0, 1, 2}, 2_z},
-                                                   {{4, 1, 0, 0, 1, 2}, 3_z},
-                                                   {{0, 0, 0, 0, 1, 2}, 4_z},
+                                                  {{1, 2, 3, 0, 1, 2}, 1_z},
+                                                  {{3, 2, 1, 0, 1, 2}, 2_z},
+                                                  {{4, 1, 0, 0, 1, 2}, 3_z},
+                                                  {{0, 0, 0, 0, 1, 2}, 4_z},
 
-                                                   {{1, 2, 3, 0, 0, 0}, 3_z},
-                                                   {{3, 2, 1, 0, 0, 0}, 6_z},
-                                                   {{4, 1, 0, 0, 0, 0}, 9_z},
-                                                   {{0, 0, 0, 0, 0, 0}, 12_z}});
+                                                  {{1, 2, 3, 0, 0, 0}, 3_z},
+                                                  {{3, 2, 1, 0, 0, 0}, 6_z},
+                                                  {{4, 1, 0, 0, 0, 0}, 9_z},
+                                                  {{0, 0, 0, 0, 0, 0}, 12_z}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -294,40 +304,42 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const MIntPoly> p2 = MIntPoly::from_dict(
         {y, z}, {{{2, 1}, -2_z}, {{0, 2}, 1_z}, {{1, 0}, 3_z}});
 
-    RCP<const MIntPoly> q1 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 0}, 1_z},
-                                                             {{4, 0, 0}, 3_z},
-                                                             {{0, 3, 0}, 4_z},
-                                                             {{0, 2, 1}, -2_z},
-                                                             {{0, 0, 2}, 1_z},
-                                                             {{0, 1, 0}, 3_z}});
+    RCP<const MIntPoly> q1 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 0}, 1_z},
+                                                  {{4, 0, 0}, 3_z},
+                                                  {{0, 3, 0}, 4_z},
+                                                  {{0, 2, 1}, -2_z},
+                                                  {{0, 0, 2}, 1_z},
+                                                  {{0, 1, 0}, 3_z}});
 
-    RCP<const MIntPoly> q2
-        = MIntPoly::from_dict({x, y, z}, {{{1, 2, 0}, 1_z},
-                                          {{4, 0, 0}, 3_z},
-                                          {{0, 3, 0}, 4_z},
-                                          {{0, 2, 1}, 2_z},
-                                          {{0, 0, 2}, -1_z},
-                                          {{0, 1, 0}, -3_z}});
+    RCP<const MIntPoly> q2 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 0}, 1_z},
+                                                  {{4, 0, 0}, 3_z},
+                                                  {{0, 3, 0}, 4_z},
+                                                  {{0, 2, 1}, 2_z},
+                                                  {{0, 0, 2}, -1_z},
+                                                  {{0, 1, 0}, -3_z}});
 
-    RCP<const MIntPoly> q3 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 0}, -1_z},
-                                                             {{4, 0, 0}, -3_z},
-                                                             {{0, 3, 0}, -4_z},
-                                                             {{0, 2, 1}, -2_z},
-                                                             {{0, 0, 2}, 1_z},
-                                                             {{0, 1, 0}, 3_z}});
+    RCP<const MIntPoly> q3 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 0}, -1_z},
+                                                  {{4, 0, 0}, -3_z},
+                                                  {{0, 3, 0}, -4_z},
+                                                  {{0, 2, 1}, -2_z},
+                                                  {{0, 0, 2}, 1_z},
+                                                  {{0, 1, 0}, 3_z}});
 
-    RCP<const MIntPoly> q4
-        = MIntPoly::from_dict({x, y, z}, {{{1, 4, 1}, -2_z},
-                                          {{4, 2, 1}, -6_z},
-                                          {{0, 5, 1}, -8_z},
+    RCP<const MIntPoly> q4 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 4, 1}, -2_z},
+                                                  {{4, 2, 1}, -6_z},
+                                                  {{0, 5, 1}, -8_z},
 
-                                          {{1, 2, 2}, 1_z},
-                                          {{4, 0, 2}, 3_z},
-                                          {{0, 3, 2}, 4_z},
+                                                  {{1, 2, 2}, 1_z},
+                                                  {{4, 0, 2}, 3_z},
+                                                  {{0, 3, 2}, 4_z},
 
-                                          {{1, 3, 0}, 3_z},
-                                          {{4, 1, 0}, 9_z},
-                                          {{0, 4, 0}, 12_z}});
+                                                  {{1, 3, 0}, 3_z},
+                                                  {{4, 1, 0}, 9_z},
+                                                  {{0, 4, 0}, 12_z}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -342,13 +354,14 @@ TEST_CASE("Testing derivative of MIntPoly", "[MIntPoly]")
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> z = symbol("z");
-    RCP<const MIntPoly> p = MIntPoly::from_dict({x, y}, {{{2, 1}, 3_z},
-                                                         {{1, 2}, 2_z},
-                                                         {{2, 0}, 3_z},
-                                                         {{0, 2}, 2_z},
-                                                         {{1, 0}, 3_z},
-                                                         {{0, 1}, 2_z},
-                                                         {{0, 0}, 5_z}});
+    RCP<const MIntPoly> p = MIntPoly::from_dict({x, y},
+                                                {{{2, 1}, 3_z},
+                                                 {{1, 2}, 2_z},
+                                                 {{2, 0}, 3_z},
+                                                 {{0, 2}, 2_z},
+                                                 {{1, 0}, 3_z},
+                                                 {{0, 1}, 2_z},
+                                                 {{0, 0}, 5_z}});
 
     RCP<const MIntPoly> q1 = MIntPoly::from_dict(
         {x, y}, {{{1, 1}, 6_z}, {{0, 2}, 2_z}, {{1, 0}, 6_z}, {{0, 0}, 3_z}});
@@ -368,51 +381,56 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
     RCP<const Symbol> x = symbol("x");
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> z = symbol("z");
-    RCP<const MIntPoly> p1 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, 1_z},
-                                                             {{3, 2, 1}, -2_z},
-                                                             {{0, 1, 2}, 1_z},
-                                                             {{0, 0, 0}, 3_z},
-                                                             {{2, 0, 0}, 2_z},
-                                                             {{1, 0, 0}, 1_z}});
+    RCP<const MIntPoly> p1 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, 1_z},
+                                                  {{3, 2, 1}, -2_z},
+                                                  {{0, 1, 2}, 1_z},
+                                                  {{0, 0, 0}, 3_z},
+                                                  {{2, 0, 0}, 2_z},
+                                                  {{1, 0, 0}, 1_z}});
     RCP<const MIntPoly> p2 = MIntPoly::from_dict({x}, {{{1}, 1_z}, {{2}, 1_z}});
     RCP<const MIntPoly> p3 = MIntPoly::from_dict({y}, {{{1}, 1_z}, {{2}, 1_z}});
 
-    RCP<const MIntPoly> q1 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, 1_z},
-                                                             {{3, 2, 1}, -2_z},
-                                                             {{0, 1, 2}, 1_z},
-                                                             {{0, 0, 0}, 3_z},
-                                                             {{2, 0, 0}, 3_z},
-                                                             {{1, 0, 0}, 2_z}});
-    RCP<const MIntPoly> q2 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, 1_z},
-                                                             {{3, 2, 1}, -2_z},
-                                                             {{0, 1, 2}, 1_z},
-                                                             {{0, 0, 0}, 3_z},
-                                                             {{2, 0, 0}, 1_z}});
-    RCP<const MIntPoly> q3
-        = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, -1_z},
-                                          {{3, 2, 1}, 2_z},
-                                          {{0, 1, 2}, -1_z},
-                                          {{0, 0, 0}, -3_z},
-                                          {{2, 0, 0}, -1_z}});
-    RCP<const MIntPoly> q4 = MIntPoly::from_dict({x, y, z}, {{{2, 2, 3}, 1_z},
-                                                             {{4, 2, 1}, -2_z},
-                                                             {{1, 1, 2}, 1_z},
-                                                             {{1, 0, 0}, 3_z},
-                                                             {{3, 0, 0}, 3_z},
+    RCP<const MIntPoly> q1 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, 1_z},
+                                                  {{3, 2, 1}, -2_z},
+                                                  {{0, 1, 2}, 1_z},
+                                                  {{0, 0, 0}, 3_z},
+                                                  {{2, 0, 0}, 3_z},
+                                                  {{1, 0, 0}, 2_z}});
+    RCP<const MIntPoly> q2 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, 1_z},
+                                                  {{3, 2, 1}, -2_z},
+                                                  {{0, 1, 2}, 1_z},
+                                                  {{0, 0, 0}, 3_z},
+                                                  {{2, 0, 0}, 1_z}});
+    RCP<const MIntPoly> q3 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, -1_z},
+                                                  {{3, 2, 1}, 2_z},
+                                                  {{0, 1, 2}, -1_z},
+                                                  {{0, 0, 0}, -3_z},
+                                                  {{2, 0, 0}, -1_z}});
+    RCP<const MIntPoly> q4 = MIntPoly::from_dict({x, y, z},
+                                                 {{{2, 2, 3}, 1_z},
+                                                  {{4, 2, 1}, -2_z},
+                                                  {{1, 1, 2}, 1_z},
+                                                  {{1, 0, 0}, 3_z},
+                                                  {{3, 0, 0}, 3_z},
 
-                                                             {{3, 2, 3}, 1_z},
-                                                             {{5, 2, 1}, -2_z},
-                                                             {{2, 1, 2}, 1_z},
-                                                             {{2, 0, 0}, 4_z},
-                                                             {{4, 0, 0}, 2_z}});
-    RCP<const MIntPoly> q5 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 3}, 1_z},
-                                                             {{3, 2, 1}, -2_z},
-                                                             {{0, 1, 2}, 1_z},
-                                                             {{0, 0, 0}, 3_z},
-                                                             {{2, 0, 0}, 2_z},
-                                                             {{1, 0, 0}, 1_z},
-                                                             {{0, 1, 0}, 1_z},
-                                                             {{0, 2, 0}, 1_z}});
+                                                  {{3, 2, 3}, 1_z},
+                                                  {{5, 2, 1}, -2_z},
+                                                  {{2, 1, 2}, 1_z},
+                                                  {{2, 0, 0}, 4_z},
+                                                  {{4, 0, 0}, 2_z}});
+    RCP<const MIntPoly> q5 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 3}, 1_z},
+                                                  {{3, 2, 1}, -2_z},
+                                                  {{0, 1, 2}, 1_z},
+                                                  {{0, 0, 0}, 3_z},
+                                                  {{2, 0, 0}, 2_z},
+                                                  {{1, 0, 0}, 1_z},
+                                                  {{0, 1, 0}, 1_z},
+                                                  {{0, 2, 0}, 1_z}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*add_mpoly(*p2, *p1), *q1));
@@ -435,34 +453,37 @@ TEST_CASE("Testing addition, subtraction, multiplication of "
         {x, y}, {{{1, 2}, 1_z}, {{2, 1}, -2_z}, {{0, 1}, 1_z}, {{0, 0}, 3_z}});
     RCP<const MIntPoly> p2 = MIntPoly::from_dict({z}, {{{1}, 1_z}, {{2}, 1_z}});
 
-    RCP<const MIntPoly> q1 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 0}, 1_z},
-                                                             {{2, 1, 0}, -2_z},
-                                                             {{0, 1, 0}, 1_z},
-                                                             {{0, 0, 0}, 3_z},
-                                                             {{0, 0, 1}, 1_z},
-                                                             {{0, 0, 2}, 1_z}});
-    RCP<const MIntPoly> q2
-        = MIntPoly::from_dict({x, y, z}, {{{1, 2, 0}, 1_z},
-                                          {{2, 1, 0}, -2_z},
-                                          {{0, 1, 0}, 1_z},
-                                          {{0, 0, 0}, 3_z},
-                                          {{0, 0, 1}, -1_z},
-                                          {{0, 0, 2}, -1_z}});
-    RCP<const MIntPoly> q3 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 0}, -1_z},
-                                                             {{2, 1, 0}, 2_z},
-                                                             {{0, 1, 0}, -1_z},
-                                                             {{0, 0, 0}, -3_z},
-                                                             {{0, 0, 1}, 1_z},
-                                                             {{0, 0, 2}, 1_z}});
-    RCP<const MIntPoly> q4 = MIntPoly::from_dict({x, y, z}, {{{1, 2, 1}, 1_z},
-                                                             {{2, 1, 1}, -2_z},
-                                                             {{0, 1, 1}, 1_z},
-                                                             {{0, 0, 1}, 3_z},
+    RCP<const MIntPoly> q1 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 0}, 1_z},
+                                                  {{2, 1, 0}, -2_z},
+                                                  {{0, 1, 0}, 1_z},
+                                                  {{0, 0, 0}, 3_z},
+                                                  {{0, 0, 1}, 1_z},
+                                                  {{0, 0, 2}, 1_z}});
+    RCP<const MIntPoly> q2 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 0}, 1_z},
+                                                  {{2, 1, 0}, -2_z},
+                                                  {{0, 1, 0}, 1_z},
+                                                  {{0, 0, 0}, 3_z},
+                                                  {{0, 0, 1}, -1_z},
+                                                  {{0, 0, 2}, -1_z}});
+    RCP<const MIntPoly> q3 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 0}, -1_z},
+                                                  {{2, 1, 0}, 2_z},
+                                                  {{0, 1, 0}, -1_z},
+                                                  {{0, 0, 0}, -3_z},
+                                                  {{0, 0, 1}, 1_z},
+                                                  {{0, 0, 2}, 1_z}});
+    RCP<const MIntPoly> q4 = MIntPoly::from_dict({x, y, z},
+                                                 {{{1, 2, 1}, 1_z},
+                                                  {{2, 1, 1}, -2_z},
+                                                  {{0, 1, 1}, 1_z},
+                                                  {{0, 0, 1}, 3_z},
 
-                                                             {{1, 2, 2}, 1_z},
-                                                             {{2, 1, 2}, -2_z},
-                                                             {{0, 1, 2}, 1_z},
-                                                             {{0, 0, 2}, 3_z}});
+                                                  {{1, 2, 2}, 1_z},
+                                                  {{2, 1, 2}, -2_z},
+                                                  {{0, 1, 2}, 1_z},
+                                                  {{0, 0, 2}, 3_z}});
 
     REQUIRE(eq(*add_mpoly(*p1, *p2), *q1));
     REQUIRE(eq(*sub_mpoly(*p1, *p2), *q2));

--- a/symengine/tests/polynomial/test_uintpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_flint.cpp
@@ -353,11 +353,12 @@ TEST_CASE("Factors of UIntPolyFlint", "[UIntPolyFlint]")
                                     x, {{0, 2_z}, {1, 2_z}, {2, 1_z}}),
                                 1)));
 
-        fac = factors(*UIntPolyFlint::from_dict(
-            x, {{0, -1_z},
-                {1, 3_z},
-                {2, -3_z},
-                {3, 1_z}})); // x**3 - 3*x**2 + 3*x - 1
+        fac = factors(
+            *UIntPolyFlint::from_dict(x,
+                                      {{0, -1_z},
+                                       {1, 3_z},
+                                       {2, -3_z},
+                                       {3, 1_z}})); // x**3 - 3*x**2 + 3*x - 1
         REQUIRE(fac.size() == 1);
         REQUIRE(factorcheck(
             fac, std::make_pair(
@@ -377,11 +378,12 @@ TEST_CASE("Factors of UIntPolyFlint", "[UIntPolyFlint]")
                      UIntPolyFlint::from_dict(x, {{0, 1_z}, {2, 1_z}}), 1)));
 
         fac = factors(*UIntPolyFlint::from_dict(
-            x, {{0, -15_z},
-                {1, -46_z},
-                {2, -31_z},
-                {3, 4_z},
-                {4, 4_z}})); // 4*x**4 + 4*x**3 - 31*x**2 - 46*x - 15
+            x,
+            {{0, -15_z},
+             {1, -46_z},
+             {2, -31_z},
+             {3, 4_z},
+             {4, 4_z}})); // 4*x**4 + 4*x**3 - 31*x**2 - 46*x - 15
         REQUIRE(fac.size() == 4);
         REQUIRE(factorcheck(
             fac, std::make_pair(
@@ -397,18 +399,19 @@ TEST_CASE("Factors of UIntPolyFlint", "[UIntPolyFlint]")
                      UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 2_z}}), 1)));
 
         fac = factors(*UIntPolyFlint::from_dict(
-            x, {{0, 47628_z},
-                {1, 90720_z},
-                {2, -77004_z},
-                {3, -207720_z},
-                {4, 6468_z},
-                {5, 145232_z},
-                {6, 28460_z},
-                {7, -31336_z},
-                {8, -5040_z},
-                {9, 2592_z}})); // 2592*x**9  - 5040*x**8  - 31336*x**7  +
-                                // 28460*x**6  + 145232*x**5  + 6468*x**4  -
-                                // 207720*x**3  - 77004*x**2  + 90720*x + 47628
+            x,
+            {{0, 47628_z},
+             {1, 90720_z},
+             {2, -77004_z},
+             {3, -207720_z},
+             {4, 6468_z},
+             {5, 145232_z},
+             {6, 28460_z},
+             {7, -31336_z},
+             {8, -5040_z},
+             {9, 2592_z}})); // 2592*x**9  - 5040*x**8  - 31336*x**7  +
+                             // 28460*x**6  + 145232*x**5  + 6468*x**4  -
+                             // 207720*x**3  - 77004*x**2  + 90720*x + 47628
         REQUIRE(fac.size() == 5);
         REQUIRE(factorcheck(
             fac, std::make_pair(UIntPolyFlint::from_dict(x, {{0, 4_z}}), 1)));

--- a/symengine/tests/polynomial/test_uratpoly.cpp
+++ b/symengine/tests/polynomial/test_uratpoly.cpp
@@ -191,8 +191,9 @@ TEST_CASE("URatPoly as_symbolic", "[URatPoly]")
 
     RCP<const URatPoly> b
         = URatPoly::from_dict(x, {{1, rc(3_z, 2_z)}, {2, 2_q}});
-    REQUIRE(eq(*b->as_symbolic(), *add(mul(x, div(integer(3), integer(2))),
-                                       mul(integer(2), pow(x, integer(2))))));
+    REQUIRE(eq(*b->as_symbolic(),
+               *add(mul(x, div(integer(3), integer(2))),
+                    mul(integer(2), pow(x, integer(2))))));
 
     RCP<const URatPoly> c = URatPoly::from_dict(x, map_uint_mpq{});
     REQUIRE(eq(*c->as_symbolic(), *zero));

--- a/symengine/tests/polynomial/test_uratpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uratpoly_flint.cpp
@@ -174,8 +174,9 @@ TEST_CASE("URatPolyFlint as_symbolic", "[URatPolyFlint]")
 
     RCP<const URatPolyFlint> b
         = URatPolyFlint::from_dict(x, {{1, rc(3_z, 2_z)}, {2, 2_q}});
-    REQUIRE(eq(*b->as_symbolic(), *add(mul(x, div(integer(3), integer(2))),
-                                       mul(integer(2), pow(x, integer(2))))));
+    REQUIRE(eq(*b->as_symbolic(),
+               *add(mul(x, div(integer(3), integer(2))),
+                    mul(integer(2), pow(x, integer(2))))));
 
     RCP<const URatPolyFlint> c = URatPolyFlint::from_dict(x, map_uint_mpq{});
     REQUIRE(eq(*c->as_symbolic(), *zero));

--- a/symengine/tests/polynomial/test_uratpoly_piranha.cpp
+++ b/symengine/tests/polynomial/test_uratpoly_piranha.cpp
@@ -172,8 +172,9 @@ TEST_CASE("URatPolyPiranha as_symbolic", "[URatPolyPiranha]")
 
     RCP<const URatPolyPiranha> b
         = URatPolyPiranha::from_dict(x, {{1, rc(3_z, 2_z)}, {2, 2_q}});
-    REQUIRE(eq(*b->as_symbolic(), *add(mul(x, div(integer(3), integer(2))),
-                                       mul(integer(2), pow(x, integer(2))))));
+    REQUIRE(eq(*b->as_symbolic(),
+               *add(mul(x, div(integer(3), integer(2))),
+                    mul(integer(2), pow(x, integer(2))))));
 
     RCP<const URatPolyPiranha> c
         = URatPolyPiranha::from_dict(x, map_uint_mpq{});

--- a/symengine/utilities/catch/catch.cpp
+++ b/symengine/utilities/catch/catch.cpp
@@ -15,17 +15,17 @@
 #include <arb.h>
 #endif // HAVE_SYMENGINE_ARB
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-	int result = Catch::Session().run( argc, argv );
+    int result = Catch::Session().run(argc, argv);
 
-	#if defined(HAVE_SYMENGINE_MPFR)
-	   mpfr_free_cache();
-	#endif // HAVE_SYMENGINE_MPFR
+#if defined(HAVE_SYMENGINE_MPFR)
+    mpfr_free_cache();
+#endif // HAVE_SYMENGINE_MPFR
 
-	#if defined(HAVE_SYMENGINE_ARB)
-	   flint_cleanup();
-	#endif // HAVE_SYMENGINE_ARB
+#if defined(HAVE_SYMENGINE_ARB)
+    flint_cleanup();
+#endif // HAVE_SYMENGINE_ARB
 
-	return result;
+    return result;
 }

--- a/symengine/utilities/teuchos/Teuchos_DLLExportMacro.h
+++ b/symengine/utilities/teuchos/Teuchos_DLLExportMacro.h
@@ -1,9 +1,9 @@
-#if defined (_WIN32) && defined (BUILD_SHARED_LIBS)
-#  if defined(TEUCHOS_LIB_EXPORTS_MODE)
-#    define TEUCHOS_LIB_DLL_EXPORT __declspec(dllexport)
-#  else
-#    define TEUCHOS_LIB_DLL_EXPORT __declspec(dllimport)
-#  endif
+#if defined(_WIN32) && defined(BUILD_SHARED_LIBS)
+#if defined(TEUCHOS_LIB_EXPORTS_MODE)
+#define TEUCHOS_LIB_DLL_EXPORT __declspec(dllexport)
 #else
-#  define TEUCHOS_LIB_DLL_EXPORT
+#define TEUCHOS_LIB_DLL_EXPORT __declspec(dllimport)
+#endif
+#else
+#define TEUCHOS_LIB_DLL_EXPORT
 #endif

--- a/symengine/utilities/teuchos/Teuchos_Ptr.cpp
+++ b/symengine/utilities/teuchos/Teuchos_Ptr.cpp
@@ -39,16 +39,15 @@
 // ***********************************************************************
 // @HEADER
 
-
 #include "Teuchos_Ptr.hpp"
 #include "Teuchos_Assert.hpp"
 #include "Teuchos_Exceptions.hpp"
 
-
-void Teuchos::PtrPrivateUtilityPack::throw_null( const std::string &type_name )
+void Teuchos::PtrPrivateUtilityPack::throw_null(const std::string &type_name)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    true, NullReferenceError,
-    "Ptr<"<<type_name<<">::assert_not_null() : You can not"
-    " call operator->() or operator*() if get()==NULL!" );
+    TEUCHOS_TEST_FOR_EXCEPTION(
+        true, NullReferenceError,
+        "Ptr<" << type_name
+               << ">::assert_not_null() : You can not"
+                  " call operator->() or operator*() if get()==NULL!");
 }

--- a/symengine/utilities/teuchos/Teuchos_RCPNode.cpp
+++ b/symengine/utilities/teuchos/Teuchos_RCPNode.cpp
@@ -43,54 +43,50 @@
 #include "Teuchos_Assert.hpp"
 #include "Teuchos_Exceptions.hpp"
 
-
 // Defined this to see tracing of RCPNodes created and destroyed
 //#define RCP_NODE_DEBUG_TRACE_PRINT
-
 
 //
 // Internal implementatation stuff
 //
 
-
-namespace {
-
+namespace
+{
 
 //
 // Local implementation types
 //
 
-
 struct RCPNodeInfo {
-  RCPNodeInfo() : nodePtr(0) {}
-  RCPNodeInfo(const std::string &info_in, Teuchos::RCPNode* nodePtr_in)
-    : info(info_in), nodePtr(nodePtr_in)
-    {}
-  std::string info;
-  Teuchos::RCPNode* nodePtr;
+    RCPNodeInfo() : nodePtr(0)
+    {
+    }
+    RCPNodeInfo(const std::string &info_in, Teuchos::RCPNode *nodePtr_in)
+        : info(info_in), nodePtr(nodePtr_in)
+    {
+    }
+    std::string info;
+    Teuchos::RCPNode *nodePtr;
 };
 
+typedef std::pair<const void *, RCPNodeInfo> VoidPtrNodeRCPInfoPair_t;
 
-typedef std::pair<const void*, RCPNodeInfo> VoidPtrNodeRCPInfoPair_t;
+typedef std::multimap<const void *, RCPNodeInfo> rcp_node_list_t;
 
-
-typedef std::multimap<const void*, RCPNodeInfo> rcp_node_list_t;
-
-
-class RCPNodeInfoListPred {
+class RCPNodeInfoListPred
+{
 public:
-  bool operator()(const rcp_node_list_t::value_type &v1,
-    const rcp_node_list_t::value_type &v2
-    ) const
+    bool operator()(const rcp_node_list_t::value_type &v1,
+                    const rcp_node_list_t::value_type &v2) const
     {
 #ifdef TEUCHOS_DEBUG
-      return v1.second.nodePtr->insertion_number() < v2.second.nodePtr->insertion_number();
+        return v1.second.nodePtr->insertion_number()
+               < v2.second.nodePtr->insertion_number();
 #else
-      return v1.first < v2.first;
+        return v1.first < v2.first;
 #endif
     }
 };
-
 
 //
 // Local static functions returning references to local static objects to
@@ -108,47 +104,44 @@ public:
 // recompilation (and even relinking with shared libraries).
 //
 
-
-rcp_node_list_t*& rcp_node_list()
+rcp_node_list_t *&rcp_node_list()
 {
-  static rcp_node_list_t *s_rcp_node_list = 0;
-  // Here we must let the ActiveRCPNodesSetup constructor and destructor handle
-  // the creation and destruction of this map object.  This will ensure that
-  // this map object will be valid when any global/static RCP objects are
-  // destroyed!  Note that this object will get created and destroyed
-  // reguardless if whether we are tracing RCPNodes or not.  This just makes our
-  // life simpler.  NOTE: This list will always get allocated no mater if
-  // TEUCHOS_DEBUG is defined or node traceing is enabled or not.
-  return s_rcp_node_list;
+    static rcp_node_list_t *s_rcp_node_list = 0;
+    // Here we must let the ActiveRCPNodesSetup constructor and destructor
+    // handle
+    // the creation and destruction of this map object.  This will ensure that
+    // this map object will be valid when any global/static RCP objects are
+    // destroyed!  Note that this object will get created and destroyed
+    // reguardless if whether we are tracing RCPNodes or not.  This just makes
+    // our
+    // life simpler.  NOTE: This list will always get allocated no mater if
+    // TEUCHOS_DEBUG is defined or node traceing is enabled or not.
+    return s_rcp_node_list;
 }
 
-
-bool& loc_isTracingActiveRCPNodes()
+bool &loc_isTracingActiveRCPNodes()
 {
-  static bool s_loc_isTracingActiveRCPNodes =
+    static bool s_loc_isTracingActiveRCPNodes =
 #if defined(TEUCHOS_DEBUG) && defined(HAVE_TEUCHOS_DEBUG_RCP_NODE_TRACING)
-    true
+        true
 #else
-    false
+        false
 #endif
-    ;
-  return s_loc_isTracingActiveRCPNodes;
+        ;
+    return s_loc_isTracingActiveRCPNodes;
 }
 
-
-Teuchos::RCPNodeTracer::RCPNodeStatistics& loc_rcpNodeStatistics()
+Teuchos::RCPNodeTracer::RCPNodeStatistics &loc_rcpNodeStatistics()
 {
-  static Teuchos::RCPNodeTracer::RCPNodeStatistics s_loc_rcpNodeStatistics;
-  return s_loc_rcpNodeStatistics;
+    static Teuchos::RCPNodeTracer::RCPNodeStatistics s_loc_rcpNodeStatistics;
+    return s_loc_rcpNodeStatistics;
 }
 
-
-bool& loc_printRCPNodeStatisticsOnExit()
+bool &loc_printRCPNodeStatisticsOnExit()
 {
-  static bool s_loc_printRCPNodeStatisticsOnExit = false;
-  return s_loc_printRCPNodeStatisticsOnExit;
+    static bool s_loc_printRCPNodeStatisticsOnExit = false;
+    return s_loc_printRCPNodeStatisticsOnExit;
 }
-
 
 //
 // Other helper functions
@@ -161,468 +154,469 @@ bool& loc_printRCPNodeStatisticsOnExit()
 // object.  If the RCPNode has an null internal object pointer, then we will
 // use the RCPNode's address itself.  In this case, we want to check and see
 // that all RCPNodes that get created get destroyed correctly.
-const void* get_map_key_void_ptr(const Teuchos::RCPNode* rcp_node)
+const void *get_map_key_void_ptr(const Teuchos::RCPNode *rcp_node)
 {
-  TEUCHOS_ASSERT(rcp_node);
+    TEUCHOS_ASSERT(rcp_node);
 #ifdef TEUCHOS_DEBUG
-  const void* base_obj_map_key_void_ptr = rcp_node->get_base_obj_map_key_void_ptr();
-  if (base_obj_map_key_void_ptr)
-    return base_obj_map_key_void_ptr;
+    const void *base_obj_map_key_void_ptr
+        = rcp_node->get_base_obj_map_key_void_ptr();
+    if (base_obj_map_key_void_ptr)
+        return base_obj_map_key_void_ptr;
 #endif
-  return rcp_node;
+    return rcp_node;
 }
 
-
-std::string convertRCPNodeToString(const Teuchos::RCPNode* rcp_node)
+std::string convertRCPNodeToString(const Teuchos::RCPNode *rcp_node)
 {
-  std::ostringstream oss;
-  oss
-    << "RCPNode {address="
-    << rcp_node
+    std::ostringstream oss;
+    oss << "RCPNode {address=" << rcp_node
 #ifdef TEUCHOS_DEBUG
-    << ", base_obj_map_key_void_ptr=" << rcp_node->get_base_obj_map_key_void_ptr()
+        << ", base_obj_map_key_void_ptr="
+        << rcp_node->get_base_obj_map_key_void_ptr()
 #endif
-    << ", base_obj_type_name=" << rcp_node->get_base_obj_type_name()
-    << ", map_key_void_ptr=" << get_map_key_void_ptr(rcp_node)
-    << ", has_ownership=" << rcp_node->has_ownership()
+        << ", base_obj_type_name=" << rcp_node->get_base_obj_type_name()
+        << ", map_key_void_ptr=" << get_map_key_void_ptr(rcp_node)
+        << ", has_ownership=" << rcp_node->has_ownership()
 #ifdef TEUCHOS_DEBUG
-    << ", insertionNumber="<< rcp_node->insertion_number()
+        << ", insertionNumber=" << rcp_node->insertion_number()
 #endif
-    << "}";
-  return oss.str();
+        << "}";
+    return oss.str();
 }
-
 
 } // namespace
 
-
-namespace Teuchos {
-
+namespace Teuchos
+{
 
 //
 // RCPNode
 //
 
-
-void RCPNode::set_extra_data(
-  const any &extra_data, const std::string& name
-  ,EPrePostDestruction destroy_when
-  ,bool force_unique
-  )
+void RCPNode::set_extra_data(const any &extra_data, const std::string &name,
+                             EPrePostDestruction destroy_when,
+                             bool force_unique)
 {
-  if(extra_data_map_==NULL) {
-    extra_data_map_ = new extra_data_map_t;
-  }
-  const std::string type_and_name( extra_data.typeName() + std::string(":") + name );
-  extra_data_map_t::iterator itr = extra_data_map_->find(type_and_name);
+    if (extra_data_map_ == NULL) {
+        extra_data_map_ = new extra_data_map_t;
+    }
+    const std::string type_and_name(extra_data.typeName() + std::string(":")
+                                    + name);
+    extra_data_map_t::iterator itr = extra_data_map_->find(type_and_name);
 #ifdef TEUCHOS_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    (itr != extra_data_map_->end() && force_unique), std::invalid_argument
-    ,"Error, the type:name pair \'" << type_and_name
-    << "\' already exists and force_unique==true!" );
-#endif
-  if (itr != extra_data_map_->end()) {
-    // Change existing extra data
-    itr->second = extra_data_entry_t(extra_data,destroy_when);
-  }
-  else {
-    // Insert new extra data
-    (*extra_data_map_)[type_and_name] =
-      extra_data_entry_t(extra_data,destroy_when);
-  }
-}
-
-
-any& RCPNode::get_extra_data( const std::string& type_name, const std::string& name )
-{
-#ifdef TEUCHOS_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    extra_data_map_==NULL, std::invalid_argument
-    ,"Error, no extra data has been set yet!" );
-#endif
-  any *extra_data = get_optional_extra_data(type_name,name);
-#ifdef TEUCHOS_DEBUG
-  if (!extra_data) {
-    const std::string type_and_name( type_name + std::string(":") + name );
     TEUCHOS_TEST_FOR_EXCEPTION(
-      extra_data == NULL, std::invalid_argument
-      ,"Error, the type:name pair \'" << type_and_name << "\' is not found!" );
-  }
+        (itr != extra_data_map_->end() && force_unique), std::invalid_argument,
+        "Error, the type:name pair \'"
+            << type_and_name << "\' already exists and force_unique==true!");
 #endif
-  return *extra_data;
+    if (itr != extra_data_map_->end()) {
+        // Change existing extra data
+        itr->second = extra_data_entry_t(extra_data, destroy_when);
+    } else {
+        // Insert new extra data
+        (*extra_data_map_)[type_and_name]
+            = extra_data_entry_t(extra_data, destroy_when);
+    }
 }
 
-
-any* RCPNode::get_optional_extra_data( const std::string& type_name,
-  const std::string& name )
+any &RCPNode::get_extra_data(const std::string &type_name,
+                             const std::string &name)
 {
-  if( extra_data_map_ == NULL ) return NULL;
-  const std::string type_and_name( type_name + std::string(":") + name );
-  extra_data_map_t::iterator itr = extra_data_map_->find(type_and_name);
-  if(itr != extra_data_map_->end())
-    return &(*itr).second.extra_data;
-  return NULL;
+#ifdef TEUCHOS_DEBUG
+    TEUCHOS_TEST_FOR_EXCEPTION(extra_data_map_ == NULL, std::invalid_argument,
+                               "Error, no extra data has been set yet!");
+#endif
+    any *extra_data = get_optional_extra_data(type_name, name);
+#ifdef TEUCHOS_DEBUG
+    if (!extra_data) {
+        const std::string type_and_name(type_name + std::string(":") + name);
+        TEUCHOS_TEST_FOR_EXCEPTION(extra_data == NULL, std::invalid_argument,
+                                   "Error, the type:name pair \'"
+                                       << type_and_name << "\' is not found!");
+    }
+#endif
+    return *extra_data;
 }
 
+any *RCPNode::get_optional_extra_data(const std::string &type_name,
+                                      const std::string &name)
+{
+    if (extra_data_map_ == NULL)
+        return NULL;
+    const std::string type_and_name(type_name + std::string(":") + name);
+    extra_data_map_t::iterator itr = extra_data_map_->find(type_and_name);
+    if (itr != extra_data_map_->end())
+        return &(*itr).second.extra_data;
+    return NULL;
+}
 
 void RCPNode::impl_pre_delete_extra_data()
 {
-  for(
-    extra_data_map_t::iterator itr = extra_data_map_->begin();
-    itr != extra_data_map_->end();
-    ++itr
-    )
-  {
-    extra_data_map_t::value_type &entry = *itr;
-    if(entry.second.destroy_when == PRE_DESTROY)
-      entry.second.extra_data = any();
-  }
+    for (extra_data_map_t::iterator itr = extra_data_map_->begin();
+         itr != extra_data_map_->end(); ++itr) {
+        extra_data_map_t::value_type &entry = *itr;
+        if (entry.second.destroy_when == PRE_DESTROY)
+            entry.second.extra_data = any();
+    }
 }
-
 
 //
 // RCPNodeTracer
 //
 
-
 // General user functions
-
 
 bool RCPNodeTracer::isTracingActiveRCPNodes()
 {
-  return loc_isTracingActiveRCPNodes();
+    return loc_isTracingActiveRCPNodes();
 }
-
 
 #if defined(TEUCHOS_DEBUG) && !defined(HAVE_TEUCHOS_DEBUG_RCP_NODE_TRACING)
 void RCPNodeTracer::setTracingActiveRCPNodes(bool tracingActiveNodes)
 {
-  loc_isTracingActiveRCPNodes() = tracingActiveNodes;
+    loc_isTracingActiveRCPNodes() = tracingActiveNodes;
 }
 #endif
 
-
 int RCPNodeTracer::numActiveRCPNodes()
 {
-  // This list always exists, no matter debug or not so just access it.
-  TEUCHOS_TEST_FOR_EXCEPT(0==rcp_node_list());
-  return rcp_node_list()->size();
-  return 0;
+    // This list always exists, no matter debug or not so just access it.
+    TEUCHOS_TEST_FOR_EXCEPT(0 == rcp_node_list());
+    return rcp_node_list()->size();
+    return 0;
 }
 
-
-RCPNodeTracer::RCPNodeStatistics
-RCPNodeTracer::getRCPNodeStatistics()
+RCPNodeTracer::RCPNodeStatistics RCPNodeTracer::getRCPNodeStatistics()
 {
-  return loc_rcpNodeStatistics();
+    return loc_rcpNodeStatistics();
 }
 
 void RCPNodeTracer::printRCPNodeStatistics(
-    const RCPNodeStatistics& rcpNodeStatistics, std::ostream &out)
+    const RCPNodeStatistics &rcpNodeStatistics, std::ostream &out)
 {
-  out
-    << "\n***"
-    << "\n*** RCPNode Tracing statistics:"
-    << "\n**\n"
-    << "\n    maxNumRCPNodes             = "<<rcpNodeStatistics.maxNumRCPNodes
-    << "\n    totalNumRCPNodeAllocations = "<<rcpNodeStatistics.totalNumRCPNodeAllocations
-    << "\n    totalNumRCPNodeDeletions   = "<<rcpNodeStatistics.totalNumRCPNodeDeletions
-    << "\n";
+    out << "\n***"
+        << "\n*** RCPNode Tracing statistics:"
+        << "\n**\n"
+        << "\n    maxNumRCPNodes             = "
+        << rcpNodeStatistics.maxNumRCPNodes
+        << "\n    totalNumRCPNodeAllocations = "
+        << rcpNodeStatistics.totalNumRCPNodeAllocations
+        << "\n    totalNumRCPNodeDeletions   = "
+        << rcpNodeStatistics.totalNumRCPNodeDeletions << "\n";
 }
-
 
 void RCPNodeTracer::setPrintRCPNodeStatisticsOnExit(
-  bool printRCPNodeStatisticsOnExit)
+    bool printRCPNodeStatisticsOnExit)
 {
-  loc_printRCPNodeStatisticsOnExit() = printRCPNodeStatisticsOnExit;
+    loc_printRCPNodeStatisticsOnExit() = printRCPNodeStatisticsOnExit;
 }
-
 
 bool RCPNodeTracer::getPrintRCPNodeStatisticsOnExit()
 {
-  return loc_printRCPNodeStatisticsOnExit();
+    return loc_printRCPNodeStatisticsOnExit();
 }
-
 
 void RCPNodeTracer::printActiveRCPNodes(std::ostream &out)
 {
 #ifdef TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
-  out
-    << "\nCalled printActiveRCPNodes() :"
-    << " rcp_node_list.size() = " << rcp_node_list().size() << "\n";
+    out << "\nCalled printActiveRCPNodes() :"
+        << " rcp_node_list.size() = " << rcp_node_list().size() << "\n";
 #endif // TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
-  if (loc_isTracingActiveRCPNodes()) {
-    TEUCHOS_TEST_FOR_EXCEPT(0==rcp_node_list());
-    if (rcp_node_list()->size() > 0) {
-      out << getActiveRCPNodeHeaderString();
-      // Create a sorted-by-insertionNumber list
-      // NOTE: You have to use std::vector and *not* Teuchos::Array rcp here
-      // because this called at the very end and uses RCPNode itself in a
-      // debug-mode build.
-      typedef std::vector<VoidPtrNodeRCPInfoPair_t> rcp_node_vec_t;
-      rcp_node_vec_t rcp_node_vec(rcp_node_list()->begin(), rcp_node_list()->end());
-      std::sort(rcp_node_vec.begin(), rcp_node_vec.end(), RCPNodeInfoListPred());
-      // Print the RCPNode objects sorted by insertion number
-      typedef rcp_node_vec_t::const_iterator itr_t;
-      int i = 0;
-      for ( itr_t itr = rcp_node_vec.begin(); itr != rcp_node_vec.end(); ++itr ) {
-        const rcp_node_list_t::value_type &entry = *itr;
-        TEUCHOS_ASSERT(entry.second.nodePtr);
-        out
-          << "\n"
-          << std::setw(3) << std::right << i << std::left
-          << ": RCPNode (map_key_void_ptr=" << entry.first << ")\n"
-          << "       Information = " << entry.second.info << "\n"
-          << "       RCPNode address = " << entry.second.nodePtr << "\n"
+    if (loc_isTracingActiveRCPNodes()) {
+        TEUCHOS_TEST_FOR_EXCEPT(0 == rcp_node_list());
+        if (rcp_node_list()->size() > 0) {
+            out << getActiveRCPNodeHeaderString();
+            // Create a sorted-by-insertionNumber list
+            // NOTE: You have to use std::vector and *not* Teuchos::Array rcp
+            // here
+            // because this called at the very end and uses RCPNode itself in a
+            // debug-mode build.
+            typedef std::vector<VoidPtrNodeRCPInfoPair_t> rcp_node_vec_t;
+            rcp_node_vec_t rcp_node_vec(rcp_node_list()->begin(),
+                                        rcp_node_list()->end());
+            std::sort(rcp_node_vec.begin(), rcp_node_vec.end(),
+                      RCPNodeInfoListPred());
+            // Print the RCPNode objects sorted by insertion number
+            typedef rcp_node_vec_t::const_iterator itr_t;
+            int i = 0;
+            for (itr_t itr = rcp_node_vec.begin(); itr != rcp_node_vec.end();
+                 ++itr) {
+                const rcp_node_list_t::value_type &entry = *itr;
+                TEUCHOS_ASSERT(entry.second.nodePtr);
+                out << "\n"
+                    << std::setw(3) << std::right << i << std::left
+                    << ": RCPNode (map_key_void_ptr=" << entry.first << ")\n"
+                    << "       Information = " << entry.second.info << "\n"
+                    << "       RCPNode address = " << entry.second.nodePtr
+                    << "\n"
 #ifdef TEUCHOS_DEBUG
-          << "       insertionNumber = " << entry.second.nodePtr->insertion_number()
+                    << "       insertionNumber = "
+                    << entry.second.nodePtr->insertion_number()
 #endif
-          ;
-        ++i;
-      }
-      out << "\n\n"
-          << getCommonDebugNotesString();
+                    ;
+                ++i;
+            }
+            out << "\n\n" << getCommonDebugNotesString();
+        }
     }
-  }
 }
-
 
 // Internal implementation functions
 
-
-void RCPNodeTracer::addNewRCPNode( RCPNode* rcp_node, const std::string &info )
+void RCPNodeTracer::addNewRCPNode(RCPNode *rcp_node, const std::string &info)
 {
 
-  // Used to allow unique identification of rcp_node to allow setting breakpoints
-  static int insertionNumber = 0;
+    // Used to allow unique identification of rcp_node to allow setting
+    // breakpoints
+    static int insertionNumber = 0;
 
-  // Set the insertion number right away in case an exception gets thrown so
-  // that you can set a break point to debug this.
+// Set the insertion number right away in case an exception gets thrown so
+// that you can set a break point to debug this.
 #ifdef TEUCHOS_DEBUG
-  rcp_node->set_insertion_number(insertionNumber);
+    rcp_node->set_insertion_number(insertionNumber);
 #endif
 
-  if (loc_isTracingActiveRCPNodes()) {
+    if (loc_isTracingActiveRCPNodes()) {
 
-    // Print the node we are adding if configured to do so.  We have to send
-    // to std::cerr to make sure that this gets printed.
+// Print the node we are adding if configured to do so.  We have to send
+// to std::cerr to make sure that this gets printed.
 #ifdef RCP_NODE_DEBUG_TRACE_PRINT
-    std::cerr
-      << "RCPNodeTracer::addNewRCPNode(...): Adding "
-      << convertRCPNodeToString(rcp_node) << " ...\n";
+        std::cerr << "RCPNodeTracer::addNewRCPNode(...): Adding "
+                  << convertRCPNodeToString(rcp_node) << " ...\n";
 #endif
 
-    TEUCHOS_TEST_FOR_EXCEPT(0==rcp_node_list());
+        TEUCHOS_TEST_FOR_EXCEPT(0 == rcp_node_list());
 
-    const void * const map_key_void_ptr = get_map_key_void_ptr(rcp_node);
+        const void *const map_key_void_ptr = get_map_key_void_ptr(rcp_node);
 
-    // See if the rcp_node or its object has already been added.
+        // See if the rcp_node or its object has already been added.
+        typedef rcp_node_list_t::iterator itr_t;
+        typedef std::pair<itr_t, itr_t> itr_itr_t;
+        const itr_itr_t itr_itr
+            = rcp_node_list()->equal_range(map_key_void_ptr);
+        const bool rcp_node_already_exists = itr_itr.first != itr_itr.second;
+        RCPNode *previous_rcp_node = 0;
+        bool previous_rcp_node_has_ownership = false;
+        for (itr_t itr = itr_itr.first; itr != itr_itr.second; ++itr) {
+            previous_rcp_node = itr->second.nodePtr;
+            if (previous_rcp_node->has_ownership()) {
+                previous_rcp_node_has_ownership = true;
+                break;
+            }
+        }
+        TEUCHOS_TEST_FOR_EXCEPTION(
+            rcp_node_already_exists && rcp_node->has_ownership()
+                && previous_rcp_node_has_ownership,
+            DuplicateOwningRCPError,
+            "RCPNodeTracer::addNewRCPNode(rcp_node): Error, the client is "
+            "trying to create a new\n"
+            "RCPNode object to an existing managed object in another RCPNode:\n"
+            "\n"
+            "  New "
+                << convertRCPNodeToString(rcp_node) << "\n"
+                                                       "\n"
+                                                       "  Existing "
+                << convertRCPNodeToString(previous_rcp_node)
+                << "\n"
+                   "\n"
+                   "  Number current nodes = "
+                << rcp_node_list()->size()
+                << "\n"
+                   "\n"
+                   "This may indicate that the user might be trying to create "
+                   "a weak RCP to an existing\n"
+                   "object but forgot make it non-ownning.  Perhaps they meant "
+                   "to use rcpFromRef(...)\n"
+                   "or an equivalent function?\n"
+                   "\n"
+                << getCommonDebugNotesString(););
+
+        // NOTE: We allow duplicate RCPNodes if the new node is non-owning. This
+        // might indicate a advanced usage of the RCP class that we want to
+        // support.  The typical problem is when the programmer unknowingly
+        // creates an owning RCP to an object already owned by another RCPNode.
+
+        // Add the new RCP node keyed as described above.
+        (*rcp_node_list())
+            .insert(
+                itr_itr.second,
+                std::make_pair(map_key_void_ptr, RCPNodeInfo(info, rcp_node)));
+        // NOTE: Above, if there is already an existing RCPNode with the same
+        // key
+        // value, this iterator itr_itr.second will point to one after the found
+        // range.  I suspect that this might also ensure that the elements are
+        // sorted in natural order.
+
+        // Update the insertion number an node tracing statistics
+        ++insertionNumber;
+        ++loc_rcpNodeStatistics().totalNumRCPNodeAllocations;
+        loc_rcpNodeStatistics().maxNumRCPNodes = TEUCHOS_MAX(
+            loc_rcpNodeStatistics().maxNumRCPNodes, numActiveRCPNodes());
+    }
+}
+
+#define TEUCHOS_RCPNODE_REMOVE_RCPNODE(CONDITION, RCPNODE)                     \
+    TEUCHOS_TEST_FOR_EXCEPTION(                                                \
+        (CONDITION), std::logic_error,                                         \
+        "RCPNodeTracer::removeRCPNode(node_ptr): Error, the "                  \
+            << convertRCPNodeToString(RCPNODE)                                 \
+            << " is not found in the list of"                                  \
+               " active RCP nodes being traced even though all nodes should "  \
+               "be traced."                                                    \
+               "  This should not be possible and can only be an internal "    \
+               "programming error!")
+
+void RCPNodeTracer::removeRCPNode(RCPNode *rcp_node)
+{
+
+    // Here, we will try to remove an RCPNode reguardless if whether
+    // loc_isTracingActiveRCPNodes==true or not.  This will not be a performance
+    // problem and it will ensure that any RCPNode objects that are added to
+    // this list will be removed and will not look like a memory leak.  In
+    // non-debug mode, this function will never be called.  In debug mode, with
+    // loc_isTracingActiveRCPNodes==false, the list *rcp_node_list will be empty
+    // and
+    // therefore this find(...) operation should be pretty cheap (even for a bad
+    // implementation of std::map).
+
+    TEUCHOS_ASSERT(rcp_node_list());
     typedef rcp_node_list_t::iterator itr_t;
     typedef std::pair<itr_t, itr_t> itr_itr_t;
-    const itr_itr_t itr_itr = rcp_node_list()->equal_range(map_key_void_ptr);
-    const bool rcp_node_already_exists = itr_itr.first != itr_itr.second;
-    RCPNode *previous_rcp_node = 0;
-    bool previous_rcp_node_has_ownership = false;
-    for (itr_t itr = itr_itr.first; itr != itr_itr.second; ++itr) {
-      previous_rcp_node = itr->second.nodePtr;
-      if (previous_rcp_node->has_ownership()) {
-        previous_rcp_node_has_ownership = true;
-        break;
-      }
-    }
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      rcp_node_already_exists && rcp_node->has_ownership() && previous_rcp_node_has_ownership,
-      DuplicateOwningRCPError,
-      "RCPNodeTracer::addNewRCPNode(rcp_node): Error, the client is trying to create a new\n"
-      "RCPNode object to an existing managed object in another RCPNode:\n"
-      "\n"
-      "  New " << convertRCPNodeToString(rcp_node) << "\n"
-      "\n"
-      "  Existing " << convertRCPNodeToString(previous_rcp_node) << "\n"
-      "\n"
-      "  Number current nodes = " << rcp_node_list()->size() << "\n"
-      "\n"
-      "This may indicate that the user might be trying to create a weak RCP to an existing\n"
-      "object but forgot make it non-ownning.  Perhaps they meant to use rcpFromRef(...)\n"
-      "or an equivalent function?\n"
-      "\n"
-      << getCommonDebugNotesString();
-      );
 
-    // NOTE: We allow duplicate RCPNodes if the new node is non-owning.  This
-    // might indicate a advanced usage of the RCP class that we want to
-    // support.  The typical problem is when the programmer unknowingly
-    // creates an owning RCP to an object already owned by another RCPNode.
-
-    // Add the new RCP node keyed as described above.
-    (*rcp_node_list()).insert(
-      itr_itr.second,
-      std::make_pair(map_key_void_ptr, RCPNodeInfo(info, rcp_node))
-      );
-    // NOTE: Above, if there is already an existing RCPNode with the same key
-    // value, this iterator itr_itr.second will point to one after the found
-    // range.  I suspect that this might also ensure that the elements are
-    // sorted in natural order.
-
-    // Update the insertion number an node tracing statistics
-    ++insertionNumber;
-    ++loc_rcpNodeStatistics().totalNumRCPNodeAllocations;
-    loc_rcpNodeStatistics().maxNumRCPNodes =
-      TEUCHOS_MAX(loc_rcpNodeStatistics().maxNumRCPNodes, numActiveRCPNodes());
-  }
-}
-
-
-#define TEUCHOS_RCPNODE_REMOVE_RCPNODE(CONDITION, RCPNODE) \
-  TEUCHOS_TEST_FOR_EXCEPTION((CONDITION), \
-    std::logic_error, \
-    "RCPNodeTracer::removeRCPNode(node_ptr): Error, the " \
-    << convertRCPNodeToString(RCPNODE) << " is not found in the list of" \
-    " active RCP nodes being traced even though all nodes should be traced." \
-    "  This should not be possible and can only be an internal programming error!")
-
-
-void RCPNodeTracer::removeRCPNode( RCPNode* rcp_node )
-{
-
-  // Here, we will try to remove an RCPNode reguardless if whether
-  // loc_isTracingActiveRCPNodes==true or not.  This will not be a performance
-  // problem and it will ensure that any RCPNode objects that are added to
-  // this list will be removed and will not look like a memory leak.  In
-  // non-debug mode, this function will never be called.  In debug mode, with
-  // loc_isTracingActiveRCPNodes==false, the list *rcp_node_list will be empty and
-  // therefore this find(...) operation should be pretty cheap (even for a bad
-  // implementation of std::map).
-
-  TEUCHOS_ASSERT(rcp_node_list());
-  typedef rcp_node_list_t::iterator itr_t;
-  typedef std::pair<itr_t, itr_t> itr_itr_t;
-
-  const itr_itr_t itr_itr =
-    rcp_node_list()->equal_range(get_map_key_void_ptr(rcp_node));
-  const bool rcp_node_exists = itr_itr.first != itr_itr.second;
+    const itr_itr_t itr_itr
+        = rcp_node_list()->equal_range(get_map_key_void_ptr(rcp_node));
+    const bool rcp_node_exists = itr_itr.first != itr_itr.second;
 
 #ifdef HAVE_TEUCHOS_DEBUG_RCP_NODE_TRACING
-  // If we have the macro HAVE_TEUCHOS_DEBUG_RCP_NODE_TRACING turned on a
-  // compile time, then all RCPNode objects that get created will have been
-  // added to this list.  In this case, we can asset that the node exists.
-  TEUCHOS_RCPNODE_REMOVE_RCPNODE(!rcp_node_exists, rcp_node);
+    // If we have the macro HAVE_TEUCHOS_DEBUG_RCP_NODE_TRACING turned on a
+    // compile time, then all RCPNode objects that get created will have been
+    // added to this list.  In this case, we can asset that the node exists.
+    TEUCHOS_RCPNODE_REMOVE_RCPNODE(!rcp_node_exists, rcp_node);
 #else
-  // If the macro HAVE_TEUCHOS_DEBUG_RCP_NODE_TRACING turned off, then is is
-  // possible that an RCP got created before the bool
-  // loc_isTracingActiveRCPNodes was turned on.  In this case, we must allow
-  // for an RCP node not to have been added to this list.  In this case we
-  // will just let this go!
+// If the macro HAVE_TEUCHOS_DEBUG_RCP_NODE_TRACING turned off, then is is
+// possible that an RCP got created before the bool
+// loc_isTracingActiveRCPNodes was turned on.  In this case, we must allow
+// for an RCP node not to have been added to this list.  In this case we
+// will just let this go!
 #endif
 
-  if (rcp_node_exists) {
+    if (rcp_node_exists) {
 #ifdef RCP_NODE_DEBUG_TRACE_PRINT
-    std::cerr
-      << "RCPNodeTracer::removeRCPNode(...): Removing "
-      << convertRCPNodeToString(rcp_node) << " ...\n";
+        std::cerr << "RCPNodeTracer::removeRCPNode(...): Removing "
+                  << convertRCPNodeToString(rcp_node) << " ...\n";
 #endif
-    bool foundRCPNode = false;
-    for(itr_t itr = itr_itr.first; itr != itr_itr.second; ++itr) {
-      if (itr->second.nodePtr == rcp_node) {
-        rcp_node_list()->erase(itr);
-        ++loc_rcpNodeStatistics().totalNumRCPNodeDeletions;
-        foundRCPNode = true;
-        break;
-      }
+        bool foundRCPNode = false;
+        for (itr_t itr = itr_itr.first; itr != itr_itr.second; ++itr) {
+            if (itr->second.nodePtr == rcp_node) {
+                rcp_node_list()->erase(itr);
+                ++loc_rcpNodeStatistics().totalNumRCPNodeDeletions;
+                foundRCPNode = true;
+                break;
+            }
+        }
+        // Whoops! Did not find the node!
+        TEUCHOS_RCPNODE_REMOVE_RCPNODE(!foundRCPNode, rcp_node);
     }
-    // Whoops! Did not find the node!
-    TEUCHOS_RCPNODE_REMOVE_RCPNODE(!foundRCPNode, rcp_node);
-  }
-
 }
 
-
-RCPNode* RCPNodeTracer::getExistingRCPNodeGivenLookupKey(const void* p)
+RCPNode *RCPNodeTracer::getExistingRCPNodeGivenLookupKey(const void *p)
 {
-  typedef rcp_node_list_t::iterator itr_t;
-  typedef std::pair<itr_t, itr_t> itr_itr_t;
-  if (!p)
-    return 0;
-  const itr_itr_t itr_itr = rcp_node_list()->equal_range(p);
-  for (itr_t itr = itr_itr.first; itr != itr_itr.second; ++itr) {
-    RCPNode* rcpNode = itr->second.nodePtr;
-    if (rcpNode->has_ownership()) {
-      return rcpNode;
+    typedef rcp_node_list_t::iterator itr_t;
+    typedef std::pair<itr_t, itr_t> itr_itr_t;
+    if (!p)
+        return 0;
+    const itr_itr_t itr_itr = rcp_node_list()->equal_range(p);
+    for (itr_t itr = itr_itr.first; itr != itr_itr.second; ++itr) {
+        RCPNode *rcpNode = itr->second.nodePtr;
+        if (rcpNode->has_ownership()) {
+            return rcpNode;
+        }
     }
-  }
-  return 0;
-  // NOTE: Above, we return the first RCPNode added that has the given key
-  // value.
+    return 0;
+    // NOTE: Above, we return the first RCPNode added that has the given key
+    // value.
 }
-
 
 std::string RCPNodeTracer::getActiveRCPNodeHeaderString()
 {
-  return std::string(
-    "\n***"
-    "\n*** Warning! The following Teuchos::RCPNode objects were created but have"
-    "\n*** not been destroyed yet.  A memory checking tool may complain that these"
-    "\n*** objects are not destroyed correctly."
-    "\n***"
-    "\n*** There can be many possible reasons that this might occur including:"
-    "\n***"
-    "\n***   a) The program called abort() or exit() before main() was finished."
-    "\n***      All of the objects that would have been freed through destructors"
-    "\n***      are not freed but some compilers (e.g. GCC) will still call the"
-    "\n***      destructors on static objects (which is what causes this message"
-    "\n***      to be printed)."
-    "\n***"
-    "\n***   b) The program is using raw new/delete to manage some objects and"
-    "\n***      delete was not called correctly and the objects not deleted hold"
-    "\n***      other objects through reference-counted pointers."
-    "\n***"
-    "\n***   c) This may be an indication that these objects may be involved in"
-    "\n***      a circular dependency of reference-counted managed objects."
-    "\n***\n"
-    );
+    return std::string(
+        "\n***"
+        "\n*** Warning! The following Teuchos::RCPNode objects were created "
+        "but have"
+        "\n*** not been destroyed yet.  A memory checking tool may complain "
+        "that these"
+        "\n*** objects are not destroyed correctly."
+        "\n***"
+        "\n*** There can be many possible reasons that this might occur "
+        "including:"
+        "\n***"
+        "\n***   a) The program called abort() or exit() before main() was "
+        "finished."
+        "\n***      All of the objects that would have been freed through "
+        "destructors"
+        "\n***      are not freed but some compilers (e.g. GCC) will still "
+        "call the"
+        "\n***      destructors on static objects (which is what causes this "
+        "message"
+        "\n***      to be printed)."
+        "\n***"
+        "\n***   b) The program is using raw new/delete to manage some objects "
+        "and"
+        "\n***      delete was not called correctly and the objects not "
+        "deleted hold"
+        "\n***      other objects through reference-counted pointers."
+        "\n***"
+        "\n***   c) This may be an indication that these objects may be "
+        "involved in"
+        "\n***      a circular dependency of reference-counted managed objects."
+        "\n***\n");
 }
-
 
 std::string RCPNodeTracer::getCommonDebugNotesString()
 {
-  return std::string(
-    "NOTE: To debug issues, open a debugger, and set a break point in the function where\n"
-    "the RCPNode object is first created to determine the context where the object first\n"
-    "gets created.  Each RCPNode object is given a unique insertionNumber to allow setting\n"
-    "breakpoints in the code.  For example, in GDB one can perform:\n"
-    "\n"
-    "1) Open the debugger (GDB) and run the program again to get updated object addresses\n"
-    "\n"
-    "2) Set a breakpoint in the RCPNode insertion routine when the desired RCPNode is first\n"
-    "inserted.  In GDB, to break when the RCPNode with insertionNumber==3 is added, do:\n"
-    "\n"
-    "  (gdb) b 'Teuchos::RCPNodeTracer::addNewRCPNode( [TAB] ' [ENTER]\n"
-    "  (gdb) cond 1 insertionNumber==3 [ENTER]\n"
-    "\n"
-    "3) Run the program in the debugger.  In GDB, do:\n"
-    "\n"
-    "  (gdb) run [ENTER]\n"
-    "\n"
-    "4) Examine the call stack when the program breaks in the function addNewRCPNode(...)\n"
-    );
+    return std::string(
+        "NOTE: To debug issues, open a debugger, and set a break point in the "
+        "function where\n"
+        "the RCPNode object is first created to determine the context where "
+        "the object first\n"
+        "gets created.  Each RCPNode object is given a unique insertionNumber "
+        "to allow setting\n"
+        "breakpoints in the code.  For example, in GDB one can perform:\n"
+        "\n"
+        "1) Open the debugger (GDB) and run the program again to get updated "
+        "object addresses\n"
+        "\n"
+        "2) Set a breakpoint in the RCPNode insertion routine when the desired "
+        "RCPNode is first\n"
+        "inserted.  In GDB, to break when the RCPNode with insertionNumber==3 "
+        "is added, do:\n"
+        "\n"
+        "  (gdb) b 'Teuchos::RCPNodeTracer::addNewRCPNode( [TAB] ' [ENTER]\n"
+        "  (gdb) cond 1 insertionNumber==3 [ENTER]\n"
+        "\n"
+        "3) Run the program in the debugger.  In GDB, do:\n"
+        "\n"
+        "  (gdb) run [ENTER]\n"
+        "\n"
+        "4) Examine the call stack when the program breaks in the function "
+        "addNewRCPNode(...)\n");
 }
-
 
 //
 // ActiveRCPNodesSetup
 //
 
-
 ActiveRCPNodesSetup::ActiveRCPNodesSetup()
 {
 #ifdef TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
-  std::cerr << "\nCalled ActiveRCPNodesSetup::ActiveRCPNodesSetup() : count = " << count_ << "\n";
+    std::cerr
+        << "\nCalled ActiveRCPNodesSetup::ActiveRCPNodesSetup() : count = "
+        << count_ << "\n";
 #endif // TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
-  if (!rcp_node_list())
-    rcp_node_list() = new rcp_node_list_t;
-  ++count_;
+    if (!rcp_node_list())
+        rcp_node_list() = new rcp_node_list_t;
+    ++count_;
 }
-
 
 ActiveRCPNodesSetup::~ActiveRCPNodesSetup()
 #ifdef TEUCHOS_DEBUG
@@ -630,95 +624,93 @@ ActiveRCPNodesSetup::~ActiveRCPNodesSetup()
 #endif
 {
 #ifdef TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
-  std::cerr << "\nCalled ActiveRCPNodesSetup::~ActiveRCPNodesSetup() : count = " << count_ << "\n";
+    std::cerr
+        << "\nCalled ActiveRCPNodesSetup::~ActiveRCPNodesSetup() : count = "
+        << count_ << "\n";
 #endif // TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
-  if( --count_ == 0 ) {
+    if (--count_ == 0) {
 #ifdef TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
-    std::cerr << "\nPrint active nodes!\n";
+        std::cerr << "\nPrint active nodes!\n";
 #endif // TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
-    std::cout << std::flush;
-    TEUCHOS_TEST_FOR_EXCEPT(0==rcp_node_list());
-    RCPNodeTracer::RCPNodeStatistics rcpNodeStatistics =
-      RCPNodeTracer::getRCPNodeStatistics();
-    if (rcpNodeStatistics.maxNumRCPNodes
-      && RCPNodeTracer::getPrintRCPNodeStatisticsOnExit())
-    {
-      RCPNodeTracer::printRCPNodeStatistics(rcpNodeStatistics, std::cout);
+        std::cout << std::flush;
+        TEUCHOS_TEST_FOR_EXCEPT(0 == rcp_node_list());
+        RCPNodeTracer::RCPNodeStatistics rcpNodeStatistics
+            = RCPNodeTracer::getRCPNodeStatistics();
+        if (rcpNodeStatistics.maxNumRCPNodes
+            && RCPNodeTracer::getPrintRCPNodeStatisticsOnExit()) {
+            RCPNodeTracer::printRCPNodeStatistics(rcpNodeStatistics, std::cout);
+        }
+        RCPNodeTracer::printActiveRCPNodes(std::cerr);
+        delete rcp_node_list();
+        rcp_node_list() = 0;
     }
-    RCPNodeTracer::printActiveRCPNodes(std::cerr);
-    delete rcp_node_list();
-    rcp_node_list() = 0;
-  }
 }
-
 
 void Teuchos::ActiveRCPNodesSetup::foo()
 {
-  int dummy = count_;
-  ++dummy; // Avoid unused variable warning (bug 2664)
+    int dummy = count_;
+    ++dummy; // Avoid unused variable warning (bug 2664)
 }
 
-
 int Teuchos::ActiveRCPNodesSetup::count_ = 0;
-
 
 //
 // RCPNodeHandle
 //
 
-
 void RCPNodeHandle::unbindOne()
 {
-  if (node_) {
-    // NOTE: We only deincrement the reference count after
-    // we have called delete on the underlying object since
-    // that call to delete may actually thrown an exception!
-    if (node_->strong_count()==1 && strength()==RCP_STRONG) {
-      // Delete the object (which might throw)
-      node_->delete_obj();
- #ifdef TEUCHOS_DEBUG
-      // We actaully also need to remove the RCPNode from the active list for
-      // some specialized use cases that need to be able to create a new RCP
-      // node pointing to the same memory.  What this means is that when the
-      // strong count goes to zero and the referenced object is destroyed,
-      // then it will not longer be picked up by any other code and instead it
-      // will only be known by its remaining weak RCPNodeHandle objects in
-      // order to perform debug-mode runtime checking in case a client tries
-      // to access the obejct.
-      local_activeRCPNodesSetup.foo(); // Make sure created!
-      RCPNodeTracer::removeRCPNode(node_);
+    if (node_) {
+        // NOTE: We only deincrement the reference count after
+        // we have called delete on the underlying object since
+        // that call to delete may actually thrown an exception!
+        if (node_->strong_count() == 1 && strength() == RCP_STRONG) {
+            // Delete the object (which might throw)
+            node_->delete_obj();
+#ifdef TEUCHOS_DEBUG
+            // We actaully also need to remove the RCPNode from the active list
+            // for
+            // some specialized use cases that need to be able to create a new
+            // RCP
+            // node pointing to the same memory.  What this means is that when
+            // the
+            // strong count goes to zero and the referenced object is destroyed,
+            // then it will not longer be picked up by any other code and
+            // instead it
+            // will only be known by its remaining weak RCPNodeHandle objects in
+            // order to perform debug-mode runtime checking in case a client
+            // tries
+            // to access the obejct.
+            local_activeRCPNodesSetup.foo(); // Make sure created!
+            RCPNodeTracer::removeRCPNode(node_);
 #endif
-   }
-    // If we get here, no exception was thrown!
-    if ( (node_->strong_count() + node_->weak_count()) == 1 ) {
-      // The last RCP object is going away so time to delete
-      // the entire node!
-      delete node_;
-      node_ = 0;
-      // NOTE: No need to deincrement the reference count since this is
-      // the last RCP object being deleted!
+        }
+        // If we get here, no exception was thrown!
+        if ((node_->strong_count() + node_->weak_count()) == 1) {
+            // The last RCP object is going away so time to delete
+            // the entire node!
+            delete node_;
+            node_ = 0;
+            // NOTE: No need to deincrement the reference count since this is
+            // the last RCP object being deleted!
+        } else {
+            // The last RCP has not gone away so just deincrement the reference
+            // count.
+            node_->deincr_count(strength());
+        }
     }
-    else {
-      // The last RCP has not gone away so just deincrement the reference
-      // count.
-      node_->deincr_count(strength());
-    }
-  }
 }
 
-
 } // namespace Teuchos
-
 
 //
 // Non-member helpers
 //
 
-
-void Teuchos::throw_null_ptr_error( const std::string &type_name )
+void Teuchos::throw_null_ptr_error(const std::string &type_name)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    true, NullReferenceError,
-    type_name << " : You can not call operator->() or operator*()"
-    <<" if getRawPtr()==0!" );
+    TEUCHOS_TEST_FOR_EXCEPTION(
+        true, NullReferenceError,
+        type_name << " : You can not call operator->() or operator*()"
+                  << " if getRawPtr()==0!");
 }

--- a/symengine/utilities/teuchos/Teuchos_TestForException.cpp
+++ b/symengine/utilities/teuchos/Teuchos_TestForException.cpp
@@ -41,70 +41,61 @@
 
 #include "Teuchos_TestForException.hpp"
 
-
 //
 // ToDo: Make these functions thread-safe!
 //
 
-
-namespace {
-
+namespace
+{
 
 int throwNumber = 0;
 
-
-bool& loc_enableStackTrace()
+bool &loc_enableStackTrace()
 {
-  static bool static_enableStackTrace =
+    static bool static_enableStackTrace =
 #ifdef HAVE_TEUCHOS_DEFAULT_STACKTRACE
-    true
+        true
 #else
-    false
+        false
 #endif
-    ;
-  return static_enableStackTrace;
+        ;
+    return static_enableStackTrace;
 }
-
 
 } // namespace
 
-
 void Teuchos::TestForException_incrThrowNumber()
 {
-  ++throwNumber;
+    ++throwNumber;
 }
-
 
 int Teuchos::TestForException_getThrowNumber()
 {
-  return throwNumber;
+    return throwNumber;
 }
 
-
-void Teuchos::TestForException_break( const std::string &errorMsg )
+void Teuchos::TestForException_break(const std::string &errorMsg)
 {
-  int break_on_me;
-  break_on_me = errorMsg.length(); // Use errMsg to avoid compiler warning.
-  (void)break_on_me;
-  // Above is just some statement for the debugger to break on.  Note: now is
-  // a good time to examine the stack trace and look at the error message in
-  // 'errorMsg' to see what happened.  In GDB just type 'where' or you can go
-  // up by typing 'up' and moving up in the stack trace to see where you are
-  // and how you got to this point in the code where you are throwning this
-  // exception!  Typing in a 'p errorMsg' will show you what the error message
-  // is.  Also, you should consider adding a conditional breakpoint in this
-  // function based on a specific value of 'throwNumber' if the exception you
-  // want to examine is not the first exception thrown.
+    int break_on_me;
+    break_on_me = errorMsg.length(); // Use errMsg to avoid compiler warning.
+    (void)break_on_me;
+    // Above is just some statement for the debugger to break on.  Note: now is
+    // a good time to examine the stack trace and look at the error message in
+    // 'errorMsg' to see what happened.  In GDB just type 'where' or you can go
+    // up by typing 'up' and moving up in the stack trace to see where you are
+    // and how you got to this point in the code where you are throwning this
+    // exception!  Typing in a 'p errorMsg' will show you what the error message
+    // is.  Also, you should consider adding a conditional breakpoint in this
+    // function based on a specific value of 'throwNumber' if the exception you
+    // want to examine is not the first exception thrown.
 }
-
 
 void Teuchos::TestForException_setEnableStacktrace(bool enableStrackTrace)
 {
-  loc_enableStackTrace() = enableStrackTrace;
+    loc_enableStackTrace() = enableStrackTrace;
 }
-
 
 bool Teuchos::TestForException_getEnableStacktrace()
 {
-  return loc_enableStackTrace();
+    return loc_enableStackTrace();
 }

--- a/symengine/utilities/teuchos/Teuchos_TypeNameTraits.cpp
+++ b/symengine/utilities/teuchos/Teuchos_TypeNameTraits.cpp
@@ -46,34 +46,38 @@
 //#define HAVE_TEUCHOS_DEMANGLE
 
 #if defined(HAVE_GCC_ABI_DEMANGLE) && defined(HAVE_TEUCHOS_DEMANGLE)
-#  include <cxxabi.h>
+#include <cxxabi.h>
 #endif
 
-
-std::string Teuchos::demangleName( const std::string &mangledName )
+std::string Teuchos::demangleName(const std::string &mangledName)
 {
 #if defined(HAVE_GCC_ABI_DEMANGLE) && defined(HAVE_TEUCHOS_DEMANGLE)
-  int status;
-  char *_demangledName = abi::__cxa_demangle(mangledName.c_str(), 0, 0, &status);
-  if (status != 0 || 0==_demangledName) {
+    int status;
+    char *_demangledName
+        = abi::__cxa_demangle(mangledName.c_str(), 0, 0, &status);
+    if (status != 0 || 0 == _demangledName) {
 #ifdef TEUCHOS_DEBUG
-    std::string nullstr("NULL");
-    const char* demangle_output = _demangledName ? _demangledName : nullstr.c_str();
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      true, std::logic_error,
-      "Error, name demangling with g++ has been enabled but the function "
-      "abi::__cxa_demangle("<<mangledName<<") returned returnVal = "<<demangle_output
-      <<" and status = "<<status<<".  Name demangling for this build"
-      "can be turned off by using --disable-teuchos-demangle at configure time." );
+        std::string nullstr("NULL");
+        const char *demangle_output
+            = _demangledName ? _demangledName : nullstr.c_str();
+        TEUCHOS_TEST_FOR_EXCEPTION(
+            true, std::logic_error,
+            "Error, name demangling with g++ has been enabled but the function "
+            "abi::__cxa_demangle("
+                << mangledName << ") returned returnVal = " << demangle_output
+                << " and status = " << status
+                << ".  Name demangling for this build"
+                   "can be turned off by using --disable-teuchos-demangle at "
+                   "configure time.");
 #endif
-    if (_demangledName != NULL)
-      free(_demangledName);
-    return ( mangledName + "<demangle-failed>" );
-  }
-  const std::string demangledName(_demangledName);
-  free(_demangledName); // We have to free this before we return!
-  return demangledName;
+        if (_demangledName != NULL)
+            free(_demangledName);
+        return (mangledName + "<demangle-failed>");
+    }
+    const std::string demangledName(_demangledName);
+    free(_demangledName); // We have to free this before we return!
+    return demangledName;
 #else
-  return mangledName;
+    return mangledName;
 #endif
 }

--- a/symengine/utilities/teuchos/Teuchos_dyn_cast.cpp
+++ b/symengine/utilities/teuchos/Teuchos_dyn_cast.cpp
@@ -46,17 +46,17 @@
   This is necessary, since bad_cast lacks the appropriate
   constructor for use with the TEUCHOS_TEST_FOR_EXCEPTION macro.
 */
-void Teuchos::dyn_cast_throw_exception(
-  const std::string &T_from,
-  const std::string &T_from_concr,
-  const std::string &T_to
-  )
+void Teuchos::dyn_cast_throw_exception(const std::string &T_from,
+                                       const std::string &T_from_concr,
+                                       const std::string &T_to)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    true, m_bad_cast
-    ,"dyn_cast<" << T_to << ">(" << T_from
-    << ") : Error, the object with the concrete type \'"
-    << T_from_concr << "\' (passed in through the interface type \'" << T_from <<  "\') "
-    " does not support the interface \'"
-    << T_to << "\' and the dynamic cast failed!" );
+    TEUCHOS_TEST_FOR_EXCEPTION(
+        true, m_bad_cast,
+        "dyn_cast<" << T_to << ">(" << T_from
+                    << ") : Error, the object with the concrete type \'"
+                    << T_from_concr
+                    << "\' (passed in through the interface type \'" << T_from
+                    << "\') "
+                       " does not support the interface \'"
+                    << T_to << "\' and the dynamic cast failed!");
 }

--- a/symengine/utilities/teuchos/Teuchos_stacktrace.cpp
+++ b/symengine/utilities/teuchos/Teuchos_stacktrace.cpp
@@ -14,7 +14,8 @@
   may be used to endorse or promote products derived from this software without
   specific prior written permission.
 
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND
   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,13 +27,10 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-
 #include "Teuchos_stacktrace.hpp"
 #include "Teuchos_RCP.hpp"
 
-
 #ifdef HAVE_TEUCHOS_STACKTRACE
-
 
 #include <string>
 #include <iostream>
@@ -47,30 +45,29 @@
 // For registering SIGSEGV callbacks
 #include <csignal>
 
-
 // The following C headers are needed for some specific C functionality (see
 // the comments), which is not available in C++:
 
 #ifdef HAVE_TEUCHOS_EXECINFO
 // backtrace() function for retrieving the stacktrace
-#  include <execinfo.h>
+#include <execinfo.h>
 #endif
 
 #if defined(HAVE_GCC_ABI_DEMANGLE) && defined(HAVE_TEUCHOS_DEMANGLE)
 // For demangling function names
-#  include <cxxabi.h>
+#include <cxxabi.h>
 #endif
 
 #ifdef HAVE_TEUCHOS_LINK
 // For dl_iterate_phdr() functionality
-#  include <link.h>
+#include <link.h>
 #endif
 
 #ifdef HAVE_TEUCHOS_BFD
 // For bfd_* family of functions for loading debugging symbols from the binary
 // This is the only nonstandard header file and the binary needs to be linked
 // with "-lbfd".
-#  include <bfd.h>
+#include <bfd.h>
 #else
 typedef long long unsigned bfd_vma;
 #endif
@@ -79,68 +76,66 @@ using Teuchos::RCP;
 using Teuchos::rcp;
 using Teuchos::null;
 
-namespace {
+namespace
+{
 
 /* This struct is used to pass information between
    addr2str() and process_section().
 */
 struct line_data {
 #ifdef HAVE_TEUCHOS_BFD
-  asymbol **symbol_table;     /* Symbol table.  */
+    asymbol **symbol_table; /* Symbol table.  */
 #endif
-  bfd_vma addr;
-  std::string filename;
-  std::string function_name;
-  unsigned int line;
-  int line_found;
+    bfd_vma addr;
+    std::string filename;
+    std::string function_name;
+    unsigned int line;
+    int line_found;
 };
-
 
 /* Return if given char is whitespace or not. */
 bool is_whitespace_char(const char c)
 {
-  return c == ' ' || c == '\t';
+    return c == ' ' || c == '\t';
 }
-
 
 /* Removes the leading whitespace from a string and returnes the new
  * string.
  */
 std::string remove_leading_whitespace(const std::string &str)
 {
-  if (str.length() && is_whitespace_char(str[0])) {
-    int first_nonwhitespace_index = 0;
-    for (int i = 0; i < static_cast<int>(str.length()); ++i) {
-      if (!is_whitespace_char(str[i])) {
-        first_nonwhitespace_index = i;
-        break;
-      }
+    if (str.length() && is_whitespace_char(str[0])) {
+        int first_nonwhitespace_index = 0;
+        for (int i = 0; i < static_cast<int>(str.length()); ++i) {
+            if (!is_whitespace_char(str[i])) {
+                first_nonwhitespace_index = i;
+                break;
+            }
+        }
+        return str.substr(first_nonwhitespace_index);
     }
-    return str.substr(first_nonwhitespace_index);
-  }
-  return str;
+    return str;
 }
-
 
 /* Reads the 'line_number'th line from the file filename. */
 std::string read_line_from_file(std::string filename, unsigned int line_number)
 {
-  std::ifstream in(filename.c_str());
-  if (!in.is_open()) {
-    return "";
-  }
-  if (line_number == 0) {
-    return "Line number must be positive";
-  }
-  unsigned int n = 0;
-  std::string line;
-  while (n < line_number) {
-    if (in.eof())
-      return "Line not found";
-    getline(in, line);
-    n += 1; // loop update
-  }
-  return line;
+    std::ifstream in(filename.c_str());
+    if (!in.is_open()) {
+        return "";
+    }
+    if (line_number == 0) {
+        return "Line number must be positive";
+    }
+    unsigned int n = 0;
+    std::string line;
+    while (n < line_number) {
+        if (in.eof())
+            return "Line not found";
+        getline(in, line);
+        n += 1; // loop update
+    }
+    return line;
 }
 
 /* Demangles the function name if needed (if the 'name' is coming from C, it
@@ -151,30 +146,28 @@ std::string read_line_from_file(std::string filename, unsigned int line_number)
 */
 std::string demangle_function_name(std::string name)
 {
-  std::string s;
+    std::string s;
 
-  if (name.length() == 0) {
-    s = "??";
-  } else {
-    char *d = 0;
-#if defined(HAVE_GCC_ABI_DEMANGLE) && defined(HAVE_TEUCHOS_DEMANGLE)
-    int status = 0;
-    d = abi::__cxa_demangle(name.c_str(), 0, 0, &status);
-#endif
-    if (d) {
-      s = d;
-      free(d);
+    if (name.length() == 0) {
+        s = "??";
     } else {
-      s = name + "()";
+        char *d = 0;
+#if defined(HAVE_GCC_ABI_DEMANGLE) && defined(HAVE_TEUCHOS_DEMANGLE)
+        int status = 0;
+        d = abi::__cxa_demangle(name.c_str(), 0, 0, &status);
+#endif
+        if (d) {
+            s = d;
+            free(d);
+        } else {
+            s = name + "()";
+        }
     }
-  }
 
-  return s;
+    return s;
 }
 
-
 #ifdef HAVE_TEUCHOS_BFD
-
 
 /* Look for an address in a section.  This is called via
    bfd_map_over_sections over all sections in abfd.
@@ -185,180 +178,178 @@ std::string demangle_function_name(std::string name)
 */
 void process_section(bfd *abfd, asection *section, void *_data)
 {
-  line_data *data = (line_data*)_data;
-  if (data->line_found) {
-    // If we already found the line, exit
-    return;
-  }
-  if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0) {
-    return;
-  }
+    line_data *data = (line_data *)_data;
+    if (data->line_found) {
+        // If we already found the line, exit
+        return;
+    }
+    if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0) {
+        return;
+    }
 
-  bfd_vma section_vma = bfd_get_section_vma(abfd, section);
-  if (data->addr < section_vma) {
-    // If the addr lies above the section, exit
-    return;
-  }
+    bfd_vma section_vma = bfd_get_section_vma(abfd, section);
+    if (data->addr < section_vma) {
+        // If the addr lies above the section, exit
+        return;
+    }
 
-  bfd_size_type section_size = bfd_section_size(abfd, section);
-  if (data->addr >= section_vma + section_size) {
-    // If the addr lies below the section, exit
-    return;
-  }
+    bfd_size_type section_size = bfd_section_size(abfd, section);
+    if (data->addr >= section_vma + section_size) {
+        // If the addr lies below the section, exit
+        return;
+    }
 
-  // Calculate the correct offset of our line in the section
-  bfd_vma offset = data->addr - section_vma - 1;
+    // Calculate the correct offset of our line in the section
+    bfd_vma offset = data->addr - section_vma - 1;
 
-  // Finds the line corresponding to the offset
+    // Finds the line corresponding to the offset
 
-  const char *filename=NULL, *function_name=NULL;
-  data->line_found = bfd_find_nearest_line(abfd, section, data->symbol_table,
-    offset, &filename, &function_name, &data->line);
+    const char *filename = NULL, *function_name = NULL;
+    data->line_found
+        = bfd_find_nearest_line(abfd, section, data->symbol_table, offset,
+                                &filename, &function_name, &data->line);
 
-  if (filename == NULL)
-    data->filename = "";
-  else
-    data->filename = filename;
+    if (filename == NULL)
+        data->filename = "";
+    else
+        data->filename = filename;
 
-  if (function_name == NULL)
-    data->function_name = "";
-  else
-    data->function_name = function_name;
+    if (function_name == NULL)
+        data->function_name = "";
+    else
+        data->function_name = function_name;
 }
-
 
 /* Loads the symbol table into 'data->symbol_table'.  */
 int load_symbol_table(bfd *abfd, line_data *data)
 {
-  if ((bfd_get_file_flags(abfd) & HAS_SYMS) == 0)
-    // If we don't have any symbols, return
+    if ((bfd_get_file_flags(abfd) & HAS_SYMS) == 0)
+        // If we don't have any symbols, return
+        return 0;
+
+    void **symbol_table_ptr = reinterpret_cast<void **>(&data->symbol_table);
+    long n_symbols;
+    unsigned int symbol_size;
+    n_symbols
+        = bfd_read_minisymbols(abfd, false, symbol_table_ptr, &symbol_size);
+    if (n_symbols == 0) {
+        // If the bfd_read_minisymbols() already allocated the table, we need
+        // to free it first:
+        if (data->symbol_table != NULL)
+            free(data->symbol_table);
+        // dynamic
+        n_symbols
+            = bfd_read_minisymbols(abfd, true, symbol_table_ptr, &symbol_size);
+    }
+
+    if (n_symbols < 0) {
+        // bfd_read_minisymbols() failed
+        return 1;
+    }
+
     return 0;
-
-  void **symbol_table_ptr = reinterpret_cast<void **>(&data->symbol_table);
-  long n_symbols;
-  unsigned int symbol_size;
-  n_symbols = bfd_read_minisymbols(abfd, false, symbol_table_ptr, &symbol_size);
-  if (n_symbols == 0) {
-    // If the bfd_read_minisymbols() already allocated the table, we need
-    // to free it first:
-    if (data->symbol_table != NULL)
-      free(data->symbol_table);
-    // dynamic
-    n_symbols = bfd_read_minisymbols(abfd, true, symbol_table_ptr, &symbol_size);
-  }
-
-  if (n_symbols < 0) {
-    // bfd_read_minisymbols() failed
-    return 1;
-  }
-
-  return 0;
 }
 
-
 #endif // HAVE_TEUCHOS_BFD
-
 
 /* Returns a string of 2 lines for the function with address 'addr' in the file
    'file_name'.
 
    Example:
 
-   File "/home/ondrej/repos/rcp/src/Teuchos_RCP.hpp", line 428, in Teuchos::RCP<A>::assert_not_null() const
+   File "/home/ondrej/repos/rcp/src/Teuchos_RCP.hpp", line 428, in
+   Teuchos::RCP<A>::assert_not_null() const
    throw_null_ptr_error(typeName(*this));
 */
 std::string addr2str(std::string file_name, bfd_vma addr)
 {
 #ifdef HAVE_TEUCHOS_BFD
-  // Initialize 'abfd' and do some sanity checks
-  bfd *abfd;
-  abfd = bfd_openr(file_name.c_str(), NULL);
-  if (abfd == NULL)
-    return "Cannot open the binary file '" + file_name + "'\n";
-  if (bfd_check_format(abfd, bfd_archive))
-    return "Cannot get addresses from the archive '" + file_name + "'\n";
-  char **matching;
-  if (!bfd_check_format_matches(abfd, bfd_object, &matching))
-    return "Unknown format of the binary file '" + file_name + "'\n";
-  line_data data;
-  data.addr = addr;
-  data.symbol_table = NULL;
-  data.line_found = false;
-  // This allocates the symbol_table:
-  if (load_symbol_table(abfd, &data) == 1)
-    return "Failed to load the symbol table from '" + file_name + "'\n";
-  // Loops over all sections and try to find the line
-  bfd_map_over_sections(abfd, process_section, &data);
-  // Deallocates the symbol table
-  if (data.symbol_table != NULL) free(data.symbol_table);
-  bfd_close(abfd);
+    // Initialize 'abfd' and do some sanity checks
+    bfd *abfd;
+    abfd = bfd_openr(file_name.c_str(), NULL);
+    if (abfd == NULL)
+        return "Cannot open the binary file '" + file_name + "'\n";
+    if (bfd_check_format(abfd, bfd_archive))
+        return "Cannot get addresses from the archive '" + file_name + "'\n";
+    char **matching;
+    if (!bfd_check_format_matches(abfd, bfd_object, &matching))
+        return "Unknown format of the binary file '" + file_name + "'\n";
+    line_data data;
+    data.addr = addr;
+    data.symbol_table = NULL;
+    data.line_found = false;
+    // This allocates the symbol_table:
+    if (load_symbol_table(abfd, &data) == 1)
+        return "Failed to load the symbol table from '" + file_name + "'\n";
+    // Loops over all sections and try to find the line
+    bfd_map_over_sections(abfd, process_section, &data);
+    // Deallocates the symbol table
+    if (data.symbol_table != NULL)
+        free(data.symbol_table);
+    bfd_close(abfd);
 #else
-  line_data data;
-  data.line_found = 0;
+    line_data data;
+    data.line_found = 0;
 #endif
 
-  std::ostringstream s;
-  // Do the printing --- print as much information as we were able to
-  // find out
-  if (!data.line_found) {
-    // If we didn't find the line, at least print the address itself
-    s << "  File unknown, address: 0x" << (long long unsigned int) addr;
-  } else {
-    std::string name = demangle_function_name(data.function_name);
-    if (data.filename.length() > 0) {
-      // Nicely format the filename + function name + line
-      s << "  File \"" << data.filename << "\", line "
-        << data.line << ", in " << name;
-      const std::string line_text = remove_leading_whitespace(
-        read_line_from_file(data.filename, data.line));
-      if (line_text != "") {
-        s << "\n    " << line_text;
-      }
+    std::ostringstream s;
+    // Do the printing --- print as much information as we were able to
+    // find out
+    if (!data.line_found) {
+        // If we didn't find the line, at least print the address itself
+        s << "  File unknown, address: 0x" << (long long unsigned int)addr;
     } else {
-      // The file is unknown (and data.line == 0 in this case), so the
-      // only meaningful thing to print is the function name:
-      s << "  File unknown, in " << name;
+        std::string name = demangle_function_name(data.function_name);
+        if (data.filename.length() > 0) {
+            // Nicely format the filename + function name + line
+            s << "  File \"" << data.filename << "\", line " << data.line
+              << ", in " << name;
+            const std::string line_text = remove_leading_whitespace(
+                read_line_from_file(data.filename, data.line));
+            if (line_text != "") {
+                s << "\n    " << line_text;
+            }
+        } else {
+            // The file is unknown (and data.line == 0 in this case), so the
+            // only meaningful thing to print is the function name:
+            s << "  File unknown, in " << name;
+        }
     }
-  }
-  s << "\n";
-  return s.str();
+    s << "\n";
+    return s.str();
 }
 
 struct match_data {
-  bfd_vma addr;
+    bfd_vma addr;
 
-  std::string filename;
-  bfd_vma addr_in_file;
+    std::string filename;
+    bfd_vma addr_in_file;
 };
 
-
 #ifdef HAVE_TEUCHOS_LINK
-
 
 /* Tries to find the 'data.addr' in the current shared lib (as passed in
    'info'). If it succeeds, returns (in the 'data') the full path to the shared
    lib and the local address in the file.
 */
-int shared_lib_callback(struct dl_phdr_info *info,
-  size_t size, void *_data)
+int shared_lib_callback(struct dl_phdr_info *info, size_t size, void *_data)
 {
-  struct match_data *data = (struct match_data *)_data;
-  for (int i=0; i < info->dlpi_phnum; i++) {
-    if (info->dlpi_phdr[i].p_type == PT_LOAD) {
-      ElfW(Addr) min_addr = info->dlpi_addr + info->dlpi_phdr[i].p_vaddr;
-      ElfW(Addr) max_addr = min_addr + info->dlpi_phdr[i].p_memsz;
-      if ((data->addr >= min_addr) && (data->addr < max_addr)) {
-        data->filename = info->dlpi_name;
-        data->addr_in_file = data->addr - info->dlpi_addr;
-        // We found a match, return a non-zero value
-        return 1;
-      }
+    struct match_data *data = (struct match_data *)_data;
+    for (int i = 0; i < info->dlpi_phnum; i++) {
+        if (info->dlpi_phdr[i].p_type == PT_LOAD) {
+            ElfW(Addr) min_addr = info->dlpi_addr + info->dlpi_phdr[i].p_vaddr;
+            ElfW(Addr) max_addr = min_addr + info->dlpi_phdr[i].p_memsz;
+            if ((data->addr >= min_addr) && (data->addr < max_addr)) {
+                data->filename = info->dlpi_name;
+                data->addr_in_file = data->addr - info->dlpi_addr;
+                // We found a match, return a non-zero value
+                return 1;
+            }
+        }
     }
-  }
-  // We didn't find a match, return a zero value
-  return 0;
+    // We didn't find a match, return a zero value
+    return 0;
 }
-
 
 #endif // HAVE_TEUCHOS_LINK
 
@@ -366,27 +357,32 @@ int shared_lib_callback(struct dl_phdr_info *info,
 // pointers, that we get from the backtrace() libc function. We make a copy of
 // the addresses, so the caller can free the memory. We use std::vector to
 // store the addresses internally, but this can be changed.
-class StacktraceAddresses {
-  std::vector<bfd_vma> stacktrace_buffer;
-  int impl_stacktrace_depth;
-public:
-  StacktraceAddresses(void *const *_stacktrace_buffer, int _size, int _impl_stacktrace_depth)
-    : impl_stacktrace_depth(_impl_stacktrace_depth)
-    {
-      for (int i=0; i < _size; i++)
-        stacktrace_buffer.push_back((bfd_vma) _stacktrace_buffer[i]);
-    }
-  bfd_vma get_address(int i) const {
-    return this->stacktrace_buffer[i];
-  }
-  int get_size() const {
-    return this->stacktrace_buffer.size();
-  }
-  int get_impl_stacktrace_depth() const {
-    return this->impl_stacktrace_depth;
-  }
-};
+class StacktraceAddresses
+{
+    std::vector<bfd_vma> stacktrace_buffer;
+    int impl_stacktrace_depth;
 
+public:
+    StacktraceAddresses(void *const *_stacktrace_buffer, int _size,
+                        int _impl_stacktrace_depth)
+        : impl_stacktrace_depth(_impl_stacktrace_depth)
+    {
+        for (int i = 0; i < _size; i++)
+            stacktrace_buffer.push_back((bfd_vma)_stacktrace_buffer[i]);
+    }
+    bfd_vma get_address(int i) const
+    {
+        return this->stacktrace_buffer[i];
+    }
+    int get_size() const
+    {
+        return this->stacktrace_buffer.size();
+    }
+    int get_impl_stacktrace_depth() const
+    {
+        return this->impl_stacktrace_depth;
+    }
+};
 
 /*
   Returns a std::string with the stacktrace corresponding to the
@@ -397,126 +393,116 @@ public:
 */
 std::string stacktrace2str(const StacktraceAddresses &stacktrace_addresses)
 {
-  int stack_depth = stacktrace_addresses.get_size() - 1;
+    int stack_depth = stacktrace_addresses.get_size() - 1;
 
-  std::string full_stacktrace_str("Traceback (most recent call last):\n");
+    std::string full_stacktrace_str("Traceback (most recent call last):\n");
 
 #ifdef HAVE_TEUCHOS_BFD
-  bfd_init();
+    bfd_init();
 #endif
-  // Loop over the stack
-  const int stack_depth_start = stack_depth;
-  const int stack_depth_end = stacktrace_addresses.get_impl_stacktrace_depth();
-  for (int i=stack_depth_start; i >= stack_depth_end; i--) {
-    // Iterate over all loaded shared libraries (see dl_iterate_phdr(3) -
-    // Linux man page for more documentation)
-    struct match_data match;
-    match.addr = stacktrace_addresses.get_address(i);
+    // Loop over the stack
+    const int stack_depth_start = stack_depth;
+    const int stack_depth_end
+        = stacktrace_addresses.get_impl_stacktrace_depth();
+    for (int i = stack_depth_start; i >= stack_depth_end; i--) {
+        // Iterate over all loaded shared libraries (see dl_iterate_phdr(3) -
+        // Linux man page for more documentation)
+        struct match_data match;
+        match.addr = stacktrace_addresses.get_address(i);
 #ifdef HAVE_TEUCHOS_BFD
-    if (dl_iterate_phdr(shared_lib_callback, &match) == 0)
-      return "dl_iterate_phdr() didn't find a match\n";
+        if (dl_iterate_phdr(shared_lib_callback, &match) == 0)
+            return "dl_iterate_phdr() didn't find a match\n";
 #else
-    match.filename = "";
-    match.addr_in_file = match.addr;
+        match.filename = "";
+        match.addr_in_file = match.addr;
 #endif
 
-    if (match.filename.length() > 0) {
-      // This happens for shared libraries (like /lib/libc.so.6, or any
-      // other shared library that the project uses). 'match.filename'
-      // then contains the full path to the .so library.
-      full_stacktrace_str += addr2str(match.filename, match.addr_in_file);
-    } else {
-      // The 'addr_in_file' is from the current executable binary, that
-      // one can find at '/proc/self/exe'. So we'll use that.
-      full_stacktrace_str += addr2str("/proc/self/exe", match.addr_in_file);
+        if (match.filename.length() > 0) {
+            // This happens for shared libraries (like /lib/libc.so.6, or any
+            // other shared library that the project uses). 'match.filename'
+            // then contains the full path to the .so library.
+            full_stacktrace_str += addr2str(match.filename, match.addr_in_file);
+        } else {
+            // The 'addr_in_file' is from the current executable binary, that
+            // one can find at '/proc/self/exe'. So we'll use that.
+            full_stacktrace_str
+                += addr2str("/proc/self/exe", match.addr_in_file);
+        }
     }
-  }
 
-  return full_stacktrace_str;
+    return full_stacktrace_str;
 }
-
 
 void loc_segfault_callback_print_stack(int sig_num)
 {
-  std::cout << "\nSegfault caught. Printing stacktrace:\n\n";
-  Teuchos::show_stacktrace();
-  std::cout << "\nDone. Exiting the program.\n";
-  // Deregister our abort callback:
-  signal(SIGABRT, SIG_DFL);
-  abort();
+    std::cout << "\nSegfault caught. Printing stacktrace:\n\n";
+    Teuchos::show_stacktrace();
+    std::cout << "\nDone. Exiting the program.\n";
+    // Deregister our abort callback:
+    signal(SIGABRT, SIG_DFL);
+    abort();
 }
-
 
 void loc_abort_callback_print_stack(int sig_num)
 {
-  std::cout << "\nAbort caught. Printing stacktrace:\n\n";
-  Teuchos::show_stacktrace();
-  std::cout << "\nDone.\n";
+    std::cout << "\nAbort caught. Printing stacktrace:\n\n";
+    Teuchos::show_stacktrace();
+    std::cout << "\nDone.\n";
 }
-
 
 RCP<StacktraceAddresses> get_stacktrace_addresses(int impl_stacktrace_depth)
 {
-  const int STACKTRACE_ARRAY_SIZE = 100; // 2010/05/22: rabartl: Is this large enough?
-  void *stacktrace_array[STACKTRACE_ARRAY_SIZE];
+    const int STACKTRACE_ARRAY_SIZE
+        = 100; // 2010/05/22: rabartl: Is this large enough?
+    void *stacktrace_array[STACKTRACE_ARRAY_SIZE];
 #ifdef HAVE_TEUCHOS_EXECINFO
-  const size_t stacktrace_size = backtrace(stacktrace_array,
-    STACKTRACE_ARRAY_SIZE);
+    const size_t stacktrace_size
+        = backtrace(stacktrace_array, STACKTRACE_ARRAY_SIZE);
 #else
-  const size_t stacktrace_size = 0;
+    const size_t stacktrace_size = 0;
 #endif
-  return rcp(new StacktraceAddresses(stacktrace_array, stacktrace_size,
-      impl_stacktrace_depth+1));
+    return rcp(new StacktraceAddresses(stacktrace_array, stacktrace_size,
+                                       impl_stacktrace_depth + 1));
 }
-
 
 RCP<StacktraceAddresses> last_stacktrace;
 
 } // Unnamed namespace
 
-
 // Public functions
-
 
 void Teuchos::store_stacktrace()
 {
-  const int impl_stacktrace_depth=1;
-  last_stacktrace = get_stacktrace_addresses(impl_stacktrace_depth);
+    const int impl_stacktrace_depth = 1;
+    last_stacktrace = get_stacktrace_addresses(impl_stacktrace_depth);
 }
-
 
 std::string Teuchos::get_stored_stacktrace()
 {
-  if (last_stacktrace == null) {
-    return "";
-  }
-  else {
-    return stacktrace2str(*last_stacktrace);
-  }
+    if (last_stacktrace == null) {
+        return "";
+    } else {
+        return stacktrace2str(*last_stacktrace);
+    }
 }
-
 
 std::string Teuchos::get_stacktrace(int impl_stacktrace_depth)
 {
-  RCP<StacktraceAddresses> addresses =
-    get_stacktrace_addresses(impl_stacktrace_depth+1);
-  return stacktrace2str(*addresses);
+    RCP<StacktraceAddresses> addresses
+        = get_stacktrace_addresses(impl_stacktrace_depth + 1);
+    return stacktrace2str(*addresses);
 }
-
 
 void Teuchos::show_stacktrace()
 {
-  const int impl_stacktrace_depth=1;
-  std::cout << Teuchos::get_stacktrace(impl_stacktrace_depth);
+    const int impl_stacktrace_depth = 1;
+    std::cout << Teuchos::get_stacktrace(impl_stacktrace_depth);
 }
-
 
 void Teuchos::print_stack_on_segfault()
 {
-  signal(SIGSEGV, loc_segfault_callback_print_stack);
-  signal(SIGABRT, loc_abort_callback_print_stack);
+    signal(SIGSEGV, loc_segfault_callback_print_stack);
+    signal(SIGABRT, loc_abort_callback_print_stack);
 }
 
-
 #endif // HAVE_TEUCHOS_STACKTRACE
-


### PR DESCRIPTION
The changes proposed in this PR are the result of running `clang-format` on the entire code-base:
```sh
$ clang-format --version
clang-format version 4.0.0 (tags/RELEASE_400/final)
$ find . \( -name '*.cpp' -o -name '*.h' \) -exec clang-format -i -style=file {} \;
```