### PR TITLE
Simplify the parser

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 if (WITH_GENERATE_PARSER)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/parser/parser.tab.cc
-                      COMMAND ${BISON_EXECUTABLE} -d parser.yy
+                      COMMAND ${BISON_EXECUTABLE} -Wall -d parser.yy
                       DEPENDS parser/parser.yy
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/parser
                      )

--- a/symengine/parser/parser.cpp
+++ b/symengine/parser/parser.cpp
@@ -283,20 +283,15 @@ Parser::parse_implicit_mul(const std::string &expr)
     char *endptr = 0;
     std::strtod(startptr, &endptr);
 
-    RCP<const Basic> num = one, sym;
-
     // Numerical part of the result of e.g. "100x";
     size_t length = endptr - startptr;
     std::string lexpr = std::string(startptr, length);
-    num = parse_numeric(lexpr);
+    RCP<const Basic> num = parse_numeric(lexpr);
 
     // get the rest of the string
     lexpr = std::string(startptr + length, expr.length() - length);
-    if (lexpr.length() == 0) {
-        sym = one;
-    } else {
-        sym = parse_identifier(lexpr);
-    }
+    SYMENGINE_ASSERT(lexpr.length() > 0);
+    RCP<const Basic> sym = parse_identifier(lexpr);
     return std::make_tuple(num, sym);
 }
 

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -448,8 +448,8 @@ static const yytype_uint8 yytranslate[]
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
-    = {0,   104, 104, 112, 115, 118, 121, 124, 127, 130, 133, 136, 139, 142,
-       150, 158, 166, 169, 172, 175, 180, 185, 190, 198, 206, 214, 220};
+    = {0,   104, 104, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118,
+       124, 130, 136, 137, 138, 139, 140, 141, 142, 146, 153, 157, 161};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -1174,223 +1174,223 @@ yyreduce:
     YY_REDUCE_PRINT(yyn);
     switch (yyn) {
         case 2:
-#line 105 "parser.yy" /* yacc.c:1646  */
+#line 104 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
             p.res = (yyval.basic);
         }
-#line 1315 "parser.tab.cc" /* yacc.c:1646  */
+#line 1312 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 3:
-#line 113 "parser.yy" /* yacc.c:1646  */
+#line 108 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = add((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1321 "parser.tab.cc" /* yacc.c:1646  */
+#line 1318 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 4:
-#line 116 "parser.yy" /* yacc.c:1646  */
+#line 109 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = sub((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1327 "parser.tab.cc" /* yacc.c:1646  */
+#line 1324 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 5:
-#line 119 "parser.yy" /* yacc.c:1646  */
+#line 110 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = mul((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1333 "parser.tab.cc" /* yacc.c:1646  */
+#line 1330 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 6:
-#line 122 "parser.yy" /* yacc.c:1646  */
+#line 111 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = div((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1339 "parser.tab.cc" /* yacc.c:1646  */
+#line 1336 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 7:
-#line 125 "parser.yy" /* yacc.c:1646  */
+#line 112 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = pow((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1345 "parser.tab.cc" /* yacc.c:1646  */
+#line 1342 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 8:
-#line 128 "parser.yy" /* yacc.c:1646  */
+#line 113 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Lt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1351 "parser.tab.cc" /* yacc.c:1646  */
+#line 1348 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 9:
-#line 131 "parser.yy" /* yacc.c:1646  */
+#line 114 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Gt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1357 "parser.tab.cc" /* yacc.c:1646  */
+#line 1354 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 10:
-#line 134 "parser.yy" /* yacc.c:1646  */
+#line 115 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Le((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1363 "parser.tab.cc" /* yacc.c:1646  */
+#line 1360 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 11:
-#line 137 "parser.yy" /* yacc.c:1646  */
+#line 116 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Ge((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1369 "parser.tab.cc" /* yacc.c:1646  */
+#line 1366 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 12:
-#line 140 "parser.yy" /* yacc.c:1646  */
+#line 117 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Eq((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1375 "parser.tab.cc" /* yacc.c:1646  */
+#line 1372 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 13:
-#line 143 "parser.yy" /* yacc.c:1646  */
+#line 118 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_or(s);
         }
-#line 1386 "parser.tab.cc" /* yacc.c:1646  */
+#line 1383 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 14:
-#line 151 "parser.yy" /* yacc.c:1646  */
+#line 124 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_and(s);
         }
-#line 1397 "parser.tab.cc" /* yacc.c:1646  */
+#line 1394 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 15:
-#line 159 "parser.yy" /* yacc.c:1646  */
+#line 130 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_xor(s);
         }
-#line 1408 "parser.tab.cc" /* yacc.c:1646  */
+#line 1405 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 16:
-#line 167 "parser.yy" /* yacc.c:1646  */
+#line 136 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
-#line 1414 "parser.tab.cc" /* yacc.c:1646  */
+#line 1411 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 17:
-#line 170 "parser.yy" /* yacc.c:1646  */
+#line 137 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
-#line 1420 "parser.tab.cc" /* yacc.c:1646  */
+#line 1417 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 18:
-#line 173 "parser.yy" /* yacc.c:1646  */
+#line 138 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
         }
-#line 1426 "parser.tab.cc" /* yacc.c:1646  */
+#line 1423 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 19:
-#line 176 "parser.yy" /* yacc.c:1646  */
+#line 139 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
-#line 1434 "parser.tab.cc" /* yacc.c:1646  */
+#line 1429 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 20:
-#line 181 "parser.yy" /* yacc.c:1646  */
+#line 140 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_numeric((yyvsp[0].string));
         }
-#line 1442 "parser.tab.cc" /* yacc.c:1646  */
+#line 1435 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 21:
-#line 186 "parser.yy" /* yacc.c:1646  */
+#line 141 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
         }
-#line 1450 "parser.tab.cc" /* yacc.c:1646  */
+#line 1441 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 22:
-#line 191 "parser.yy" /* yacc.c:1646  */
+#line 142 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[0].string));
             (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
         }
-#line 1459 "parser.tab.cc" /* yacc.c:1646  */
+#line 1450 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 23:
-#line 199 "parser.yy" /* yacc.c:1646  */
+#line 146 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[-2].string));
             (yyval.basic) = mul(std::get<0>(tup),
                                 pow(std::get<1>(tup), (yyvsp[0].basic)));
         }
-#line 1468 "parser.tab.cc" /* yacc.c:1646  */
+#line 1459 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 24:
-#line 207 "parser.yy" /* yacc.c:1646  */
+#line 153 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
         }
-#line 1476 "parser.tab.cc" /* yacc.c:1646  */
+#line 1465 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 25:
-#line 215 "parser.yy" /* yacc.c:1646  */
+#line 157 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec)
                 = (yyvsp[-2].basic_vec); // TODO : should make copy?
             (yyval.basic_vec).push_back((yyvsp[0].basic));
         }
-#line 1485 "parser.tab.cc" /* yacc.c:1646  */
+#line 1474 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 26:
-#line 221 "parser.yy" /* yacc.c:1646  */
+#line 161 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }
-#line 1493 "parser.tab.cc" /* yacc.c:1646  */
+#line 1482 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-#line 1497 "parser.tab.cc" /* yacc.c:1646  */
+#line 1486 "parser.tab.cc" /* yacc.c:1646  */
         default:
             break;
     }

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -449,7 +449,7 @@ static const yytype_uint8 yytranslate[]
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
     = {0,   102, 102, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-       116, 122, 128, 134, 135, 136, 137, 138, 139, 140, 144, 151, 152};
+       116, 121, 126, 131, 132, 133, 135, 136, 137, 138, 141, 147, 148};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -1268,118 +1268,118 @@ yyreduce:
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_or(s);
         }
-#line 1383 "parser.tab.cc" /* yacc.c:1646  */
+#line 1382 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 14:
-#line 122 "parser.yy" /* yacc.c:1646  */
+#line 121 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_and(s);
         }
-#line 1394 "parser.tab.cc" /* yacc.c:1646  */
+#line 1392 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 15:
-#line 128 "parser.yy" /* yacc.c:1646  */
+#line 126 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_xor(s);
         }
-#line 1405 "parser.tab.cc" /* yacc.c:1646  */
+#line 1402 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 16:
-#line 134 "parser.yy" /* yacc.c:1646  */
+#line 131 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
-#line 1411 "parser.tab.cc" /* yacc.c:1646  */
+#line 1408 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 17:
-#line 135 "parser.yy" /* yacc.c:1646  */
+#line 132 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
-#line 1417 "parser.tab.cc" /* yacc.c:1646  */
+#line 1414 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 18:
-#line 136 "parser.yy" /* yacc.c:1646  */
+#line 133 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
         }
-#line 1423 "parser.tab.cc" /* yacc.c:1646  */
+#line 1421 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 19:
-#line 137 "parser.yy" /* yacc.c:1646  */
+#line 135 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
-#line 1429 "parser.tab.cc" /* yacc.c:1646  */
+#line 1427 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 20:
-#line 138 "parser.yy" /* yacc.c:1646  */
+#line 136 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_numeric((yyvsp[0].string));
         }
-#line 1435 "parser.tab.cc" /* yacc.c:1646  */
+#line 1433 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 21:
-#line 139 "parser.yy" /* yacc.c:1646  */
+#line 137 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
         }
-#line 1441 "parser.tab.cc" /* yacc.c:1646  */
+#line 1439 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 22:
-#line 140 "parser.yy" /* yacc.c:1646  */
+#line 138 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[0].string));
             (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
         }
-#line 1450 "parser.tab.cc" /* yacc.c:1646  */
+#line 1447 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 23:
-#line 144 "parser.yy" /* yacc.c:1646  */
+#line 141 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[-2].string));
             (yyval.basic) = mul(std::get<0>(tup),
                                 pow(std::get<1>(tup), (yyvsp[0].basic)));
         }
-#line 1459 "parser.tab.cc" /* yacc.c:1646  */
+#line 1455 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 24:
-#line 151 "parser.yy" /* yacc.c:1646  */
+#line 147 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = (yyvsp[-2].basic_vec);
             (yyval.basic_vec).push_back((yyvsp[0].basic));
         }
-#line 1465 "parser.tab.cc" /* yacc.c:1646  */
+#line 1461 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 25:
-#line 152 "parser.yy" /* yacc.c:1646  */
+#line 148 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }
-#line 1471 "parser.tab.cc" /* yacc.c:1646  */
+#line 1467 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-#line 1475 "parser.tab.cc" /* yacc.c:1646  */
+#line 1471 "parser.tab.cc" /* yacc.c:1646  */
         default:
             break;
     }

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -448,8 +448,8 @@ static const yytype_uint8 yytranslate[]
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
-    = {0,   104, 104, 112, 115, 118, 121, 126, 136, 139, 142, 145, 148, 151,
-       154, 162, 170, 178, 181, 184, 187, 192, 197, 203, 208, 215, 223, 229};
+    = {0,   104, 104, 112, 115, 118, 121, 126, 132, 135, 138, 141, 144, 147,
+       150, 158, 166, 174, 177, 180, 183, 188, 193, 199, 204, 211, 219, 225};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -1218,196 +1218,192 @@ yyreduce:
 #line 127 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[-2].string));
