### PR TITLE
Document cmake options for cotire & c++14

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ their default values indicated below:
     cmake -DCMAKE_INSTALL_PREFIX:PATH="/usr/local" \  # Installation prefix
         -DCMAKE_BUILD_TYPE:STRING="Release" \         # Type of build, one of: Debug or Release
         -DWITH_BFD:BOOL=OFF \                         # Install with BFD library (requires binutils-dev)s
+        -DWITH_COTIRE=ON \                            # Use Cotire for precompiled headers
+        -DWITH_CPP14=OFF \                            # Enable C++14 during compilation
         -DWITH_SYMENGINE_ASSERT:BOOL=OFF \            # Test all SYMENGINE_ASSERT statements in the code
         -DWITH_SYMENGINE_RCP:BOOL=ON \                # Use our faster special implementation of RCP
         -DWITH_SYMENGINE_THREAD_SAFE:BOOL=OFF \       # Build with thread safety


### PR DESCRIPTION
I've recently started moving towards using Ubuntu 20.04. New versions of cmake, compilers, etc. meant that I needed to disable cotire and enable c++14 to make symengine work. I haven't narrowed down exactly what's changed to cause this, however, I found that both these options were not documented in the README so I thought we might add them?