### PR TITLE
Parse atan2

### DIFF
--- a/symengine/parser/parser.cpp
+++ b/symengine/parser/parser.cpp
@@ -99,10 +99,14 @@ RCP<const Basic> Parser::functionify(const std::string &name, vec_basic &params)
                               const RCP<const Basic> &,
                               const RCP<const Basic> &)>>
         double_arg_functions = {
-            {"pow", (double_arg_func)pow}, {"beta", beta},
-            {"log", double_casted_log},    {"zeta", double_casted_zeta},
-            {"lowergamma", lowergamma},    {"uppergamma", uppergamma},
-            {"polygamma", polygamma},      {"kronecker_delta", kronecker_delta},
+            {"pow", (double_arg_func)pow},
+            {"beta", beta},
+            {"log", double_casted_log},
+            {"zeta", double_casted_zeta},
+            {"lowergamma", lowergamma},
+            {"uppergamma", uppergamma},
+            {"polygamma", polygamma},
+            {"kronecker_delta", kronecker_delta},
             {"atan2", atan2},
         };
 

--- a/symengine/parser/parser.cpp
+++ b/symengine/parser/parser.cpp
@@ -103,6 +103,7 @@ RCP<const Basic> Parser::functionify(const std::string &name, vec_basic &params)
             {"log", double_casted_log},    {"zeta", double_casted_zeta},
             {"lowergamma", lowergamma},    {"uppergamma", uppergamma},
             {"polygamma", polygamma},      {"kronecker_delta", kronecker_delta},
+            {"atan2", atan2},
         };
 
     const static std::map<const std::string,

--- a/symengine/tests/basic/test_parser.cpp
+++ b/symengine/tests/basic/test_parser.cpp
@@ -342,6 +342,10 @@ TEST_CASE("Parsing: functions", "[parser]")
     res = parse(s);
     REQUIRE(eq(*res, *sin(max({log(x, y), min({x, y})}))));
 
+    s = "atan2(x, y)";
+    res = parse(s);
+    REQUIRE(eq(*res, *atan2(x, y)));
+
     s = "Eq(x)";
     res = parse(s);
     CHECK(eq(*res, *Eq(x, integer(0))));


### PR DESCRIPTION
Found during usage that "atan2" was being parsed as a `FunctionSymbol` rather than `ATan2`. Reading from type_codes.inc, there are a few others that are missing (e.g. GaloisField, Conjugate, Floor, Ceiling, and sets/Boolean operations) - not sure which of these would be desirable to include in the parser.