-            if (neq(*std::get<1>(tup), *one)) {
-                (yyval.basic) = mul(std::get<0>(tup),
-                                    pow(std::get<1>(tup), (yyvsp[0].basic)));
-            } else {
-                (yyval.basic) = pow(std::get<0>(tup), (yyvsp[0].basic));
-            }
+            (yyval.basic) = mul(std::get<0>(tup),
+                                pow(std::get<1>(tup), (yyvsp[0].basic)));
         }
-#line 1352 "parser.tab.cc" /* yacc.c:1646  */
+#line 1348 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 8:
-#line 137 "parser.yy" /* yacc.c:1646  */
+#line 133 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = pow((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1358 "parser.tab.cc" /* yacc.c:1646  */
+#line 1354 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 9:
-#line 140 "parser.yy" /* yacc.c:1646  */
+#line 136 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = rcp_static_cast<const Basic>(
                 Lt((yyvsp[-2].basic), (yyvsp[0].basic)));
         }
-#line 1364 "parser.tab.cc" /* yacc.c:1646  */
+#line 1360 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 10:
-#line 143 "parser.yy" /* yacc.c:1646  */
+#line 139 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = rcp_static_cast<const Basic>(
                 Gt((yyvsp[-2].basic), (yyvsp[0].basic)));
         }
-#line 1370 "parser.tab.cc" /* yacc.c:1646  */
+#line 1366 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 11:
-#line 146 "parser.yy" /* yacc.c:1646  */
+#line 142 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = rcp_static_cast<const Basic>(
                 Le((yyvsp[-2].basic), (yyvsp[0].basic)));
         }
-#line 1376 "parser.tab.cc" /* yacc.c:1646  */
+#line 1372 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 12:
-#line 149 "parser.yy" /* yacc.c:1646  */
+#line 145 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = rcp_static_cast<const Basic>(
                 Ge((yyvsp[-2].basic), (yyvsp[0].basic)));
         }
-#line 1382 "parser.tab.cc" /* yacc.c:1646  */
+#line 1378 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 13:
-#line 152 "parser.yy" /* yacc.c:1646  */
+#line 148 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = rcp_static_cast<const Basic>(
                 Eq((yyvsp[-2].basic), (yyvsp[0].basic)));
         }
-#line 1388 "parser.tab.cc" /* yacc.c:1646  */
+#line 1384 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 14:
-#line 155 "parser.yy" /* yacc.c:1646  */
+#line 151 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = rcp_static_cast<const Basic>(logical_or(s));
         }
-#line 1399 "parser.tab.cc" /* yacc.c:1646  */
+#line 1395 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 15:
-#line 163 "parser.yy" /* yacc.c:1646  */
+#line 159 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = rcp_static_cast<const Basic>(logical_and(s));
         }
-#line 1410 "parser.tab.cc" /* yacc.c:1646  */
+#line 1406 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 16:
-#line 171 "parser.yy" /* yacc.c:1646  */
+#line 167 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = rcp_static_cast<const Basic>(logical_xor(s));
         }
-#line 1421 "parser.tab.cc" /* yacc.c:1646  */
+#line 1417 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 17:
-#line 179 "parser.yy" /* yacc.c:1646  */
+#line 175 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
-#line 1427 "parser.tab.cc" /* yacc.c:1646  */
+#line 1423 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 18:
-#line 182 "parser.yy" /* yacc.c:1646  */
+#line 178 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
-#line 1433 "parser.tab.cc" /* yacc.c:1646  */
+#line 1429 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 19:
-#line 185 "parser.yy" /* yacc.c:1646  */
+#line 181 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = rcp_static_cast<const Basic>(
                 logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic))));
         }
-#line 1439 "parser.tab.cc" /* yacc.c:1646  */
+#line 1435 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 20:
-#line 188 "parser.yy" /* yacc.c:1646  */
+#line 184 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = rcp_static_cast<const Basic>((yyvsp[0].basic));
         }
-#line 1445 "parser.tab.cc" /* yacc.c:1646  */
+#line 1441 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 21:
-#line 193 "parser.yy" /* yacc.c:1646  */
+#line 189 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
-#line 1453 "parser.tab.cc" /* yacc.c:1646  */
+#line 1449 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 22:
-#line 198 "parser.yy" /* yacc.c:1646  */
+#line 194 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[0].string));
             (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
         }
-#line 1462 "parser.tab.cc" /* yacc.c:1646  */
+#line 1458 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 23:
-#line 204 "parser.yy" /* yacc.c:1646  */
+#line 200 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_numeric((yyvsp[0].string));
         }
-#line 1470 "parser.tab.cc" /* yacc.c:1646  */
+#line 1466 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 24:
-#line 209 "parser.yy" /* yacc.c:1646  */
+#line 205 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
         }
-#line 1478 "parser.tab.cc" /* yacc.c:1646  */
+#line 1474 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 25:
-#line 216 "parser.yy" /* yacc.c:1646  */
+#line 212 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
         }
-#line 1486 "parser.tab.cc" /* yacc.c:1646  */
+#line 1482 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 26:
-#line 224 "parser.yy" /* yacc.c:1646  */
+#line 220 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec)
                 = (yyvsp[-2].basic_vec); // TODO : should make copy?
             (yyval.basic_vec).push_back((yyvsp[0].basic));
         }
-#line 1495 "parser.tab.cc" /* yacc.c:1646  */
+#line 1491 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 27:
-#line 230 "parser.yy" /* yacc.c:1646  */
+#line 226 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }
-#line 1503 "parser.tab.cc" /* yacc.c:1646  */
+#line 1499 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-#line 1507 "parser.tab.cc" /* yacc.c:1646  */
+#line 1503 "parser.tab.cc" /* yacc.c:1646  */
         default:
             break;
     }

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -448,8 +448,8 @@ static const yytype_uint8 yytranslate[]
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
-    = {0,   101, 101, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
-       115, 120, 125, 130, 131, 132, 134, 135, 136, 137, 140, 146, 147};
+    = {0,   99,  99,  103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
+       113, 118, 123, 128, 129, 130, 132, 133, 134, 135, 138, 144, 145};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -1172,7 +1172,7 @@ yyreduce:
     YY_REDUCE_PRINT(yyn);
     switch (yyn) {
         case 2:
-#line 101 "parser.yy" /* yacc.c:1646  */
+#line 99 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
             p.res = (yyval.basic);
@@ -1181,7 +1181,7 @@ yyreduce:
         break;
 
         case 3:
-#line 105 "parser.yy" /* yacc.c:1646  */
+#line 103 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = add((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1189,7 +1189,7 @@ yyreduce:
         break;
 
         case 4:
-#line 106 "parser.yy" /* yacc.c:1646  */
+#line 104 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = sub((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1197,7 +1197,7 @@ yyreduce:
         break;
 
         case 5:
-#line 107 "parser.yy" /* yacc.c:1646  */
+#line 105 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = mul((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1205,7 +1205,7 @@ yyreduce:
         break;
 
         case 6:
-#line 108 "parser.yy" /* yacc.c:1646  */
+#line 106 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = div((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1213,7 +1213,7 @@ yyreduce:
         break;
 
         case 7:
-#line 109 "parser.yy" /* yacc.c:1646  */
+#line 107 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = pow((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1221,7 +1221,7 @@ yyreduce:
         break;
 
         case 8:
-#line 110 "parser.yy" /* yacc.c:1646  */
+#line 108 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Lt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1229,7 +1229,7 @@ yyreduce:
         break;
 
         case 9:
-#line 111 "parser.yy" /* yacc.c:1646  */
+#line 109 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Gt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1237,7 +1237,7 @@ yyreduce:
         break;
 
         case 10:
-#line 112 "parser.yy" /* yacc.c:1646  */
+#line 110 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Le((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1245,7 +1245,7 @@ yyreduce:
         break;
 
         case 11:
-#line 113 "parser.yy" /* yacc.c:1646  */
+#line 111 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Ge((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1253,7 +1253,7 @@ yyreduce:
         break;
 
         case 12:
-#line 114 "parser.yy" /* yacc.c:1646  */
+#line 112 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Eq((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1261,7 +1261,7 @@ yyreduce:
         break;
 
         case 13:
-#line 115 "parser.yy" /* yacc.c:1646  */
+#line 113 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1272,7 +1272,7 @@ yyreduce:
         break;
 
         case 14:
-#line 120 "parser.yy" /* yacc.c:1646  */
+#line 118 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1283,7 +1283,7 @@ yyreduce:
         break;
 
         case 15:
-#line 125 "parser.yy" /* yacc.c:1646  */
+#line 123 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1294,7 +1294,7 @@ yyreduce:
         break;
 
         case 16:
-#line 130 "parser.yy" /* yacc.c:1646  */
+#line 128 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
@@ -1302,7 +1302,7 @@ yyreduce:
         break;
 
         case 17:
-#line 131 "parser.yy" /* yacc.c:1646  */
+#line 129 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
@@ -1310,7 +1310,7 @@ yyreduce:
         break;
 
         case 18:
-#line 132 "parser.yy" /* yacc.c:1646  */
+#line 130 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
@@ -1319,7 +1319,7 @@ yyreduce:
         break;
 
         case 19:
-#line 134 "parser.yy" /* yacc.c:1646  */
+#line 132 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
@@ -1327,7 +1327,7 @@ yyreduce:
         break;
 
         case 20:
-#line 135 "parser.yy" /* yacc.c:1646  */
+#line 133 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_numeric((yyvsp[0].string));
         }
@@ -1335,7 +1335,7 @@ yyreduce:
         break;
 
         case 21:
-#line 136 "parser.yy" /* yacc.c:1646  */
+#line 134 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
@@ -1344,7 +1344,7 @@ yyreduce:
         break;
 
         case 22:
