### PR TITLE
Add a virtual destructor to Visitor

### DIFF
--- a/symengine/visitor.h
+++ b/symengine/visitor.h
@@ -31,6 +31,7 @@ namespace SymEngine
 class Visitor
 {
 public:
+    virtual ~Visitor(){};
 #define SYMENGINE_ENUM(TypeID, Class) virtual void visit(const Class &) = 0;
 #include "symengine/type_codes.inc"
 #undef SYMENGINE_ENUM


### PR DESCRIPTION
Otherwise, clang emits

    warning:
      destructor called on non-final 'SymEngine::LambdaRealDoubleVisitor' that
      has virtual functions but non-virtual destructor
      [-Wdelete-non-virtual-dtor]