### PR TITLE
Use opt_level in code generation

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -65,15 +65,17 @@ llvm::Value *LLVMVisitor::apply(const Basic &b)
 }
 
 void LLVMVisitor::init(const vec_basic &x, const Basic &b, bool symbolic_cse,
-                       int opt_level)
+                       unsigned opt_level)
 {
-    init(x, b, symbolic_cse, LLVMVisitor::create_default_passes(opt_level));
+    init(x, b, symbolic_cse, LLVMVisitor::create_default_passes(opt_level),
+         opt_level);
 }
 
 void LLVMVisitor::init(const vec_basic &x, const Basic &b, bool symbolic_cse,
-                       const std::vector<llvm::Pass *> &passes)
+                       const std::vector<llvm::Pass *> &passes,
+                       unsigned opt_level)
 {
-    init(x, {b.rcp_from_this()}, symbolic_cse, passes);
+    init(x, {b.rcp_from_this()}, symbolic_cse, passes, opt_level);
 }
 
 llvm::Function *LLVMVisitor::get_function_type(llvm::LLVMContext *context)
@@ -169,15 +171,16 @@ std::vector<llvm::Pass *> LLVMVisitor::create_default_passes(int optlevel)
 }
 
 void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
-                       const bool symbolic_cse, int opt_level)
+                       const bool symbolic_cse, unsigned opt_level)
 {
     init(inputs, outputs, symbolic_cse,
-         LLVMVisitor::create_default_passes(opt_level));
+         LLVMVisitor::create_default_passes(opt_level), opt_level);
 }
 
 void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
                        const bool symbolic_cse,
-                       const std::vector<llvm::Pass *> &passes)
+                       const std::vector<llvm::Pass *> &passes,
+                       unsigned opt_level)
 {
     executionengine.reset();
     llvm::InitializeNativeTarget();
@@ -291,7 +294,7 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
     executionengine = std::shared_ptr<llvm::ExecutionEngine>(
         llvm::EngineBuilder(std::move(module))
             .setEngineKind(llvm::EngineKind::Kind::JIT)
-            .setOptLevel(llvm::CodeGenOpt::Level::Aggressive)
+            .setOptLevel(static_cast<llvm::CodeGenOpt::Level>(opt_level))
             .setErrorStr(&error)
             .create());
 

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -52,13 +52,14 @@ protected:
 public:
     llvm::Value *apply(const Basic &b);
     void init(const vec_basic &x, const Basic &b,
-              const bool symbolic_cse = false, int opt_level = 2);
+              const bool symbolic_cse = false, unsigned opt_level = 3);
     void init(const vec_basic &x, const Basic &b, const bool symbolic_cse,
-              const std::vector<llvm::Pass *> &passes);
+              const std::vector<llvm::Pass *> &passes, unsigned opt_level = 3);
     void init(const vec_basic &inputs, const vec_basic &outputs,
-              const bool symbolic_cse = false, int opt_level = 2);
+              const bool symbolic_cse = false, unsigned opt_level = 3);
     void init(const vec_basic &inputs, const vec_basic &outputs,
-              const bool symbolic_cse, const std::vector<llvm::Pass *> &passes);
+              const bool symbolic_cse, const std::vector<llvm::Pass *> &passes,
+              unsigned opt_level = 3);
 
     static std::vector<llvm::Pass *> create_default_passes(int optlevel);
 


### PR DESCRIPTION
@isuruf  Sorry, if you're just busy, but please merge this branch of yours. :)
Only this makes `LLVMDouble` with `opt_level=0` compile faster than `opt_level=3`.