-#line 137 "parser.yy" /* yacc.c:1646  */
+#line 135 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[0].string));
             (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
@@ -1353,7 +1353,7 @@ yyreduce:
         break;
 
         case 23:
-#line 140 "parser.yy" /* yacc.c:1646  */
+#line 138 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[-2].string));
             (yyval.basic) = mul(std::get<0>(tup),
@@ -1363,7 +1363,7 @@ yyreduce:
         break;
 
         case 24:
-#line 146 "parser.yy" /* yacc.c:1646  */
+#line 144 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = (yyvsp[-2].basic_vec);
             (yyval.basic_vec).push_back((yyvsp[0].basic));
@@ -1372,7 +1372,7 @@ yyreduce:
         break;
 
         case 25:
-#line 147 "parser.yy" /* yacc.c:1646  */
+#line 145 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -407,18 +407,18 @@ union yyalloc {
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL 16
+#define YYFINAL 15
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST 144
+#define YYLAST 143
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS 25
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS 6
+#define YYNNTS 5
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES 27
+#define YYNRULES 26
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES 50
+#define YYNSTATES 49
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
@@ -448,8 +448,8 @@ static const yytype_uint8 yytranslate[]
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
-    = {0,   104, 104, 112, 115, 118, 121, 126, 132, 135, 138, 141, 144, 147,
-       150, 158, 166, 174, 177, 180, 183, 188, 193, 199, 204, 211, 219, 225};
+    = {0,   103, 103, 111, 114, 117, 120, 125, 131, 134, 137, 140, 143, 146,
+       149, 157, 165, 173, 176, 179, 182, 187, 193, 198, 205, 213, 219};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -461,8 +461,8 @@ static const char *const yytname[]
        "'>'",          "'<'",     "LE",         "GE",         "'-'",
        "'+'",          "'*'",     "'/'",        "UMINUS",     "POW",
        "NOT",          "'('",     "')'",        "'~'",        "','",
-       "$accept",      "st_expr", "expr",       "leaf",       "func",
-       "expr_list",    YY_NULLPTR};
+       "$accept",      "st_expr", "expr",       "func",       "expr_list",
+       YY_NULLPTR};
 #endif
 
 #ifdef YYPRINT
@@ -473,9 +473,9 @@ static const yytype_uint16 yytoknum[]
        263, 45,  43,  42,  47,  264, 265, 266, 40, 41,  126, 44};
 #endif
 
-#define YYPACT_NINF -17
+#define YYPACT_NINF -20
 
-#define yypact_value_is_default(Yystate) (!!((Yystate) == (-17)))
+#define yypact_value_is_default(Yystate) (!!((Yystate) == (-20)))
 
 #define YYTABLE_NINF -1
 
@@ -484,63 +484,63 @@ static const yytype_uint16 yytoknum[]
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
 static const yytype_int8 yypact[]
-    = {24,  -16, -17, -10, 24,  24,  24, 11,  59,  -17, -17, 24, 24,
-       7,   42,  -17, -17, 24,  24,  24, 24,  24,  24,  24,  24, 24,
-       24,  24,  24,  24,  59,  -12, 7,  -17, 72,  84,  95,  20, 104,
-       112, 119, 125, -13, -13, 7,   7,  7,   -17, 24,  59};
+    = {23,  -17, -20, -9, 23,  23, 23,  25,  58, -20, 23, 23,  20,
+       41,  -20, -20, 23, 23,  23, 23,  23,  23, 23,  23, 23,  23,
+       23,  23,  23,  58, -19, 20, -20, 71,  83, 94,  19, 103, 111,
+       118, 124, -8,  -8, 20,  20, 20,  -20, 23, 58};
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
    Performed when YYTABLE does not specify something else to do.  Zero
    means the default is an error.  */
 static const yytype_uint8 yydefact[]
-    = {0,  21, 23, 22, 0,  0, 0,  0,  2, 20, 24, 0, 0, 18, 0, 19, 1,
-       0,  0,  0,  0,  0,  0, 0,  0,  0, 0,  0,  0, 0, 27, 0, 7,  17,
-       14, 16, 15, 13, 10, 9, 11, 12, 4, 3,  5,  6, 8, 25, 0, 26};
+    = {0,  20, 22, 21, 0, 0,  0,  0, 2, 23, 0, 0, 18, 0, 19, 1,  0,
+       0,  0,  0,  0,  0, 0,  0,  0, 0, 0,  0, 0, 26, 0, 7,  17, 14,
+       16, 15, 13, 10, 9, 11, 12, 4, 3, 5,  6, 8, 24, 0, 25};
 
 /* YYPGOTO[NTERM-NUM].  */
-static const yytype_int8 yypgoto[] = {-17, -17, -4, -17, -17, -17};
+static const yytype_int8 yypgoto[] = {-20, -20, -4, -20, -20};
 
 /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] = {-1, 7, 8, 9, 10, 31};
+static const yytype_int8 yydefgoto[] = {-1, 7, 8, 9, 30};
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
    positive, shift that token.  If negative, reduce the rule whose
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
-static const yytype_uint8 yytable[] = {
-    13, 14, 15, 27, 28, 11, 29, 30, 32, 12, 47, 16, 48, 34, 35, 36, 37, 38, 39,
-    40, 41, 42, 43, 44, 45, 46, 29, 1,  2,  3,  21, 22, 23, 24, 25, 26, 27, 28,
-    4,  29, 0,  0,  0,  0,  49, 5,  0,  6,  17, 18, 19, 20, 21, 22, 23, 24, 25,
-    26, 27, 28, 0,  29, 0,  0,  33, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
-    28, 0,  29, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 0,  29, 19, 20, 21,
-    22, 23, 24, 25, 26, 27, 28, 0,  29, 20, 21, 22, 23, 24, 25, 26, 27, 28, 0,
-    29, 22, 23, 24, 25, 26, 27, 28, 0,  29, 23, 24, 25, 26, 27, 28, 0,  29, 24,
-    25, 26, 27, 28, 0,  29, 25, 26, 27, 28, 0,  29};
+static const yytype_uint8 yytable[]
+    = {12, 13, 14, 46, 10, 47, 29, 31, 26, 27, 11, 28, 33, 34, 35, 36, 37, 38,
+       39, 40, 41, 42, 43, 44, 45, 15, 1,  2,  3,  20, 21, 22, 23, 24, 25, 26,
+       27, 4,  28, 28, 0,  0,  0,  48, 5,  0,  6,  16, 17, 18, 19, 20, 21, 22,
+       23, 24, 25, 26, 27, 0,  28, 0,  0,  32, 16, 17, 18, 19, 20, 21, 22, 23,
+       24, 25, 26, 27, 0,  28, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 0,
+       28, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 0,  28, 19, 20, 21, 22, 23,
+       24, 25, 26, 27, 0,  28, 21, 22, 23, 24, 25, 26, 27, 0,  28, 22, 23, 24,
+       25, 26, 27, 0,  28, 23, 24, 25, 26, 27, 0,  28, 24, 25, 26, 27, 0,  28};
 
-static const yytype_int8 yycheck[] = {
-    4,  5,  6,  16, 17, 21, 19, 11, 12, 19, 22, 0,  24, 17, 18, 19, 20, 21, 22,
-    23, 24, 25, 26, 27, 28, 29, 19, 3,  4,  5,  10, 11, 12, 13, 14, 15, 16, 17,
-    14, 19, -1, -1, -1, -1, 48, 21, -1, 23, 6,  7,  8,  9,  10, 11, 12, 13, 14,
-    15, 16, 17, -1, 19, -1, -1, 22, 6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
-    17, -1, 19, 7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, -1, 19, 8,  9,  10,
-    11, 12, 13, 14, 15, 16, 17, -1, 19, 9,  10, 11, 12, 13, 14, 15, 16, 17, -1,
-    19, 11, 12, 13, 14, 15, 16, 17, -1, 19, 12, 13, 14, 15, 16, 17, -1, 19, 13,
-    14, 15, 16, 17, -1, 19, 14, 15, 16, 17, -1, 19};
+static const yytype_int8 yycheck[]
+    = {4,  5,  6,  22, 21, 24, 10, 11, 16, 17, 19, 19, 16, 17, 18, 19, 20, 21,
+       22, 23, 24, 25, 26, 27, 28, 0,  3,  4,  5,  10, 11, 12, 13, 14, 15, 16,
+       17, 14, 19, 19, -1, -1, -1, 47, 21, -1, 23, 6,  7,  8,  9,  10, 11, 12,
+       13, 14, 15, 16, 17, -1, 19, -1, -1, 22, 6,  7,  8,  9,  10, 11, 12, 13,
+       14, 15, 16, 17, -1, 19, 7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, -1,
+       19, 8,  9,  10, 11, 12, 13, 14, 15, 16, 17, -1, 19, 9,  10, 11, 12, 13,
+       14, 15, 16, 17, -1, 19, 11, 12, 13, 14, 15, 16, 17, -1, 19, 12, 13, 14,
+       15, 16, 17, -1, 19, 13, 14, 15, 16, 17, -1, 19, 14, 15, 16, 17, -1, 19};
 
 /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
    symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[]
-    = {0,  3,  4,  5,  14, 21, 23, 26, 27, 28, 29, 21, 19, 27, 27, 27, 0,
-       6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 19, 27, 30, 27, 22,
-       27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 22, 24, 27};
+    = {0,  3,  4,  5,  14, 21, 23, 26, 27, 28, 21, 19, 27, 27, 27, 0,  6,
+       7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 19, 27, 29, 27, 22, 27,
+       27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 22, 24, 27};
 
 /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[]
     = {0,  25, 26, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27,
-       27, 27, 27, 27, 27, 27, 27, 28, 28, 28, 28, 29, 30, 30};
+       27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28, 29, 29};
 
 /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] = {0, 2, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                    3, 3, 3, 3, 2, 2, 1, 1, 1, 1, 1, 4, 3, 1};
+                                    3, 3, 3, 3, 2, 2, 1, 1, 1, 1, 4, 3, 1};
 
 #define yyerrok (yyerrstatus = 0)
 #define yyclearin (yychar = YYEMPTY)
