### PR TITLE
bug fix for -Abs(x) with llvm backend

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -726,7 +726,6 @@ void LLVMDoubleVisitor::bvisit(const Abs &x)
     result_ = r;
 }
 
-
 void LLVMDoubleVisitor::bvisit(const Min &x)
 {
     llvm::Value *value = nullptr;

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -699,7 +699,6 @@ SYMENGINE_RELATIONAL_FUNCTION(StrictLessThan, CreateFCmpOLT);
         result_ = r;                                                           \
     }
 
-SYMENGINE_MACRO_EXTERNAL_FUNCTION(Abs, abs)
 SYMENGINE_MACRO_EXTERNAL_FUNCTION(Tan, tan)
 SYMENGINE_MACRO_EXTERNAL_FUNCTION(Sinh, sinh)
 SYMENGINE_MACRO_EXTERNAL_FUNCTION(Cosh, cosh)
@@ -715,6 +714,18 @@ SYMENGINE_MACRO_EXTERNAL_FUNCTION(LogGamma, lgamma)
 SYMENGINE_MACRO_EXTERNAL_FUNCTION(Erf, erf)
 SYMENGINE_MACRO_EXTERNAL_FUNCTION(Erfc, erfc)
 SYMENGINE_MACRO_EXTERNAL_FUNCTION(ATan2, atan2)
+
+void LLVMDoubleVisitor::bvisit(const Abs &x)
+{
+    std::vector<llvm::Value *> args;
+    llvm::Function *fun;
+    args.push_back(apply(*x.get_arg()));
+    fun = get_double_intrinsic(llvm::Intrinsic::fabs, 1, mod);
+    auto r = builder->CreateCall(fun, args);
+    r->setTailCall(true);
+    result_ = r;
+}
+
 
 void LLVMDoubleVisitor::bvisit(const Min &x)
 {

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -250,6 +250,7 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
     r = add(sin(x), add(mul(pow(y, integer(4)), mul(z, integer(2))),
                         pow(sin(x), integer(2))));
     exprs.push_back(r);
+    exprs.push_back(neg(abs(z)));
 
     // Piecewise
     auto int1 = interval(NegInf, integer(2), true, false);
@@ -281,35 +282,6 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
         REQUIRE(::fabs((d - d2)) < 1e-12);
         REQUIRE(::fabs((d - d3)) < 1e-12);
     }
-}
-
-TEST_CASE("Check llvm and lambda are equal 2", "[llvm_double]")
-{
-
-    RCP<const Basic> x, r;
-    double d, d2, d3;
-    x = symbol("x");
-
-    auto expr = sub(real_double(0.0), abs(x));
-              
-
-    LambdaRealDoubleVisitor v;
-    v.init({x}, *expr);
-
-    LLVMDoubleVisitor v2;
-    v2.init({x}, *expr);
-
-    LLVMDoubleVisitor v3;
-    bool symbolic_cse = true;
-    int opt_level = 3;
-    v3.init({x}, *expr, symbolic_cse, opt_level);
-
-    d = v.call({-2.0});
-    d2 = v2.call({-2.0});
-    d3 = v3.call({-2.0});
-    std::cout << "d= " << d << " d2= " << d2 << " d3= " << d3 << std::endl;
-    REQUIRE(::fabs((d - d2)) < 1e-12);
-    REQUIRE(::fabs((d - d3)) < 1e-12);
 }
 
 TEST_CASE("Check llvm save and load", "[llvm_double]")

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -283,6 +283,35 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
     }
 }
 
+TEST_CASE("Check llvm and lambda are equal 2", "[llvm_double]")
+{
+
+    RCP<const Basic> x, r;
+    double d, d2, d3;
+    x = symbol("x");
+
+    auto expr = sub(real_double(0.0), abs(x));
+              
+
+    LambdaRealDoubleVisitor v;
+    v.init({x}, *expr);
+
+    LLVMDoubleVisitor v2;
+    v2.init({x}, *expr);
+
+    LLVMDoubleVisitor v3;
+    bool symbolic_cse = true;
+    int opt_level = 3;
+    v3.init({x}, *expr, symbolic_cse, opt_level);
+
+    d = v.call({-2.0});
+    d2 = v2.call({-2.0});
+    d3 = v3.call({-2.0});
+    std::cout << "d= " << d << " d2= " << d2 << " d3= " << d3 << std::endl;
+    REQUIRE(::fabs((d - d2)) < 1e-12);
+    REQUIRE(::fabs((d - d3)) < 1e-12);
+}
+
 TEST_CASE("Check llvm save and load", "[llvm_double]")
 {
     RCP<const Basic> x, y, z, r;


### PR DESCRIPTION
When using lambdify with llvm backend, the expression `-abs(x)` results in `x` not `-x`, if you subs a negative number. I've added a testcase that triggers the bug.
I think I've also fixed it. Was there a reason why you didn't use llvm's `fabs`?