### PR TITLE
Support LowerGamma with MPFR

### DIFF
--- a/symengine/eval_mpfr.cpp
+++ b/symengine/eval_mpfr.cpp
@@ -306,9 +306,19 @@ public:
     void bvisit(const UpperGamma &x)
     {
         mpfr_class t(mpfr_get_prec(result_));
-        apply(result_, *(x.get_args()[0]));
-        apply(t.get_mpfr_t(), *(x.get_args()[1]));
-        mpfr_gamma_inc(result_, result_, t.get_mpfr_t(), rnd_);
+        apply(result_, *(x.get_args()[1]));
+        apply(t.get_mpfr_t(), *(x.get_args()[0]));
+        mpfr_gamma_inc(result_, t.get_mpfr_t(), result_, rnd_);
+    };
+
+    void bvisit(const LowerGamma &x)
+    {
+        mpfr_class t(mpfr_get_prec(result_));
+        apply(result_, *(x.get_args()[1]));
+        apply(t.get_mpfr_t(), *(x.get_args()[0]));
+        mpfr_gamma_inc(result_, t.get_mpfr_t(), result_, rnd_);
+        mpfr_gamma(t.get_mpfr_t(), t.get_mpfr_t(), rnd_);
+        mpfr_sub(result_, t.get_mpfr_t(), result_, rnd_);
     };
 #endif
     void bvisit(const LogGamma &x)
@@ -400,7 +410,7 @@ public:
     }
 
     // Classes not implemented are
-    // Subs, LowerGamma, Dirichlet_eta, Zeta
+    // Subs, Dirichlet_eta, Zeta
     // LeviCivita, KroneckerDelta, LambertW
     // Derivative, Complex, ComplexDouble, ComplexMPC
     void bvisit(const Basic &)

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -2910,6 +2910,12 @@ bool LowerGamma::is_canonical(const RCP<const Basic> &s,
         return false;
     if (is_a<Integer>(*mul(i2, s)))
         return false;
+#ifdef HAVE_SYMENGINE_MPFR
+#if MPFR_VERSION_MAJOR > 3
+    if (is_a<RealMPFR>(*s) && is_a<RealMPFR>(*x))
+        return false;
+#endif
+#endif
     return true;
 }
 
@@ -2948,6 +2954,23 @@ RCP<const Basic> lowergamma(const RCP<const Basic> &s,
                            mul(pow(x, s), exp(mul(minus_one, x)))),
                        s);
         }
+#ifdef HAVE_SYMENGINE_MPFR
+#if MPFR_VERSION_MAJOR > 3
+    } else if (is_a<RealMPFR>(*s) && is_a<RealMPFR>(*x)) {
+        const auto &s_ = down_cast<const RealMPFR &>(*s).i.get_mpfr_t();
+        const auto &x_ = down_cast<const RealMPFR &>(*x).i.get_mpfr_t();
+        if (mpfr_cmp_si(x_, 0) >= 0) {
+            mpfr_class t(std::max(mpfr_get_prec(s_), mpfr_get_prec(x_)));
+            mpfr_class u(std::max(mpfr_get_prec(s_), mpfr_get_prec(x_)));
+            mpfr_gamma_inc(t.get_mpfr_t(), s_, x_, MPFR_RNDN);
+            mpfr_gamma(u.get_mpfr_t(), s_, MPFR_RNDN);
+            mpfr_sub(t.get_mpfr_t(), u.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
+            return real_mpfr(std::move(t));
+        } else {
+            throw NotImplementedError("Not implemented.");
+        }
+#endif
+#endif
     }
     return make_rcp<const LowerGamma>(s, x);
 }

--- a/symengine/tests/eval/test_eval_mpfr.cpp
+++ b/symengine/tests/eval/test_eval_mpfr.cpp
@@ -56,6 +56,7 @@ using SymEngine::GoldenRatio;
 using SymEngine::pow;
 using SymEngine::gamma;
 using SymEngine::uppergamma;
+using SymEngine::lowergamma;
 using SymEngine::beta;
 using SymEngine::constant;
 using SymEngine::NotImplementedError;
@@ -201,6 +202,8 @@ TEST_CASE("precision: eval_mpfr", "[eval_mpfr]")
 #if MPFR_VERSION_MAJOR > 3
         std::make_tuple(uppergamma(sqrt(integer(2)), arg2), 0.80040012955715,
                         0.80040012955716),
+        std::make_tuple(lowergamma(sqrt(integer(2)), arg2), 0.08618129916210,
+                        0.08618129916211),
 #endif
         std::make_tuple(beta(add(arg1, arg2), arg1), 0.13675213675213,
                         0.13675213675214),


### PR DESCRIPTION
Once we have an implementation of gamma and uppergamma, we can subtract
the two to make lowergamma. This constructs it with MPFR instead of
Symengine so that there is slightly less overhead.

Signed-off-by: Connor Behan <connor.behan@gmail.com>