@@ -1174,7 +1174,7 @@ yyreduce:
     YY_REDUCE_PRINT(yyn);
     switch (yyn) {
         case 2:
-#line 105 "parser.yy" /* yacc.c:1646  */
+#line 104 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
             p.res = (yyval.basic);
@@ -1183,7 +1183,7 @@ yyreduce:
         break;
 
         case 3:
-#line 113 "parser.yy" /* yacc.c:1646  */
+#line 112 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = add((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1191,7 +1191,7 @@ yyreduce:
         break;
 
         case 4:
-#line 116 "parser.yy" /* yacc.c:1646  */
+#line 115 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = sub((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1199,7 +1199,7 @@ yyreduce:
         break;
 
         case 5:
-#line 119 "parser.yy" /* yacc.c:1646  */
+#line 118 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = mul((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1207,7 +1207,7 @@ yyreduce:
         break;
 
         case 6:
-#line 122 "parser.yy" /* yacc.c:1646  */
+#line 121 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = div((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1215,7 +1215,7 @@ yyreduce:
         break;
 
         case 7:
-#line 127 "parser.yy" /* yacc.c:1646  */
+#line 126 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[-2].string));
             (yyval.basic) = mul(std::get<0>(tup),
@@ -1225,7 +1225,7 @@ yyreduce:
         break;
 
         case 8:
-#line 133 "parser.yy" /* yacc.c:1646  */
+#line 132 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = pow((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1233,7 +1233,7 @@ yyreduce:
         break;
 
         case 9:
-#line 136 "parser.yy" /* yacc.c:1646  */
+#line 135 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Lt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1241,7 +1241,7 @@ yyreduce:
         break;
 
         case 10:
-#line 139 "parser.yy" /* yacc.c:1646  */
+#line 138 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Gt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1249,7 +1249,7 @@ yyreduce:
         break;
 
         case 11:
-#line 142 "parser.yy" /* yacc.c:1646  */
+#line 141 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Le((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1257,7 +1257,7 @@ yyreduce:
         break;
 
         case 12:
-#line 145 "parser.yy" /* yacc.c:1646  */
+#line 144 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Ge((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1265,7 +1265,7 @@ yyreduce:
         break;
 
         case 13:
-#line 148 "parser.yy" /* yacc.c:1646  */
+#line 147 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Eq((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1273,7 +1273,7 @@ yyreduce:
         break;
 
         case 14:
-#line 151 "parser.yy" /* yacc.c:1646  */
+#line 150 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1284,7 +1284,7 @@ yyreduce:
         break;
 
         case 15:
-#line 159 "parser.yy" /* yacc.c:1646  */
+#line 158 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1295,7 +1295,7 @@ yyreduce:
         break;
 
         case 16:
-#line 167 "parser.yy" /* yacc.c:1646  */
+#line 166 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1306,7 +1306,7 @@ yyreduce:
         break;
 
         case 17:
-#line 175 "parser.yy" /* yacc.c:1646  */
+#line 174 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
@@ -1314,7 +1314,7 @@ yyreduce:
         break;
 
         case 18:
-#line 178 "parser.yy" /* yacc.c:1646  */
+#line 177 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
@@ -1322,7 +1322,7 @@ yyreduce:
         break;
 
         case 19:
-#line 181 "parser.yy" /* yacc.c:1646  */
+#line 180 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
@@ -1331,74 +1331,66 @@ yyreduce:
         break;
 
         case 20:
-#line 184 "parser.yy" /* yacc.c:1646  */
-        {
-            (yyval.basic) = (yyvsp[0].basic);
-        }
-#line 1441 "parser.tab.cc" /* yacc.c:1646  */
-        break;
-
-        case 21:
-#line 189 "parser.yy" /* yacc.c:1646  */
+#line 183 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
-#line 1449 "parser.tab.cc" /* yacc.c:1646  */
+#line 1443 "parser.tab.cc" /* yacc.c:1646  */
+        break;
+
+        case 21:
+#line 188 "parser.yy" /* yacc.c:1646  */
+        {
+            auto tup = p.parse_implicit_mul((yyvsp[0].string));
+            (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
+        }
+#line 1452 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 22:
 #line 194 "parser.yy" /* yacc.c:1646  */
         {
-            auto tup = p.parse_implicit_mul((yyvsp[0].string));
-            (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
+            (yyval.basic) = p.parse_numeric((yyvsp[0].string));
         }
-#line 1458 "parser.tab.cc" /* yacc.c:1646  */
+#line 1460 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 23:
-#line 200 "parser.yy" /* yacc.c:1646  */
-        {
-            (yyval.basic) = p.parse_numeric((yyvsp[0].string));
-        }
-#line 1466 "parser.tab.cc" /* yacc.c:1646  */
-        break;
-
-        case 24:
-#line 205 "parser.yy" /* yacc.c:1646  */
+#line 199 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
         }
-#line 1474 "parser.tab.cc" /* yacc.c:1646  */
+#line 1468 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 25:
-#line 212 "parser.yy" /* yacc.c:1646  */
+        case 24:
+#line 206 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
         }
-#line 1482 "parser.tab.cc" /* yacc.c:1646  */
+#line 1476 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 26:
-#line 220 "parser.yy" /* yacc.c:1646  */
+        case 25:
+#line 214 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec)
                 = (yyvsp[-2].basic_vec); // TODO : should make copy?
             (yyval.basic_vec).push_back((yyvsp[0].basic));
         }
-#line 1491 "parser.tab.cc" /* yacc.c:1646  */
+#line 1485 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 27:
-#line 226 "parser.yy" /* yacc.c:1646  */
+        case 26:
+#line 220 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }
-#line 1499 "parser.tab.cc" /* yacc.c:1646  */
+#line 1493 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-#line 1503 "parser.tab.cc" /* yacc.c:1646  */
+#line 1497 "parser.tab.cc" /* yacc.c:1646  */
         default:
             break;
     }

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -448,8 +448,8 @@ static const yytype_uint8 yytranslate[]
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
-    = {0,   103, 103, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
-       117, 123, 129, 135, 136, 137, 138, 139, 140, 141, 145, 152, 153};
+    = {0,   102, 102, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+       116, 122, 128, 134, 135, 136, 137, 138, 139, 140, 144, 151, 152};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -1172,7 +1172,7 @@ yyreduce:
     YY_REDUCE_PRINT(yyn);
     switch (yyn) {
         case 2:
-#line 103 "parser.yy" /* yacc.c:1646  */
+#line 102 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
             p.res = (yyval.basic);
@@ -1181,7 +1181,7 @@ yyreduce:
         break;
 
         case 3:
-#line 107 "parser.yy" /* yacc.c:1646  */
+#line 106 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = add((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1189,7 +1189,7 @@ yyreduce:
         break;
 
         case 4:
-#line 108 "parser.yy" /* yacc.c:1646  */
+#line 107 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = sub((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1197,7 +1197,7 @@ yyreduce:
         break;
 
         case 5:
-#line 109 "parser.yy" /* yacc.c:1646  */
+#line 108 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = mul((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1205,7 +1205,7 @@ yyreduce:
         break;
 
         case 6:
-#line 110 "parser.yy" /* yacc.c:1646  */
+#line 109 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = div((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1213,7 +1213,7 @@ yyreduce:
         break;
 
         case 7:
-#line 111 "parser.yy" /* yacc.c:1646  */
+#line 110 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = pow((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1221,7 +1221,7 @@ yyreduce:
         break;
 
         case 8:
-#line 112 "parser.yy" /* yacc.c:1646  */
+#line 111 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Lt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1229,7 +1229,7 @@ yyreduce:
         break;
 
         case 9:
-#line 113 "parser.yy" /* yacc.c:1646  */
+#line 112 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Gt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1237,7 +1237,7 @@ yyreduce:
         break;
 
         case 10:
-#line 114 "parser.yy" /* yacc.c:1646  */
+#line 113 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Le((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1245,7 +1245,7 @@ yyreduce:
         break;
 
         case 11:
-#line 115 "parser.yy" /* yacc.c:1646  */
+#line 114 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Ge((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1253,7 +1253,7 @@ yyreduce:
         break;
 
         case 12:
-#line 116 "parser.yy" /* yacc.c:1646  */
+#line 115 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Eq((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1261,7 +1261,7 @@ yyreduce:
         break;
 
         case 13:
-#line 117 "parser.yy" /* yacc.c:1646  */
+#line 116 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1272,7 +1272,7 @@ yyreduce:
         break;
 
         case 14:
-#line 123 "parser.yy" /* yacc.c:1646  */
+#line 122 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1283,7 +1283,7 @@ yyreduce:
         break;
 
         case 15:
-#line 129 "parser.yy" /* yacc.c:1646  */
+#line 128 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1294,7 +1294,7 @@ yyreduce:
         break;
 
         case 16:
-#line 135 "parser.yy" /* yacc.c:1646  */
+#line 134 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
@@ -1302,7 +1302,7 @@ yyreduce:
         break;
 
         case 17:
-#line 136 "parser.yy" /* yacc.c:1646  */
+#line 135 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
@@ -1310,7 +1310,7 @@ yyreduce:
         break;
 
         case 18:
-#line 137 "parser.yy" /* yacc.c:1646  */
+#line 136 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
@@ -1319,7 +1319,7 @@ yyreduce:
         break;
 
         case 19:
-#line 138 "parser.yy" /* yacc.c:1646  */
+#line 137 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
@@ -1327,7 +1327,7 @@ yyreduce:
         break;
 
         case 20:
-#line 139 "parser.yy" /* yacc.c:1646  */
+#line 138 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_numeric((yyvsp[0].string));
         }
@@ -1335,7 +1335,7 @@ yyreduce:
         break;
 
         case 21:
-#line 140 "parser.yy" /* yacc.c:1646  */
+#line 139 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
@@ -1344,7 +1344,7 @@ yyreduce:
         break;
 
         case 22:
