### PR TITLE
Add release_authors.sh script

### DIFF
--- a/bin/release_authors.sh
+++ b/bin/release_authors.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Prints the list of authors who contributed to a given release.
+#
+# To obtain the list of authors who contributed to the v0.3.0 release:
+#
+# bin/release_authors.sh v0.2.0 v0.3.0
+#
+# To obtain the list of authors who contributed to upcoming (not yet tagged)
+# v0.4.0 release:
+#
+# bin/release_authors.sh v0.3.0 master
+
+set -e
+
+git log --reverse --format="%aN" $1..$2 | awk ' !x[$0]++'


### PR DESCRIPTION
This script can be used to obtain the list of authors who contributed to a
given release. The documentation how to use it is in the script itself.