### PR TITLE
A negative base raised to a rational exponent should not produce a co…

### DIFF
--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -82,6 +82,11 @@ public:
     {
         return false;
     }
+    //! \return `true` if even
+    inline virtual bool is_even() const
+    {
+        return this->i % 2 == 0;
+    }
 
     /* These are very fast methods for add/sub/mul/div/pow on Integers only */
     //! Fast Integer Addition

--- a/symengine/real_double.h
+++ b/symengine/real_double.h
@@ -382,6 +382,11 @@ public:
     RCP<const Number> powreal(const Rational &other) const
     {
         if (i < 0) {
+            if (!other.get_den().get()->is_even()) {
+                double k = other.get_num().get()->is_even() ? 1.0 : -1.0;
+                return make_rcp<const RealDouble>(
+                    k * std::pow(-i, mp_get_d(other.as_rational_class())));
+            }
             return number(std::pow(std::complex<double>(i),
                                    mp_get_d(other.as_rational_class())));
         }


### PR DESCRIPTION
…mplex number if the denominator of the exponent is odd; the result should be real.

For example -8 ^ (1/3) should return -2, not a complex number

Added is_even() method to Integer to help accomplish this