-#line 141 "parser.yy" /* yacc.c:1646  */
+#line 140 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[0].string));
             (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
@@ -1353,7 +1353,7 @@ yyreduce:
         break;
 
         case 23:
-#line 145 "parser.yy" /* yacc.c:1646  */
+#line 144 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[-2].string));
             (yyval.basic) = mul(std::get<0>(tup),
@@ -1363,7 +1363,7 @@ yyreduce:
         break;
 
         case 24:
-#line 152 "parser.yy" /* yacc.c:1646  */
+#line 151 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = (yyvsp[-2].basic_vec);
             (yyval.basic_vec).push_back((yyvsp[0].basic));
@@ -1372,7 +1372,7 @@ yyreduce:
         break;
 
         case 25:
-#line 153 "parser.yy" /* yacc.c:1646  */
+#line 152 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -448,8 +448,8 @@ static const yytype_uint8 yytranslate[]
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
-    = {0,   102, 102, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-       116, 121, 126, 131, 132, 133, 135, 136, 137, 138, 141, 147, 148};
+    = {0,   101, 101, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+       115, 120, 125, 130, 131, 132, 134, 135, 136, 137, 140, 146, 147};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -1172,7 +1172,7 @@ yyreduce:
     YY_REDUCE_PRINT(yyn);
     switch (yyn) {
         case 2:
-#line 102 "parser.yy" /* yacc.c:1646  */
+#line 101 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
             p.res = (yyval.basic);
@@ -1181,7 +1181,7 @@ yyreduce:
         break;
 
         case 3:
-#line 106 "parser.yy" /* yacc.c:1646  */
+#line 105 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = add((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1189,7 +1189,7 @@ yyreduce:
         break;
 
         case 4:
-#line 107 "parser.yy" /* yacc.c:1646  */
+#line 106 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = sub((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1197,7 +1197,7 @@ yyreduce:
         break;
 
         case 5:
-#line 108 "parser.yy" /* yacc.c:1646  */
+#line 107 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = mul((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1205,7 +1205,7 @@ yyreduce:
         break;
 
         case 6:
-#line 109 "parser.yy" /* yacc.c:1646  */
+#line 108 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = div((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1213,7 +1213,7 @@ yyreduce:
         break;
 
         case 7:
-#line 110 "parser.yy" /* yacc.c:1646  */
+#line 109 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = pow((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1221,7 +1221,7 @@ yyreduce:
         break;
 
         case 8:
-#line 111 "parser.yy" /* yacc.c:1646  */
+#line 110 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Lt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1229,7 +1229,7 @@ yyreduce:
         break;
 
         case 9:
-#line 112 "parser.yy" /* yacc.c:1646  */
+#line 111 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Gt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1237,7 +1237,7 @@ yyreduce:
         break;
 
         case 10:
-#line 113 "parser.yy" /* yacc.c:1646  */
+#line 112 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Le((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1245,7 +1245,7 @@ yyreduce:
         break;
 
         case 11:
-#line 114 "parser.yy" /* yacc.c:1646  */
+#line 113 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Ge((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1253,7 +1253,7 @@ yyreduce:
         break;
 
         case 12:
-#line 115 "parser.yy" /* yacc.c:1646  */
+#line 114 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Eq((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1261,7 +1261,7 @@ yyreduce:
         break;
 
         case 13:
-#line 116 "parser.yy" /* yacc.c:1646  */
+#line 115 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1272,7 +1272,7 @@ yyreduce:
         break;
 
         case 14:
-#line 121 "parser.yy" /* yacc.c:1646  */
+#line 120 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1283,7 +1283,7 @@ yyreduce:
         break;
 
         case 15:
-#line 126 "parser.yy" /* yacc.c:1646  */
+#line 125 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1294,7 +1294,7 @@ yyreduce:
         break;
 
         case 16:
-#line 131 "parser.yy" /* yacc.c:1646  */
+#line 130 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
@@ -1302,7 +1302,7 @@ yyreduce:
         break;
 
         case 17:
-#line 132 "parser.yy" /* yacc.c:1646  */
+#line 131 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
@@ -1310,7 +1310,7 @@ yyreduce:
         break;
 
         case 18:
-#line 133 "parser.yy" /* yacc.c:1646  */
+#line 132 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
@@ -1319,7 +1319,7 @@ yyreduce:
         break;
 
         case 19:
-#line 135 "parser.yy" /* yacc.c:1646  */
+#line 134 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
@@ -1327,7 +1327,7 @@ yyreduce:
         break;
 
         case 20:
-#line 136 "parser.yy" /* yacc.c:1646  */
+#line 135 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_numeric((yyvsp[0].string));
         }
@@ -1335,7 +1335,7 @@ yyreduce:
         break;
 
         case 21:
-#line 137 "parser.yy" /* yacc.c:1646  */
+#line 136 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
@@ -1344,7 +1344,7 @@ yyreduce:
         break;
 
         case 22:
-#line 138 "parser.yy" /* yacc.c:1646  */
+#line 137 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[0].string));
             (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
@@ -1353,7 +1353,7 @@ yyreduce:
         break;
 
         case 23:
-#line 141 "parser.yy" /* yacc.c:1646  */
+#line 140 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[-2].string));
             (yyval.basic) = mul(std::get<0>(tup),
@@ -1363,7 +1363,7 @@ yyreduce:
         break;
 
         case 24:
-#line 147 "parser.yy" /* yacc.c:1646  */
+#line 146 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = (yyvsp[-2].basic_vec);
             (yyval.basic_vec).push_back((yyvsp[0].basic));
@@ -1372,7 +1372,7 @@ yyreduce:
         break;
 
         case 25:
-#line 148 "parser.yy" /* yacc.c:1646  */
+#line 147 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -448,8 +448,8 @@ static const yytype_uint8 yytranslate[]
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
-    = {0,   103, 103, 111, 114, 117, 120, 125, 131, 134, 137, 140, 143, 146,
-       149, 157, 165, 173, 176, 179, 182, 187, 193, 198, 205, 213, 219};
+    = {0,   104, 104, 112, 115, 118, 121, 124, 127, 130, 133, 136, 139, 142,
+       150, 158, 166, 169, 172, 175, 180, 185, 190, 198, 206, 214, 220};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -493,9 +493,9 @@ static const yytype_int8 yypact[]
    Performed when YYTABLE does not specify something else to do.  Zero
    means the default is an error.  */
 static const yytype_uint8 yydefact[]
-    = {0,  20, 22, 21, 0, 0,  0,  0, 2, 23, 0, 0, 18, 0, 19, 1,  0,
-       0,  0,  0,  0,  0, 0,  0,  0, 0, 0,  0, 0, 26, 0, 7,  17, 14,
-       16, 15, 13, 10, 9, 11, 12, 4, 3, 5,  6, 8, 24, 0, 25};
+    = {0,  19, 20, 22, 0, 0,  0,  0, 2, 21, 0, 0, 17, 0, 18, 1,  0,
+       0,  0,  0,  0,  0, 0,  0,  0, 0, 0,  0, 0, 26, 0, 23, 16, 13,
+       15, 14, 12, 9,  8, 10, 11, 4, 3, 5,  6, 7, 24, 0, 25};
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] = {-20, -20, -4, -20, -20};
@@ -540,7 +540,7 @@ static const yytype_uint8 yyr1[]
 
 /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] = {0, 2, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                    3, 3, 3, 3, 2, 2, 1, 1, 1, 1, 4, 3, 1};
+                                    3, 3, 3, 2, 2, 1, 1, 1, 1, 3, 4, 3, 1};
 
 #define yyerrok (yyerrstatus = 0)
 #define yyclearin (yychar = YYEMPTY)
@@ -1174,7 +1174,7 @@ yyreduce:
     YY_REDUCE_PRINT(yyn);
     switch (yyn) {
         case 2:
-#line 104 "parser.yy" /* yacc.c:1646  */
+#line 105 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
             p.res = (yyval.basic);
@@ -1183,7 +1183,7 @@ yyreduce:
         break;
 
         case 3:
-#line 112 "parser.yy" /* yacc.c:1646  */
+#line 113 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = add((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1191,7 +1191,7 @@ yyreduce:
         break;
 
         case 4:
-#line 115 "parser.yy" /* yacc.c:1646  */
+#line 116 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = sub((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1199,7 +1199,7 @@ yyreduce:
         break;
 
         case 5:
-#line 118 "parser.yy" /* yacc.c:1646  */
+#line 119 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = mul((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1207,7 +1207,7 @@ yyreduce:
         break;
 
         case 6:
-#line 121 "parser.yy" /* yacc.c:1646  */
+#line 122 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = div((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1215,156 +1215,156 @@ yyreduce:
         break;
 
         case 7:
-#line 126 "parser.yy" /* yacc.c:1646  */
-        {
-            auto tup = p.parse_implicit_mul((yyvsp[-2].string));
-            (yyval.basic) = mul(std::get<0>(tup),
-                                pow(std::get<1>(tup), (yyvsp[0].basic)));
-        }
-#line 1348 "parser.tab.cc" /* yacc.c:1646  */
-        break;
-
-        case 8:
-#line 132 "parser.yy" /* yacc.c:1646  */
+#line 125 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = pow((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1354 "parser.tab.cc" /* yacc.c:1646  */
+#line 1345 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 9:
-#line 135 "parser.yy" /* yacc.c:1646  */
+        case 8:
+#line 128 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Lt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1360 "parser.tab.cc" /* yacc.c:1646  */
+#line 1351 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 10:
-#line 138 "parser.yy" /* yacc.c:1646  */
+        case 9:
+#line 131 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Gt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1366 "parser.tab.cc" /* yacc.c:1646  */
+#line 1357 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 11:
-#line 141 "parser.yy" /* yacc.c:1646  */
+        case 10:
+#line 134 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Le((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1372 "parser.tab.cc" /* yacc.c:1646  */
+#line 1363 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 12:
-#line 144 "parser.yy" /* yacc.c:1646  */
+        case 11:
+#line 137 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Ge((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1378 "parser.tab.cc" /* yacc.c:1646  */
+#line 1369 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 13:
-#line 147 "parser.yy" /* yacc.c:1646  */
+        case 12:
+#line 140 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Eq((yyvsp[-2].basic), (yyvsp[0].basic));
         }
-#line 1384 "parser.tab.cc" /* yacc.c:1646  */
+#line 1375 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 14:
-#line 150 "parser.yy" /* yacc.c:1646  */
+        case 13:
+#line 143 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_or(s);
         }
-#line 1395 "parser.tab.cc" /* yacc.c:1646  */
+#line 1386 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 15:
-#line 158 "parser.yy" /* yacc.c:1646  */
+        case 14:
+#line 151 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_and(s);
         }
-#line 1406 "parser.tab.cc" /* yacc.c:1646  */
+#line 1397 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 16:
-#line 166 "parser.yy" /* yacc.c:1646  */
+        case 15:
+#line 159 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
             (yyval.basic) = logical_xor(s);
         }
-#line 1417 "parser.tab.cc" /* yacc.c:1646  */
+#line 1408 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 17:
-#line 174 "parser.yy" /* yacc.c:1646  */
+        case 16:
+#line 167 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
-#line 1423 "parser.tab.cc" /* yacc.c:1646  */
+#line 1414 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 18:
-#line 177 "parser.yy" /* yacc.c:1646  */
+        case 17:
+#line 170 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
-#line 1429 "parser.tab.cc" /* yacc.c:1646  */
+#line 1420 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 19:
-#line 180 "parser.yy" /* yacc.c:1646  */
+        case 18:
+#line 173 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
         }
-#line 1435 "parser.tab.cc" /* yacc.c:1646  */
+#line 1426 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-        case 20:
-#line 183 "parser.yy" /* yacc.c:1646  */
+        case 19:
+#line 176 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
-#line 1443 "parser.tab.cc" /* yacc.c:1646  */
+#line 1434 "parser.tab.cc" /* yacc.c:1646  */
+        break;
+
+        case 20:
+#line 181 "parser.yy" /* yacc.c:1646  */
+        {
+            (yyval.basic) = p.parse_numeric((yyvsp[0].string));
+        }
+#line 1442 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 21:
-#line 188 "parser.yy" /* yacc.c:1646  */
+#line 186 "parser.yy" /* yacc.c:1646  */
+        {
+            (yyval.basic) = (yyvsp[0].basic);
+        }
+#line 1450 "parser.tab.cc" /* yacc.c:1646  */
+        break;
+
+        case 22:
+#line 191 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[0].string));
             (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
         }
-#line 1452 "parser.tab.cc" /* yacc.c:1646  */
-        break;
-
-        case 22:
-#line 194 "parser.yy" /* yacc.c:1646  */
-        {
-            (yyval.basic) = p.parse_numeric((yyvsp[0].string));
-        }
-#line 1460 "parser.tab.cc" /* yacc.c:1646  */
+#line 1459 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 23:
 #line 199 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = (yyvsp[0].basic);
+            auto tup = p.parse_implicit_mul((yyvsp[-2].string));
+            (yyval.basic) = mul(std::get<0>(tup),
+                                pow(std::get<1>(tup), (yyvsp[0].basic)));
         }
 #line 1468 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 24:
-#line 206 "parser.yy" /* yacc.c:1646  */
+#line 207 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
@@ -1373,7 +1373,7 @@ yyreduce:
         break;
 
         case 25:
-#line 214 "parser.yy" /* yacc.c:1646  */
+#line 215 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec)
                 = (yyvsp[-2].basic_vec); // TODO : should make copy?
@@ -1383,7 +1383,7 @@ yyreduce:
         break;
 
         case 26:
-#line 220 "parser.yy" /* yacc.c:1646  */
+#line 221 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -1235,8 +1235,7 @@ yyreduce:
         case 9:
 #line 136 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = rcp_static_cast<const Basic>(
