### PR TITLE
Allow symengine rcp even in debug mode 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   matrix:
   ## Out of tree builds (default):
   # Debug build (with BFD)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" TRIGGER_FEEDSTOCK="yes"
+  - BUILD_TYPE="Debug" WITH_BFD="yes"
   # Debug build (with BFD and SYMENGINE_THREAD_SAFE)
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_THREAD_SAFE="yes"
   # Debug build (with BFD, ECM, PRIMESIEVE and MPC)
@@ -37,7 +37,7 @@ env:
   # Debug build (with BFD, Flint and Arb and INTEGER_CLASS from flint)
   - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_ARB="yes" INTEGER_CLASS="flint" WITH_MPC="yes" BUILD_DOXYGEN="yes" TEST_IN_TREE="yes"
   # Debug build (with BFD, MPFR and INTEGER_CLASS from gmpxx)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_MPFR="yes" INTEGER_CLASS="gmpxx"
+  - BUILD_TYPE="Debug" WITH_SYMENGINE_RCP="yes" WITH_MPFR="yes" INTEGER_CLASS="gmpxx"
   # Debug build (with BFD and INTEGER_CLASS from boostmp)
   - BUILD_TYPE="Debug" WITH_BFD="yes" INTEGER_CLASS="boostmp"
   # Debug build shared lib (with BFD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,10 +512,6 @@ endif()
 set(WITH_SYMENGINE_ASSERT no
     CACHE BOOL "Enable SYMENGINE_ASSERT macro")
 
-# SYMENGINE_RCP
-set(WITH_SYMENGINE_RCP yes
-    CACHE BOOL "Enable SYMENGINE_RCP support")
-
 # SYMENGINE_THREAD_SAFE
 set(WITH_SYMENGINE_THREAD_SAFE no
     CACHE BOOL "Enable SYMENGINE_THREAD_SAFE support")
@@ -551,12 +547,18 @@ endif()
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     # In Debug mode we use Teuchos::RCP and enable debugging checks that make
     # the usage 100% safe, as long as the Teuchos guidelines are followed.
-    set(WITH_SYMENGINE_RCP no) # Use the Teuchos::RCP
+    set(WITH_SYMENGINE_RCP_DEFAULT no) # Use the Teuchos::RCP
     set(HAVE_TEUCHOS_DEBUG yes) # Enable safety checks
     set(HAVE_TEUCHOS_DEBUG_RCP_NODE_TRACING yes) # Enable safety checks
 
     set(WITH_SYMENGINE_ASSERT yes) # Also enable assertions
+else ()
+    set(WITH_SYMENGINE_RCP_DEFAULT yes)
 endif()
+
+# SYMENGINE_RCP
+set(WITH_SYMENGINE_RCP ${WITH_SYMENGINE_RCP_DEFAULT}
+    CACHE BOOL "Enable SYMENGINE_RCP support")
 
 if (WITH_COVERAGE)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage")


### PR DESCRIPTION
This is a workaround to https://github.com/symengine/symengine/issues/1516
With this change you can build in debug mode without Teuchos by passing `-DWITH_SYMENGINE_RCP=yes` to cmake.

cc @jppelteret 