### PR TITLE
add support for LLVM 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,13 @@ endif()
 
 # Enable C++11 support in all compilers. SymEngine will not compile unless
 # the C++11 support is enabled.
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|Intel")
-    set(CXX11_OPTIONS "-std=c++11")
+set(WITH_CPP14 no CACHE BOOL "Build with C++14 support")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|Intel")
+    if(WITH_CPP14)
+        set(CXX11_OPTIONS "-std=c++14")
+    else()
+        set(CXX11_OPTIONS "-std=c++11")
+    endif()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
     # pgcpp
     set(CXX11_OPTIONS "--gnu --c++11 -D__GXX_EXPERIMENTAL_CXX0X__")

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -54,6 +54,12 @@
 namespace SymEngine
 {
 
+#if (LLVM_VERSION_MAJOR >= 10)
+using std::make_unique;
+#else
+using llvm::make_unique;
+#endif
+
 class IRBuilder : public llvm::IRBuilder<>
 {
 };
@@ -191,7 +197,7 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
 
     // Create some module to put our function into it.
     std::unique_ptr<llvm::Module> module
-        = llvm::make_unique<llvm::Module>("SymEngine", *context.get());
+        = make_unique<llvm::Module>("SymEngine", *context.get());
     module->setDataLayout("");
     mod = module.get();
 
@@ -957,7 +963,7 @@ void LLVMVisitor::loads(const std::string &s)
 
     // Create some module to put our function into it.
     std::unique_ptr<llvm::Module> module
-        = llvm::make_unique<llvm::Module>("SymEngine", *context);
+        = make_unique<llvm::Module>("SymEngine", *context);
     module->setDataLayout("");
     mod = module.get();
 

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -18,6 +18,13 @@ class ExecutionEngine;
 class MemoryBufferRef;
 class LLVMContext;
 class Pass;
+#if (LLVM_VERSION_MAJOR >= 10)
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args &&... args)
+{
+    return std::make_unique<T>(std::forward<Args>(args)...);
+}
+#endif
 namespace legacy
 {
 class FunctionPassManager;

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -18,13 +18,6 @@ class ExecutionEngine;
 class MemoryBufferRef;
 class LLVMContext;
 class Pass;
-#if (LLVM_VERSION_MAJOR >= 10)
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args &&... args)
-{
-    return std::make_unique<T>(std::forward<Args>(args)...);
-}
-#endif
 namespace legacy
 {
 class FunctionPassManager;


### PR DESCRIPTION
  - requires c++14: add WITH_CPP14 option to CMake
  - llvm::make_unique has been removed: alias it to std::make_unique