-                Lt((yyvsp[-2].basic), (yyvsp[0].basic)));
+            (yyval.basic) = Lt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
 #line 1360 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1244,8 +1243,7 @@ yyreduce:
         case 10:
 #line 139 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = rcp_static_cast<const Basic>(
-                Gt((yyvsp[-2].basic), (yyvsp[0].basic)));
+            (yyval.basic) = Gt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
 #line 1366 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1253,8 +1251,7 @@ yyreduce:
         case 11:
 #line 142 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = rcp_static_cast<const Basic>(
-                Le((yyvsp[-2].basic), (yyvsp[0].basic)));
+            (yyval.basic) = Le((yyvsp[-2].basic), (yyvsp[0].basic));
         }
 #line 1372 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1262,8 +1259,7 @@ yyreduce:
         case 12:
 #line 145 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = rcp_static_cast<const Basic>(
-                Ge((yyvsp[-2].basic), (yyvsp[0].basic)));
+            (yyval.basic) = Ge((yyvsp[-2].basic), (yyvsp[0].basic));
         }
 #line 1378 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1271,8 +1267,7 @@ yyreduce:
         case 13:
 #line 148 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = rcp_static_cast<const Basic>(
-                Eq((yyvsp[-2].basic), (yyvsp[0].basic)));
+            (yyval.basic) = Eq((yyvsp[-2].basic), (yyvsp[0].basic));
         }
 #line 1384 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1283,7 +1278,7 @@ yyreduce:
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
-            (yyval.basic) = rcp_static_cast<const Basic>(logical_or(s));
+            (yyval.basic) = logical_or(s);
         }
 #line 1395 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1294,7 +1289,7 @@ yyreduce:
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.insert(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
-            (yyval.basic) = rcp_static_cast<const Basic>(logical_and(s));
+            (yyval.basic) = logical_and(s);
         }
 #line 1406 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1305,7 +1300,7 @@ yyreduce:
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
-            (yyval.basic) = rcp_static_cast<const Basic>(logical_xor(s));
+            (yyval.basic) = logical_xor(s);
         }
 #line 1417 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1329,8 +1324,8 @@ yyreduce:
         case 19:
 #line 181 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = rcp_static_cast<const Basic>(
-                logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic))));
+            (yyval.basic)
+                = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
         }
 #line 1435 "parser.tab.cc" /* yacc.c:1646  */
         break;
@@ -1338,7 +1333,7 @@ yyreduce:
         case 20:
 #line 184 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = rcp_static_cast<const Basic>((yyvsp[0].basic));
+            (yyval.basic) = (yyvsp[0].basic);
         }
 #line 1441 "parser.tab.cc" /* yacc.c:1646  */
         break;

--- a/symengine/parser/parser.tab.cc
+++ b/symengine/parser/parser.tab.cc
@@ -407,18 +407,18 @@ union yyalloc {
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL 15
+#define YYFINAL 14
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST 143
+#define YYLAST 142
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS 25
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS 5
+#define YYNNTS 4
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES 26
+#define YYNRULES 25
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES 49
+#define YYNSTATES 48
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
@@ -448,8 +448,8 @@ static const yytype_uint8 yytranslate[]
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[]
-    = {0,   104, 104, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118,
-       124, 130, 136, 137, 138, 139, 140, 141, 142, 146, 153, 157, 161};
+    = {0,   103, 103, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
+       117, 123, 129, 135, 136, 137, 138, 139, 140, 141, 145, 152, 153};
 #endif
 
 #if YYDEBUG || YYERROR_VERBOSE || 0
@@ -461,8 +461,7 @@ static const char *const yytname[]
        "'>'",          "'<'",     "LE",         "GE",         "'-'",
        "'+'",          "'*'",     "'/'",        "UMINUS",     "POW",
        "NOT",          "'('",     "')'",        "'~'",        "','",
-       "$accept",      "st_expr", "expr",       "func",       "expr_list",
-       YY_NULLPTR};
+       "$accept",      "st_expr", "expr",       "expr_list",  YY_NULLPTR};
 #endif
 
 #ifdef YYPRINT
@@ -473,9 +472,9 @@ static const yytype_uint16 yytoknum[]
        263, 45,  43,  42,  47,  264, 265, 266, 40, 41,  126, 44};
 #endif
 
-#define YYPACT_NINF -20
+#define YYPACT_NINF -19
 
-#define yypact_value_is_default(Yystate) (!!((Yystate) == (-20)))
+#define yypact_value_is_default(Yystate) (!!((Yystate) == (-19)))
 
 #define YYTABLE_NINF -1
 
@@ -484,63 +483,62 @@ static const yytype_uint16 yytoknum[]
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
 static const yytype_int8 yypact[]
-    = {23,  -17, -20, -9, 23,  23, 23,  25,  58, -20, 23, 23,  20,
-       41,  -20, -20, 23, 23,  23, 23,  23,  23, 23,  23, 23,  23,
-       23,  23,  23,  58, -19, 20, -20, 71,  83, 94,  19, 103, 111,
-       118, 124, -8,  -8, 20,  20, 20,  -20, 23, 58};
+    = {22, -18, -19, -15, 22,  22,  22,  9,   57, 22, 22, 5,  40, -19, -19, 22,
+       22, 22,  22,  22,  22,  22,  22,  22,  22, 22, 22, 22, 57, 16,  5,   -19,
+       70, 82,  93,  18,  102, 110, 117, 123, -9, -9, 5,  5,  5,  -19, 22,  57};
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
    Performed when YYTABLE does not specify something else to do.  Zero
    means the default is an error.  */
 static const yytype_uint8 yydefact[]
-    = {0,  19, 20, 22, 0, 0,  0,  0, 2, 21, 0, 0, 17, 0, 18, 1,  0,
-       0,  0,  0,  0,  0, 0,  0,  0, 0, 0,  0, 0, 26, 0, 23, 16, 13,
-       15, 14, 12, 9,  8, 10, 11, 4, 3, 5,  6, 7, 24, 0, 25};
+    = {0,  19, 20, 22, 0, 0, 0,  0,  2, 0, 0, 17, 0,  18, 1,  0,
+       0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0, 0,  25, 0,  23, 16,
+       13, 15, 14, 12, 9, 8, 10, 11, 4, 3, 5, 6,  7,  21, 0,  24};
 
 /* YYPGOTO[NTERM-NUM].  */
-static const yytype_int8 yypgoto[] = {-20, -20, -4, -20, -20};
+static const yytype_int8 yypgoto[] = {-19, -19, -4, -19};
 
 /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] = {-1, 7, 8, 9, 30};
+static const yytype_int8 yydefgoto[] = {-1, 7, 8, 29};
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
    positive, shift that token.  If negative, reduce the rule whose
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[]
-    = {12, 13, 14, 46, 10, 47, 29, 31, 26, 27, 11, 28, 33, 34, 35, 36, 37, 38,
-       39, 40, 41, 42, 43, 44, 45, 15, 1,  2,  3,  20, 21, 22, 23, 24, 25, 26,
-       27, 4,  28, 28, 0,  0,  0,  48, 5,  0,  6,  16, 17, 18, 19, 20, 21, 22,
-       23, 24, 25, 26, 27, 0,  28, 0,  0,  32, 16, 17, 18, 19, 20, 21, 22, 23,
-       24, 25, 26, 27, 0,  28, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 0,
-       28, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 0,  28, 19, 20, 21, 22, 23,
-       24, 25, 26, 27, 0,  28, 21, 22, 23, 24, 25, 26, 27, 0,  28, 22, 23, 24,
-       25, 26, 27, 0,  28, 23, 24, 25, 26, 27, 0,  28, 24, 25, 26, 27, 0,  28};
+    = {11, 12, 13, 9,  10, 28, 30, 25, 26, 14, 27, 32, 33, 34, 35, 36, 37, 38,
+       39, 40, 41, 42, 43, 44, 27, 1,  2,  3,  19, 20, 21, 22, 23, 24, 25, 26,
+       4,  27, 45, 0,  46, 0,  47, 5,  0,  6,  15, 16, 17, 18, 19, 20, 21, 22,
+       23, 24, 25, 26, 0,  27, 0,  0,  31, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+       24, 25, 26, 0,  27, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 0,  27,
+       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 0,  27, 18, 19, 20, 21, 22, 23,
+       24, 25, 26, 0,  27, 20, 21, 22, 23, 24, 25, 26, 0,  27, 21, 22, 23, 24,
+       25, 26, 0,  27, 22, 23, 24, 25, 26, 0,  27, 23, 24, 25, 26, 0,  27};
 
 static const yytype_int8 yycheck[]
-    = {4,  5,  6,  22, 21, 24, 10, 11, 16, 17, 19, 19, 16, 17, 18, 19, 20, 21,
-       22, 23, 24, 25, 26, 27, 28, 0,  3,  4,  5,  10, 11, 12, 13, 14, 15, 16,
-       17, 14, 19, 19, -1, -1, -1, 47, 21, -1, 23, 6,  7,  8,  9,  10, 11, 12,
-       13, 14, 15, 16, 17, -1, 19, -1, -1, 22, 6,  7,  8,  9,  10, 11, 12, 13,
-       14, 15, 16, 17, -1, 19, 7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, -1,
-       19, 8,  9,  10, 11, 12, 13, 14, 15, 16, 17, -1, 19, 9,  10, 11, 12, 13,
-       14, 15, 16, 17, -1, 19, 11, 12, 13, 14, 15, 16, 17, -1, 19, 12, 13, 14,
-       15, 16, 17, -1, 19, 13, 14, 15, 16, 17, -1, 19, 14, 15, 16, 17, -1, 19};
+    = {4,  5,  6,  21, 19, 9,  10, 16, 17, 0,  19, 15, 16, 17, 18, 19, 20, 21,
+       22, 23, 24, 25, 26, 27, 19, 3,  4,  5,  10, 11, 12, 13, 14, 15, 16, 17,
+       14, 19, 22, -1, 24, -1, 46, 21, -1, 23, 6,  7,  8,  9,  10, 11, 12, 13,
+       14, 15, 16, 17, -1, 19, -1, -1, 22, 6,  7,  8,  9,  10, 11, 12, 13, 14,
+       15, 16, 17, -1, 19, 7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, -1, 19,
+       8,  9,  10, 11, 12, 13, 14, 15, 16, 17, -1, 19, 9,  10, 11, 12, 13, 14,
+       15, 16, 17, -1, 19, 11, 12, 13, 14, 15, 16, 17, -1, 19, 12, 13, 14, 15,
+       16, 17, -1, 19, 13, 14, 15, 16, 17, -1, 19, 14, 15, 16, 17, -1, 19};
 
 /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
    symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[]
