### PR TITLE
Verify that subsequent calls to parse() are fast

### DIFF
--- a/benchmarks/parsing.cpp
+++ b/benchmarks/parsing.cpp
@@ -16,6 +16,8 @@ int main(int argc, char *argv[])
     RCP<const Basic> a;
     int N;
 
+    std::cout << "First call (initialization)" << std::endl;
+
     auto t1 = std::chrono::high_resolution_clock::now();
     a = parse("0");
     auto t2 = std::chrono::high_resolution_clock::now();
@@ -23,6 +25,23 @@ int main(int argc, char *argv[])
               << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1)
                      .count()
               << "us" << std::endl;
+
+    std::cout << "Subsequent calls" << std::endl;
+
+    for (int i = 0; i < 10; i++) {
+        t1 = std::chrono::high_resolution_clock::now();
+        a = parse("0");
+        t2 = std::chrono::high_resolution_clock::now();
+        std::cout << std::chrono::duration_cast<std::chrono::microseconds>(t2
+                                                                           - t1)
+                         .count()
+                  << "us ";
+    }
+    std::cout << std::endl;
+
+    /* ------------------------------------------------- */
+
+    std::cout << std::endl << "Single long benchmark" << std::endl;
 
     N = 5000;
     std::string text;
@@ -49,6 +68,8 @@ int main(int argc, char *argv[])
     std::cout << *a << std::endl;
 
     /* ------------------------------------------------- */
+
+    std::cout << std::endl << "Repeated short benchmark" << std::endl;
 
     N = 3000;
     t1 = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Improve the output also. Now it prints:
```
$ ./benchmarks/parsing 
First call (initialization)
parse('0') = 0: 35us
Subsequent calls
8us 5us 4us 4us 5us 4us 4us 5us 4us 5us 

Single long benchmark
35ms
(x + y - sin(x)/(-4 + z**2) - x**(y**z))**5001
82ms
(x + y - sin(x)/(-4 + z**2) - x**(y**z))**5001

Repeated short benchmark
21ms
100ms
```
So one can see that the first call to `parse()` costs 35us, but subsequent calls cost ~ 5us. This is related to the changes introduced in #1593.