### PR TITLE
Add missing headers in dict.h

### DIFF
--- a/symengine/dict.h
+++ b/symengine/dict.h
@@ -9,6 +9,11 @@
 #include <symengine/mp_class.h>
 #include <algorithm>
 #include <cstdint>
+#include <map>
+#include <vector>
+#include <unordered_map>
+#include <set>
+#include <unordered_set>
 
 namespace SymEngine
 {


### PR DESCRIPTION
If `dict.h` is included before some other headers, the compiler complains that `std::unordered_map` & co are undefined. This is corrected by adding these missing headers.