-    = {0,  3,  4,  5,  14, 21, 23, 26, 27, 28, 21, 19, 27, 27, 27, 0,  6,
-       7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 19, 27, 29, 27, 22, 27,
-       27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 22, 24, 27};
+    = {0,  3,  4,  5,  14, 21, 23, 26, 27, 21, 19, 27, 27, 27, 0,  6,
+       7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 19, 27, 28, 27, 22,
+       27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 22, 24, 27};
 
 /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[]
-    = {0,  25, 26, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27,
-       27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28, 29, 29};
+    = {0,  25, 26, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27,
+       27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28, 28};
 
 /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] = {0, 2, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                    3, 3, 3, 2, 2, 1, 1, 1, 1, 3, 4, 3, 1};
+static const yytype_uint8 yyr2[] = {0, 2, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                    3, 3, 3, 3, 2, 2, 1, 1, 4, 1, 3, 3, 1};
 
 #define yyerrok (yyerrstatus = 0)
 #define yyclearin (yychar = YYEMPTY)
@@ -1174,7 +1172,7 @@ yyreduce:
     YY_REDUCE_PRINT(yyn);
     switch (yyn) {
         case 2:
-#line 104 "parser.yy" /* yacc.c:1646  */
+#line 103 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[0].basic);
             p.res = (yyval.basic);
@@ -1183,7 +1181,7 @@ yyreduce:
         break;
 
         case 3:
-#line 108 "parser.yy" /* yacc.c:1646  */
+#line 107 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = add((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1191,7 +1189,7 @@ yyreduce:
         break;
 
         case 4:
-#line 109 "parser.yy" /* yacc.c:1646  */
+#line 108 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = sub((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1199,7 +1197,7 @@ yyreduce:
         break;
 
         case 5:
-#line 110 "parser.yy" /* yacc.c:1646  */
+#line 109 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = mul((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1207,7 +1205,7 @@ yyreduce:
         break;
 
         case 6:
-#line 111 "parser.yy" /* yacc.c:1646  */
+#line 110 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = div((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1215,7 +1213,7 @@ yyreduce:
         break;
 
         case 7:
-#line 112 "parser.yy" /* yacc.c:1646  */
+#line 111 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = pow((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1223,7 +1221,7 @@ yyreduce:
         break;
 
         case 8:
-#line 113 "parser.yy" /* yacc.c:1646  */
+#line 112 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Lt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1231,7 +1229,7 @@ yyreduce:
         break;
 
         case 9:
-#line 114 "parser.yy" /* yacc.c:1646  */
+#line 113 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Gt((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1239,7 +1237,7 @@ yyreduce:
         break;
 
         case 10:
-#line 115 "parser.yy" /* yacc.c:1646  */
+#line 114 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Le((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1247,7 +1245,7 @@ yyreduce:
         break;
 
         case 11:
-#line 116 "parser.yy" /* yacc.c:1646  */
+#line 115 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Ge((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1255,7 +1253,7 @@ yyreduce:
         break;
 
         case 12:
-#line 117 "parser.yy" /* yacc.c:1646  */
+#line 116 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = Eq((yyvsp[-2].basic), (yyvsp[0].basic));
         }
@@ -1263,7 +1261,7 @@ yyreduce:
         break;
 
         case 13:
-#line 118 "parser.yy" /* yacc.c:1646  */
+#line 117 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1274,7 +1272,7 @@ yyreduce:
         break;
 
         case 14:
-#line 124 "parser.yy" /* yacc.c:1646  */
+#line 123 "parser.yy" /* yacc.c:1646  */
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1285,7 +1283,7 @@ yyreduce:
         break;
 
         case 15:
-#line 130 "parser.yy" /* yacc.c:1646  */
+#line 129 "parser.yy" /* yacc.c:1646  */
         {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>((yyvsp[-2].basic)));
@@ -1296,7 +1294,7 @@ yyreduce:
         break;
 
         case 16:
-#line 136 "parser.yy" /* yacc.c:1646  */
+#line 135 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = (yyvsp[-1].basic);
         }
@@ -1304,7 +1302,7 @@ yyreduce:
         break;
 
         case 17:
-#line 137 "parser.yy" /* yacc.c:1646  */
+#line 136 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = neg((yyvsp[0].basic));
         }
@@ -1312,7 +1310,7 @@ yyreduce:
         break;
 
         case 18:
-#line 138 "parser.yy" /* yacc.c:1646  */
+#line 137 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic)
                 = logical_not(rcp_static_cast<const Boolean>((yyvsp[0].basic)));
@@ -1321,7 +1319,7 @@ yyreduce:
         break;
 
         case 19:
-#line 139 "parser.yy" /* yacc.c:1646  */
+#line 138 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_identifier((yyvsp[0].string));
         }
@@ -1329,7 +1327,7 @@ yyreduce:
         break;
 
         case 20:
-#line 140 "parser.yy" /* yacc.c:1646  */
+#line 139 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic) = p.parse_numeric((yyvsp[0].string));
         }
@@ -1337,15 +1335,16 @@ yyreduce:
         break;
 
         case 21:
-#line 141 "parser.yy" /* yacc.c:1646  */
+#line 140 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic) = (yyvsp[0].basic);
+            (yyval.basic)
+                = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
         }
 #line 1441 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 22:
-#line 142 "parser.yy" /* yacc.c:1646  */
+#line 141 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[0].string));
             (yyval.basic) = mul(std::get<0>(tup), std::get<1>(tup));
@@ -1354,7 +1353,7 @@ yyreduce:
         break;
 
         case 23:
-#line 146 "parser.yy" /* yacc.c:1646  */
+#line 145 "parser.yy" /* yacc.c:1646  */
         {
             auto tup = p.parse_implicit_mul((yyvsp[-2].string));
             (yyval.basic) = mul(std::get<0>(tup),
@@ -1364,33 +1363,23 @@ yyreduce:
         break;
 
         case 24:
-#line 153 "parser.yy" /* yacc.c:1646  */
+#line 152 "parser.yy" /* yacc.c:1646  */
         {
-            (yyval.basic)
-                = p.functionify((yyvsp[-3].string), (yyvsp[-1].basic_vec));
+            (yyval.basic_vec) = (yyvsp[-2].basic_vec);
+            (yyval.basic_vec).push_back((yyvsp[0].basic));
         }
 #line 1465 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
         case 25:
-#line 157 "parser.yy" /* yacc.c:1646  */
-        {
-            (yyval.basic_vec)
-                = (yyvsp[-2].basic_vec); // TODO : should make copy?
-            (yyval.basic_vec).push_back((yyvsp[0].basic));
-        }
-#line 1474 "parser.tab.cc" /* yacc.c:1646  */
-        break;
-
-        case 26:
-#line 161 "parser.yy" /* yacc.c:1646  */
+#line 153 "parser.yy" /* yacc.c:1646  */
         {
             (yyval.basic_vec) = vec_basic(1, (yyvsp[0].basic));
         }
-#line 1482 "parser.tab.cc" /* yacc.c:1646  */
+#line 1471 "parser.tab.cc" /* yacc.c:1646  */
         break;
 
-#line 1486 "parser.tab.cc" /* yacc.c:1646  */
+#line 1475 "parser.tab.cc" /* yacc.c:1646  */
         default:
             break;
     }

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -88,11 +88,10 @@ void yyerror(SymEngine::Parser &p, const std::string &msg)
 %left GE
 %left '-' '+'
 %left '*' '/'
-%right UMINUS
-%left IMPLICIT_MUL
+%precedence UMINUS
+%precedence IMPLICIT_MUL
 %right POW
-%right NOT
-%nonassoc '('
+%precedence NOT
 
 
 %start st_expr

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -149,11 +149,6 @@ expr
     ;
 
 expr_list
-    : expr_list ',' expr {
-            $$ = $1; // TODO : should make copy?
-            $$ .push_back($3);
-        }
-    | expr {
-            $$ = vec_basic(1, $1);
-        }
+    : expr_list ',' expr { $$ = $1; $$.push_back($3); }
+    | expr { $$ = vec_basic(1, $1); }
     ;

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -71,10 +71,12 @@ void yyerror(SymEngine::Parser &p, const std::string &msg)
 
 
 
+%token END_OF_FILE 0
 %token <string> IDENTIFIER
 %token <string> NUMERIC
 %token <string> IMPLICIT_MUL
-%token END_OF_FILE 0
+%type <basic> st_expr expr
+%type <basic_vec> expr_list
 
 %left '|'
 %left '^'
@@ -92,9 +94,6 @@ void yyerror(SymEngine::Parser &p, const std::string &msg)
 %right NOT
 %nonassoc '('
 
-%type <basic> st_expr
-%type <basic> expr
-%type <basic_vec> expr_list
 
 %start st_expr
 

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -133,26 +133,26 @@ expr:
         { $$ = pow($1, $3); }
 |
         expr '<' expr
-        { $$ = rcp_static_cast<const Basic>(Lt($1, $3)); }
+        { $$ = Lt($1, $3); }
 |
         expr '>' expr
-        { $$ = rcp_static_cast<const Basic>(Gt($1, $3)); }
+        { $$ = Gt($1, $3); }
 |
         expr LE expr
-        { $$ = rcp_static_cast<const Basic>(Le($1, $3)); }
+        { $$ = Le($1, $3); }
 |
         expr GE expr
-        { $$ = rcp_static_cast<const Basic>(Ge($1, $3)); }
+        { $$ = Ge($1, $3); }
 |
         expr EQ expr
-        { $$ = rcp_static_cast<const Basic>(Eq($1, $3)); }
+        { $$ = Eq($1, $3); }
 |
         expr '|' expr
         {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>($1));
             s.insert(rcp_static_cast<const Boolean>($3));
-            $$ = rcp_static_cast<const Basic>(logical_or(s));
+            $$ = logical_or(s);
         }
 |
         expr '&' expr
@@ -160,7 +160,7 @@ expr:
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>($1));
             s.insert(rcp_static_cast<const Boolean>($3));
-            $$ = rcp_static_cast<const Basic>(logical_and(s));
+            $$ = logical_and(s);
         }
 |
         expr '^' expr
@@ -168,7 +168,7 @@ expr:
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>($1));
             s.push_back(rcp_static_cast<const Boolean>($3));
-            $$ = rcp_static_cast<const Basic>(logical_xor(s));
+            $$ = logical_xor(s);
         }
 |
         '(' expr ')'
@@ -178,10 +178,10 @@ expr:
         { $$ = neg($2); }
 |
         '~' expr %prec NOT
-        { $$ = rcp_static_cast<const Basic>(logical_not(rcp_static_cast<const Boolean>($2))); }
+        { $$ = logical_not(rcp_static_cast<const Boolean>($2)); }
 |
         leaf
-        { $$ = rcp_static_cast<const Basic>($1); }
+        { $$ = $1; }
 ;
 
 leaf:

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -72,9 +72,7 @@ void yyerror(SymEngine::Parser &p, const std::string &msg)
 
 
 %token END_OF_FILE 0
