### PR TITLE
Add INTERFACE_INCLUDE_DIRECTORIES to the exported CMake target

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -263,6 +263,7 @@ install(TARGETS symengine
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
 install(FILES
     "${symengine_BINARY_DIR}/symengine/symengine_config.h"


### PR DESCRIPTION
Currently, the exported CMake target `symengine` does not have `INTERFACE_INCLUDE_DIRECTORIES` set. So I have to do this in a demo project:
```cmake
find_package(SymEngine CONFIG REQUIRED)
add_executable(symengine_test symengine_test.cpp)
target_include_directories(symengine_test PRIVATE ${SYMENGINE_INCLUDE_DIR})
target_link_libraries(symengine_test PRIVATE symengine)
```

With this patch, the `target_include_directories(symengine_test PRIVATE ${SYMENGINE_INCLUDE_DIR})` is unnecessary any more:
```cmake
find_package(SymEngine CONFIG REQUIRED)
add_executable(symengine_test symengine_test.cpp)
target_link_libraries(symengine_test PRIVATE symengine)
```
