### PR TITLE
Fix LLVMDoubleVisitor load

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -843,6 +843,7 @@ const std::string &LLVMDoubleVisitor::dumps() const
 
 void LLVMDoubleVisitor::loads(const std::string &s)
 {
+    membuffer = s;
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
     llvm::InitializeNativeTargetAsmParser();

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -329,6 +329,28 @@ TEST_CASE("Check llvm save and load", "[llvm_double]")
     d = v.call({0.4, 2.0, 3.0});
     d2 = v2.call({0.4, 2.0, 3.0});
     REQUIRE(::fabs((d - d2) / d) < 1e-12);
+
+    // Test that dumping and loading on a loaded object also works
+    t1 = std::chrono::high_resolution_clock::now();
+    auto &s = v2.dumps();
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "Saving "
+              << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1)
+                     .count()
+              << "us" << std::endl;
+
+    LLVMDoubleVisitor v3;
+
+    t1 = std::chrono::high_resolution_clock::now();
+    v3.loads(s);
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "Loading "
+              << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1)
+                     .count()
+              << "us" << std::endl;
+
+    d3 = v3.call({0.4, 2.0, 3.0});
+    REQUIRE(::fabs((d - d3) / d) < 1e-12);
 }
 
 TEST_CASE("Check that our default LLVM passes give correct results",

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -331,23 +331,9 @@ TEST_CASE("Check llvm save and load", "[llvm_double]")
     REQUIRE(::fabs((d - d2) / d) < 1e-12);
 
     // Test that dumping and loading on a loaded object also works
-    t1 = std::chrono::high_resolution_clock::now();
-    auto &s = v2.dumps();
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "Saving "
-              << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1)
-                     .count()
-              << "us" << std::endl;
-
+    auto &s2 = v2.dumps();
     LLVMDoubleVisitor v3;
-
-    t1 = std::chrono::high_resolution_clock::now();
-    v3.loads(s);
-    t2 = std::chrono::high_resolution_clock::now();
-    std::cout << "Loading "
-              << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1)
-                     .count()
-              << "us" << std::endl;
+    v3.loads(s2);
 
     d3 = v3.call({0.4, 2.0, 3.0});
     REQUIRE(::fabs((d - d3) / d) < 1e-12);


### PR DESCRIPTION
From discussion on gitter:

> Pickling and unpickling the `LLVMDouble` (via symengine.py) does not correctly reset the `LLVMDoubleVisitor` that is supposed to be in `llvm_double[0]`. 
> 
> ### Reproducing the bug
> 
> 
> ```python
> from symengine import symbols
> x, y, z = symbols('x y z')
> ex = x**2 + y**2 + z**2
> from symengine import lambdify
> l = lambdify([x, y, z], [ex], backend='llvm')
> import pickle
> print('pickle.loads(pickle.dumps(l)) == l  :: ', pickle.loads(pickle.dumps(l)) == l)
> print(l.__reduce__())
> print(pickle.loads(pickle.dumps(l)).__reduce__())
> ```
> 
> gives 
> 
> ```python
> pickle.loads(pickle.dumps(l)) == l  ::  False
> (<built-in function llvm_loading_func>, (3, 1, [()], True, 1, 'C', [0, 1], <class 'numpy.float64'>, b"\xcf\xfa\xed\xfe\x07\x00\x00\x01\x03\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00`\x01\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x19\x00\x00\x00\xe8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00`\x00\x00\x00\x00\x00\x00\x00\x80\x01\x00\x00\x00\x00\x00\x00`\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00__text\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00__TEXT\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'\x00\x00\x00\x00\x00\x00\x00\x80\x01\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00__eh_frame\x00\x00\x00\x00\x00\x00__TEXT\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00(\x00\x00\x00\x00\x00\x00\x008\x00\x00\x00\x00\x00\x00\x00\xa8\x01\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0b\x00\x00h\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00$\x00\x00\x00\x10\x00\x00\x00\x00\x0e\n\x00\x00\x00\x00\x00\x02\x00\x00\x00\x18\x00\x00\x00\xe0\x01\x00\x00\x01\x00\x00\x00\xf0\x01\x00\x00\x10\x00\x00\x00\x0b\x00\x00\x00P\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf2\x0f\x10\x07\xf2\x0f\x10O\x08\xf2\x0f\x10W\x10\xf2\x0fY\xd2\xf2\x0fY\xc0\xf2\x0fX\xc2\xf2\x0fY\xc9\xf2\x0fX\xc8\xf2\x0f\x11\x0e\xc3\x00\x14\x00\x00\x00\x00\x00\x00\x00\x01zR\x00\x01x\x10\x01\x10\x0c\x07\x08\x90\x01\x00\x00\x1c\x00\x00\x00\x1c\x00\x00\x00\xb8\xff\xff\xff\xff\xff\xff\xff'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x0e\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00___unnamed_1\x00\x00\x00"))
> (<built-in function llvm_loading_func>, (3, 1, [()], True, 1, 'C', [0, 1], <class 'numpy.float64'>, b''))
> ```
> 
> You can see that the pickled/unpickled version gives an empty byte string for the dumped LLVMDoubleVisitor bytes. @richardotis and I were tracking this down and the issue looks to be that the `membuffer` is not correctly reset in  `LLVMDoubleVisitor.loads` [here](https://github.com/symengine/symengine/blob/72e2f22ab035db281aee0d6eebac67d2c65bebc0/symengine/llvm_double.cpp#L844) when called in `self.llvm_double[0].loads` as part of the `LLVMDouble._load` method [here](https://github.com/symengine/symengine.py/blob/1366cf98ceaade339c5dd24ae3381a0e63ea9dad/symengine/lib/symengine_wrapper.pyx#L4734). In that case, the root fix would be to set the `membuffer` in `LLVMDoubleVisitor.loads` in the same way as `LLVMDoubleVisitor.__init__`.
> 
> A test for this might be to do `pickle.loads(pickle.dumps(pickle.loads(pickle.dumps(l))))`, which currently will kill the kernel with a `LLVM ERROR: The file was not recognized as a valid object file`