-%token <string> IDENTIFIER
-%token <string> NUMERIC
-%token <string> IMPLICIT_MUL
+%token <string> IDENTIFIER NUMERIC IMPLICIT_MUL
 %type <basic> st_expr expr
 %type <basic_vec> expr_list
 

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -126,11 +126,7 @@ expr:
         IMPLICIT_MUL POW expr
         {
           auto tup = p.parse_implicit_mul($1);
-          if (neq(*std::get<1>(tup), *one)) {
-            $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3));
-          } else {
-            $$ = pow(std::get<0>(tup), $3);
-          }
+          $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3));
         }
 |
         expr POW expr

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -87,6 +87,7 @@ void yyerror(SymEngine::Parser &p, const std::string &msg)
 %left '-' '+'
 %left '*' '/'
 %right UMINUS
+%left IMPLICIT_MUL
 %right POW
 %right NOT
 %nonassoc '('

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -100,125 +100,65 @@ void yyerror(SymEngine::Parser &p, const std::string &msg)
 %start st_expr
 
 %%
-st_expr :
-    expr
-    {
-        $$ = $1;
-        p.res = $$;
-    }
-;
+st_expr
+    : expr { $$ = $1; p.res = $$; }
+    ;
 
-expr:
-        expr '+' expr
-        { $$ = add($1, $3); }
-|
-        expr '-' expr
-        { $$ = sub($1, $3); }
-|
-        expr '*' expr
-        { $$ = mul($1, $3); }
-|
-        expr '/' expr
-        { $$ = div($1, $3); }
-|
-        expr POW expr
-        { $$ = pow($1, $3); }
-|
-        expr '<' expr
-        { $$ = Lt($1, $3); }
-|
-        expr '>' expr
-        { $$ = Gt($1, $3); }
-|
-        expr LE expr
-        { $$ = Le($1, $3); }
-|
-        expr GE expr
-        { $$ = Ge($1, $3); }
-|
-        expr EQ expr
-        { $$ = Eq($1, $3); }
-|
-        expr '|' expr
-        {
+expr
+    : expr '+' expr { $$ = add($1, $3); }
+    | expr '-' expr { $$ = sub($1, $3); }
+    | expr '*' expr { $$ = mul($1, $3); }
+    | expr '/' expr { $$ = div($1, $3); }
+    | expr POW expr { $$ = pow($1, $3); }
+    | expr '<' expr { $$ = Lt($1, $3); }
+    | expr '>' expr { $$ = Gt($1, $3); }
+    | expr LE expr { $$ = Le($1, $3); }
+    | expr GE expr { $$ = Ge($1, $3); }
+    | expr EQ expr { $$ = Eq($1, $3); }
+    | expr '|' expr {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>($1));
             s.insert(rcp_static_cast<const Boolean>($3));
             $$ = logical_or(s);
         }
-|
-        expr '&' expr
-        {
+    | expr '&' expr {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>($1));
             s.insert(rcp_static_cast<const Boolean>($3));
             $$ = logical_and(s);
         }
-|
-        expr '^' expr
-        {
+    | expr '^' expr {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>($1));
             s.push_back(rcp_static_cast<const Boolean>($3));
             $$ = logical_xor(s);
         }
-|
-        '(' expr ')'
-        { $$ = $2; }
-|
-        '-' expr %prec UMINUS
-        { $$ = neg($2); }
-|
-        '~' expr %prec NOT
-        { $$ = logical_not(rcp_static_cast<const Boolean>($2)); }
-|
-    IDENTIFIER
-    {
-        $$ = p.parse_identifier($1);
-    }
-|
-    NUMERIC
-    {
-        $$ = p.parse_numeric($1);
-    }
-|
-    func
-    {
-        $$ = $1;
-    }
-|
-    IMPLICIT_MUL
-    {
-        auto tup = p.parse_implicit_mul($1);
-        $$ = mul(std::get<0>(tup), std::get<1>(tup));
-    }
-|
-// FIXME: This rule generates:
-// parser.yy: warning: 1 shift/reduce conflict [-Wconflicts-sr]
-        IMPLICIT_MUL POW expr
-        {
-          auto tup = p.parse_implicit_mul($1);
-          $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3));
+    | '(' expr ')' { $$ = $2; }
+    | '-' expr %prec UMINUS { $$ = neg($2); }
+    | '~' expr %prec NOT {$$ = logical_not(rcp_static_cast<const Boolean>($2));}
+    | IDENTIFIER { $$ = p.parse_identifier($1); }
+    | NUMERIC { $$ = p.parse_numeric($1); }
+    | func { $$ = $1; }
+    | IMPLICIT_MUL {
+            auto tup = p.parse_implicit_mul($1);
+            $$ = mul(std::get<0>(tup), std::get<1>(tup));
         }
-;
+    | IMPLICIT_MUL POW expr {
+            auto tup = p.parse_implicit_mul($1);
+            $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3));
+        }
+    ;
 
-func:
-    IDENTIFIER '(' expr_list ')'
-    {
-        $$ = p.functionify($1, $3);
-    }
-;
+func
+    : IDENTIFIER '(' expr_list ')' { $$ = p.functionify($1, $3); }
+    ;
 
-expr_list:
-
-    expr_list ',' expr
-    {
-        $$ = $1; // TODO : should make copy?
-        $$ .push_back($3);
-    }
-|
-    expr
-    {
-        $$ = vec_basic(1, $1);
-    }
-;
+expr_list
+    : expr_list ',' expr {
+            $$ = $1; // TODO : should make copy?
+            $$ .push_back($3);
+        }
+    | expr {
+            $$ = vec_basic(1, $1);
+        }
+    ;

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -95,7 +95,6 @@ void yyerror(SymEngine::Parser &p, const std::string &msg)
 %type <basic> st_expr
 %type <basic> expr
 %type <basic_vec> expr_list
-%type <basic> func
 
 %start st_expr
 
@@ -138,7 +137,7 @@ expr
     | '~' expr %prec NOT {$$ = logical_not(rcp_static_cast<const Boolean>($2));}
     | IDENTIFIER { $$ = p.parse_identifier($1); }
     | NUMERIC { $$ = p.parse_numeric($1); }
-    | func { $$ = $1; }
+    | IDENTIFIER '(' expr_list ')' { $$ = p.functionify($1, $3); }
     | IMPLICIT_MUL {
             auto tup = p.parse_implicit_mul($1);
             $$ = mul(std::get<0>(tup), std::get<1>(tup));
@@ -147,10 +146,6 @@ expr
             auto tup = p.parse_implicit_mul($1);
             $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3));
         }
-    ;
-
-func
-    : IDENTIFIER '(' expr_list ')' { $$ = p.functionify($1, $3); }
     ;
 
 expr_list

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -117,34 +117,30 @@ expr
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>($1));
             s.insert(rcp_static_cast<const Boolean>($3));
-            $$ = logical_or(s);
-        }
+            $$ = logical_or(s); }
     | expr '&' expr {
             set_boolean s;
             s.insert(rcp_static_cast<const Boolean>($1));
             s.insert(rcp_static_cast<const Boolean>($3));
-            $$ = logical_and(s);
-        }
+            $$ = logical_and(s); }
     | expr '^' expr {
             vec_boolean s;
             s.push_back(rcp_static_cast<const Boolean>($1));
             s.push_back(rcp_static_cast<const Boolean>($3));
-            $$ = logical_xor(s);
-        }
+            $$ = logical_xor(s); }
     | '(' expr ')' { $$ = $2; }
     | '-' expr %prec UMINUS { $$ = neg($2); }
-    | '~' expr %prec NOT {$$ = logical_not(rcp_static_cast<const Boolean>($2));}
+    | '~' expr %prec NOT {
+            $$ = logical_not(rcp_static_cast<const Boolean>($2)); }
     | IDENTIFIER { $$ = p.parse_identifier($1); }
     | NUMERIC { $$ = p.parse_numeric($1); }
     | IDENTIFIER '(' expr_list ')' { $$ = p.functionify($1, $3); }
     | IMPLICIT_MUL {
             auto tup = p.parse_implicit_mul($1);
-            $$ = mul(std::get<0>(tup), std::get<1>(tup));
-        }
+            $$ = mul(std::get<0>(tup), std::get<1>(tup)); }
     | IMPLICIT_MUL POW expr {
             auto tup = p.parse_implicit_mul($1);
-            $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3));
-        }
+            $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3)); }
     ;
 
 expr_list

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -120,14 +120,6 @@ expr:
         expr '/' expr
         { $$ = div($1, $3); }
 |
-// FIXME: This rule generates:
-// parser.yy: warning: 1 shift/reduce conflict [-Wconflicts-sr]
-        IMPLICIT_MUL POW expr
-        {
-          auto tup = p.parse_implicit_mul($1);
-          $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3));
-        }
-|
         expr POW expr
         { $$ = pow($1, $3); }
 |
@@ -184,12 +176,6 @@ expr:
         $$ = p.parse_identifier($1);
     }
 |
-    IMPLICIT_MUL
-    {
-        auto tup = p.parse_implicit_mul($1);
-        $$ = mul(std::get<0>(tup), std::get<1>(tup));
-    }
-|
     NUMERIC
     {
         $$ = p.parse_numeric($1);
@@ -199,6 +185,20 @@ expr:
     {
         $$ = $1;
     }
+|
+    IMPLICIT_MUL
+    {
+        auto tup = p.parse_implicit_mul($1);
+        $$ = mul(std::get<0>(tup), std::get<1>(tup));
+    }
+|
+// FIXME: This rule generates:
+// parser.yy: warning: 1 shift/reduce conflict [-Wconflicts-sr]
+        IMPLICIT_MUL POW expr
+        {
+          auto tup = p.parse_implicit_mul($1);
+          $$ = mul(std::get<0>(tup), pow(std::get<1>(tup), $3));
+        }
 ;
 
 func:

--- a/symengine/parser/parser.yy
+++ b/symengine/parser/parser.yy
@@ -94,7 +94,6 @@ void yyerror(SymEngine::Parser &p, const std::string &msg)
 %type <basic> st_expr
 %type <basic> expr
 %type <basic_vec> expr_list
-%type <basic> leaf
 %type <basic> func
 
 %start st_expr
@@ -180,11 +179,6 @@ expr:
         '~' expr %prec NOT
         { $$ = logical_not(rcp_static_cast<const Boolean>($2)); }
 |
-        leaf
-        { $$ = $1; }
-;
-
-leaf:
     IDENTIFIER
     {
         $$ = p.parse_identifier($1);


### PR DESCRIPTION
Several simplifications were done:

* `parse_implicit_mul()` cannot return an error, added an assert and simplified the `parser.yy`
* `parser.yy`: merged all the rules that could be merged; changed syntax that makes it more readable; `rcp_static_cast` casts were removed as they are not needed
* There is a slight speedup due to the simplified grammar:
```
$ ./benchmarks/parsing 
parse('0') = 0: 25us
33ms
(x + y - sin(x)/(-4 + z**2) - x**(y**z))**5001
83ms
(x + y - sin(x)/(-4 + z**2) - x**(y**z))**5001
19ms
101ms
```