### PR TITLE
Print stack on segfault

### DIFF
--- a/symengine/utilities/catch/catch.cpp
+++ b/symengine/utilities/catch/catch.cpp
@@ -6,6 +6,7 @@
 #include "catch.hpp"
 
 #include <symengine/symengine_config.h>
+#include <symengine/symengine_rcp.h>
 
 #if defined(HAVE_SYMENGINE_MPFR)
 #include <mpfr.h>
@@ -15,17 +16,20 @@
 #include <arb.h>
 #endif // HAVE_SYMENGINE_ARB
 
+using SymEngine::print_stack_on_segfault;
+
 int main(int argc, char* argv[])
 {
-	int result = Catch::Session().run( argc, argv );
+    print_stack_on_segfault();
+    int result = Catch::Session().run( argc, argv );
 
-	#if defined(HAVE_SYMENGINE_MPFR)
-	   mpfr_free_cache();
-	#endif // HAVE_SYMENGINE_MPFR
+    #if defined(HAVE_SYMENGINE_MPFR)
+    mpfr_free_cache();
+    #endif // HAVE_SYMENGINE_MPFR
 
-	#if defined(HAVE_SYMENGINE_ARB)
-	   flint_cleanup();
-	#endif // HAVE_SYMENGINE_ARB
+    #if defined(HAVE_SYMENGINE_ARB)
+    flint_cleanup();
+    #endif // HAVE_SYMENGINE_ARB
 
-	return result;
+    return result;
 }


### PR DESCRIPTION
In https://github.com/symengine/symengine/pull/1439 the code for printing stacktrace was removed. In that PR, catch changed from using signal to sigaction and then re-raising which means we can catch the signal that is re-raised and print the stacktrace