### PR TITLE
Avoid unnecessary copies in loops

### DIFF
--- a/symengine/ntheory.cpp
+++ b/symengine/ntheory.cpp
@@ -931,7 +931,7 @@ RCP<const Integer> carmichael(const RCP<const Integer> &n)
 
     prime_factor_multiplicities(prime_mul, *n);
     lambda = 1;
-    for (const auto it : prime_mul) {
+    for (const auto &it : prime_mul) {
         p = it.first->as_integer_class();
         multiplicity = it.second;
         if (p == 2
@@ -967,7 +967,7 @@ bool multiplicative_order(const Ptr<RCP<const Integer>> &o,
     _a %= _n;
     order = lambda->as_integer_class();
 
-    for (const auto it : prime_mul) {
+    for (const auto &it : prime_mul) {
         p = it.first->as_integer_class();
         mp_pow_ui(t, p, it.second);
         mp_divexact(order, order, t);

--- a/symengine/utilities/matchpycpp/many_to_one.h
+++ b/symengine/utilities/matchpycpp/many_to_one.h
@@ -120,7 +120,7 @@ public:
             pattern_ids.insert(subject_pattern_ids.begin(),
                                subject_pattern_ids.end());
         }
-        for (const pair<set<int>, tuple<int, multiset<int>, PatternSet>> &p :
+        for (const pair<const set<int>, tuple<int, multiset<int>, PatternSet>> &p :
              patterns) {
             int pattern_index = get<0>(p.second);
             multiset<int> pattern_set = get<1>(p.second);
@@ -209,7 +209,7 @@ public:
             };
              */
             vector<TEdgeValue> iterobjs;
-            for (const pair<tuple<int, int>, tuple<int, int>> &p3 : matching) {
+            for (const pair<const tuple<int, int>, tuple<int, int>> &p3 : matching) {
                 iterobjs.push_back(
                     bipartite.__getitem__(make_tuple(p3.first, p3.second)));
             }
@@ -219,7 +219,7 @@ public:
                     = substitution_union(substitution, substs);
 
                 multiset<int> matched_subjects;
-                for (const pair<tuple<int, int>, tuple<int, int>> &p3 :
+                for (const pair<const tuple<int, int>, tuple<int, int>> &p3 :
                      matching) {
                     int elem = get<0>(p3.first);
                     matched_subjects.insert(elem);
@@ -272,13 +272,13 @@ public:
 
     bool _is_canonical_matching(const Matching &matching)
     {
-        for (const pair<tuple<int, int>, tuple<int, int>> &pair1 : matching) {
+        for (const pair<const tuple<int, int>, tuple<int, int>> &pair1 : matching) {
             //.items():
             int s1 = get<0>(pair1.first);
             int n1 = get<1>(pair1.first);
             int p1 = get<0>(pair1.second);
             int m1 = get<1>(pair1.second);
-            for (const pair<tuple<int, int>, tuple<int, int>> &pair2 :
+            for (const pair<const tuple<int, int>, tuple<int, int>> &pair2 :
                  matching) {
                 int s2 = get<0>(pair2.first);
                 int n2 = get<1>(pair2.first);
@@ -306,7 +306,7 @@ public:
         int n = 0;
         int m = 0;
         map<int, int> p_states;
-        for (const pair<int, int> &p : count_multiset(subjects)) {
+        for (const pair<const int, int> &p : count_multiset(subjects)) {
             int subject = p.first;
             int s_count = p.second;
             auto elem = this->bipartite._graph_left.find(subject);

--- a/symengine/utilities/matchpycpp/substitution.h
+++ b/symengine/utilities/matchpycpp/substitution.h
@@ -48,7 +48,7 @@ substitution_union(const SubstitutionMultiset &subst,
 {
     SubstitutionMultiset new_subst = subst;
     for (const SubstitutionMultiset &other : others) {
-        for (const pair<string, multiset_basic> &p : other) {
+        for (const pair<const string, multiset_basic> &p : other) {
             int ret = try_add_variable(new_subst, p.first, p.second);
             assert(ret == 0);
         }

--- a/symengine/utilities/matchpycpp/utils.h
+++ b/symengine/utilities/matchpycpp/utils.h
@@ -97,7 +97,7 @@ _commutative_single_variable_partiton_iter(const multiset_basic &values,
         }
     } else {
         multiset_basic new_values;
-        for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
+        for (const pair<const RCP<const Basic>, int> &p : count_multiset(values)) {
             RCP<const Basic> element = p.first;
             int element_count = p.second;
             if (element_count % count != 0) {
@@ -160,7 +160,7 @@ generator<SubstitutionMultiset> commutative_sequence_variable_partition_iter(
     }
 
     vector<function<void(SubstitutionMultiset)>> generators;
-    for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
+    for (const pair<const RCP<const Basic>, int> &p : count_multiset(values)) {
         RCP<const Basic> value = p.first;
         int count = p.second;
         generators.push_back(


### PR DESCRIPTION
- add `const` or `&` as suggested in compiler warnings below to prevent unnecessary copies being made in loops
```
../symengine/ntheory.cpp:934:21: warning: loop variable 'it' of type 'const std::pair<const SymEngine::RCP<const SymEngine::Integer>, unsigned int>' creates a copy from type 'const std::pair<const SymEngine::RCP<const SymEngine::Integer>, unsigned int>' [-Wrange-loop-construct]
    for (const auto it : prime_mul) {
                    ^
../symengine/ntheory.cpp:934:10: note: use reference type 'const std::pair<const SymEngine::RCP<const SymEngine::Integer>, unsigned int> &' to prevent copying
    for (const auto it : prime_mul) {
         ^~~~~~~~~~~~~~~
                    &
../symengine/ntheory.cpp:970:21: warning: loop variable 'it' of type 'const std::pair<const SymEngine::RCP<const SymEngine::Integer>, unsigned int>' creates a copy from type 'const std::pair<const SymEngine::RCP<const SymEngine::Integer>, unsigned int>' [-Wrange-loop-construct]
    for (const auto it : prime_mul) {
                    ^
../symengine/ntheory.cpp:970:10: note: use reference type 'const std::pair<const SymEngine::RCP<const SymEngine::Integer>, unsigned int> &' to prevent copying
    for (const auto it : prime_mul) {
         ^~~~~~~~~~~~~~~
                    &
2 warnings generated.
[61/157] Building CXX object symengine/tests/basic/CMakeFiles/test_fields.dir/test_fields.cpp.o
../symengine/tests/basic/test_fields.cpp:204:8: warning: explicitly assigning value of variable of type 'SymEngine::GaloisFieldDict' to itself [-Wself-assign-overloaded]
    d2 -= d2;
    ~~ ^  ~~
../symengine/tests/basic/test_fields.cpp:208:8: warning: explicitly assigning value of variable of type 'SymEngine::GaloisFieldDict' to itself [-Wself-assign-overloaded]
    d2 /= d2;
    ~~ ^  ~~
../symengine/tests/basic/test_fields.cpp:211:8: warning: explicitly assigning value of variable of type 'SymEngine::GaloisFieldDict' to itself [-Wself-assign-overloaded]
    d2 %= d2;
    ~~ ^  ~~
3 warnings generated.
[95/157] Building CXX object symengine/utilities/matchpycpp/tests/bipartite/CMakeFiles/test_bipartite.dir/test_bipartite.cpp.o
In file included from ../symengine/utilities/matchpycpp/tests/bipartite/test_bipartite.cpp:2:
In file included from ../symengine/utilities/matchpycpp/bipartite.h:9:
In file included from ../symengine/utilities/matchpycpp/common.h:14:
../symengine/utilities/matchpycpp/substitution.h:51:50: warning: loop variable 'p' has type 'const pair<std::string, SymEngine::multiset_basic> &' (aka 'const pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> > &') but is initialized with type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<string, multiset_basic> &p : other) {
                                                 ^
../symengine/utilities/matchpycpp/substitution.h:51:14: note: use non-reference type 'pair<std::string, SymEngine::multiset_basic>' (aka 'pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> >') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > > &' to prevent copying
        for (const pair<string, multiset_basic> &p : other) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[96/157] Building CXX object symengine/utilities/matchpycpp/autogen_tests/CMakeFiles/test_case001.dir/test_case001.cpp.o
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case001.cpp:20:
In file included from ../symengine/utilities/matchpycpp/common.h:14:
../symengine/utilities/matchpycpp/substitution.h:51:50: warning: loop variable 'p' has type 'const pair<std::string, SymEngine::multiset_basic> &' (aka 'const pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> > &') but is initialized with type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<string, multiset_basic> &p : other) {
                                                 ^
../symengine/utilities/matchpycpp/substitution.h:51:14: note: use non-reference type 'pair<std::string, SymEngine::multiset_basic>' (aka 'pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> >') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > > &' to prevent copying
        for (const pair<string, multiset_basic> &p : other) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[97/157] Building CXX object symengine/utilities/matchpycpp/autogen_tests/CMakeFiles/test_case002.dir/test_case002.cpp.o
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case002.cpp:20:
In file included from ../symengine/utilities/matchpycpp/common.h:14:
../symengine/utilities/matchpycpp/substitution.h:51:50: warning: loop variable 'p' has type 'const pair<std::string, SymEngine::multiset_basic> &' (aka 'const pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> > &') but is initialized with type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<string, multiset_basic> &p : other) {
                                                 ^
../symengine/utilities/matchpycpp/substitution.h:51:14: note: use non-reference type 'pair<std::string, SymEngine::multiset_basic>' (aka 'pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> >') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > > &' to prevent copying
        for (const pair<string, multiset_basic> &p : other) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[98/157] Building CXX object symengine/utilities/matchpycpp/autogen_tests/CMakeFiles/test_case007.dir/test_case007.cpp.o
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case007.cpp:21:
In file included from ../symengine/utilities/matchpycpp/bipartite.h:9:
In file included from ../symengine/utilities/matchpycpp/common.h:14:
../symengine/utilities/matchpycpp/substitution.h:51:50: warning: loop variable 'p' has type 'const pair<std::string, SymEngine::multiset_basic> &' (aka 'const pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> > &') but is initialized with type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<string, multiset_basic> &p : other) {
                                                 ^
../symengine/utilities/matchpycpp/substitution.h:51:14: note: use non-reference type 'pair<std::string, SymEngine::multiset_basic>' (aka 'pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> >') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > > &' to prevent copying
        for (const pair<string, multiset_basic> &p : other) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case007.cpp:23:
In file included from ../symengine/utilities/matchpycpp/many_to_one.h:5:
../symengine/utilities/matchpycpp/utils.h:100:49: warning: loop variable 'p' has type 'const pair<RCP<const SymEngine::Basic>, int> &' but is initialized with type 'std::pair<const SymEngine::RCP<const SymEngine::Basic>, int>' resulting in a copy [-Wrange-loop-construct]
        for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
                                                ^
../symengine/utilities/matchpycpp/utils.h:100:14: note: use non-reference type 'pair<RCP<const SymEngine::Basic>, int>' to keep the copy or type 'const std::pair<const SymEngine::RCP<const SymEngine::Basic>, int> &' to prevent copying
        for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/utils.h:163:45: warning: loop variable 'p' has type 'const pair<RCP<const SymEngine::Basic>, int> &' but is initialized with type 'std::pair<const SymEngine::RCP<const SymEngine::Basic>, int>' resulting in a copy [-Wrange-loop-construct]
    for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
                                            ^
../symengine/utilities/matchpycpp/utils.h:163:10: note: use non-reference type 'pair<RCP<const SymEngine::Basic>, int>' to keep the copy or type 'const std::pair<const SymEngine::RCP<const SymEngine::Basic>, int> &' to prevent copying
    for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case007.cpp:23:
../symengine/utilities/matchpycpp/many_to_one.h:123:75: warning: loop variable 'p' has type 'const pair<set<int>, tuple<int, multiset<int>, PatternSet> > &' (aka 'const pair<set<int>, tuple<int, multiset<int>, set<tuple<VariableWithCount, int>, lessVariableCount> > > &') but is initialized with type 'std::pair<const std::set<int, std::less<int>, std::allocator<int> >, std::tuple<int, std::multiset<int, std::less<int>, std::allocator<int> >, std::set<std::tuple<VariableWithCount, int>, lessVariableCount, std::allocator<std::tuple<VariableWithCount, int> > > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<set<int>, tuple<int, multiset<int>, PatternSet>> &p :
                                                                          ^
../symengine/utilities/matchpycpp/many_to_one.h:123:14: note: use non-reference type 'pair<set<int>, tuple<int, multiset<int>, PatternSet> >' (aka 'pair<set<int>, tuple<int, multiset<int>, set<tuple<VariableWithCount, int>, lessVariableCount> > >') to keep the copy or type 'const std::pair<const std::set<int, std::less<int>, std::allocator<int> >, std::tuple<int, std::multiset<int, std::less<int>, std::allocator<int> >, std::set<std::tuple<VariableWithCount, int>, lessVariableCount, std::allocator<std::tuple<VariableWithCount, int> > > > > &' to prevent copying
        for (const pair<set<int>, tuple<int, multiset<int>, PatternSet>> &p :
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:212:64: warning: loop variable 'p3' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
            for (const pair<tuple<int, int>, tuple<int, int>> &p3 : matching) {
                                                               ^
../symengine/utilities/matchpycpp/many_to_one.h:212:18: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
            for (const pair<tuple<int, int>, tuple<int, int>> &p3 : matching) {
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:222:68: warning: loop variable 'p3' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
                for (const pair<tuple<int, int>, tuple<int, int>> &p3 :
                                                                   ^
../symengine/utilities/matchpycpp/many_to_one.h:222:22: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
                for (const pair<tuple<int, int>, tuple<int, int>> &p3 :
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:281:64: warning: loop variable 'pair2' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
            for (const pair<tuple<int, int>, tuple<int, int>> &pair2 :
                                                               ^
../symengine/utilities/matchpycpp/many_to_one.h:281:18: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
            for (const pair<tuple<int, int>, tuple<int, int>> &pair2 :
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:275:60: warning: loop variable 'pair1' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<tuple<int, int>, tuple<int, int>> &pair1 : matching) {
                                                           ^
../symengine/utilities/matchpycpp/many_to_one.h:275:14: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
        for (const pair<tuple<int, int>, tuple<int, int>> &pair1 : matching) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:309:36: warning: loop variable 'p' has type 'const pair<int, int> &' but is initialized with type 'std::pair<const int, int>' resulting in a copy [-Wrange-loop-construct]
        for (const pair<int, int> &p : count_multiset(subjects)) {
                                   ^
../symengine/utilities/matchpycpp/many_to_one.h:309:14: note: use non-reference type 'pair<int, int>' to keep the copy or type 'const std::pair<const int, int> &' to prevent copying
        for (const pair<int, int> &p : count_multiset(subjects)) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~
9 warnings generated.
[99/157] Building CXX object symengine/utilities/matchpycpp/autogen_tests/CMakeFiles/test_case005.dir/test_case005.cpp.o
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case005.cpp:20:
In file included from ../symengine/utilities/matchpycpp/common.h:14:
../symengine/utilities/matchpycpp/substitution.h:51:50: warning: loop variable 'p' has type 'const pair<std::string, SymEngine::multiset_basic> &' (aka 'const pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> > &') but is initialized with type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<string, multiset_basic> &p : other) {
                                                 ^
../symengine/utilities/matchpycpp/substitution.h:51:14: note: use non-reference type 'pair<std::string, SymEngine::multiset_basic>' (aka 'pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> >') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > > &' to prevent copying
        for (const pair<string, multiset_basic> &p : other) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[100/157] Building CXX object symengine/utilities/matchpycpp/autogen_tests/CMakeFiles/test_case004.dir/test_case004.cpp.o
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case004.cpp:21:
In file included from ../symengine/utilities/matchpycpp/bipartite.h:9:
In file included from ../symengine/utilities/matchpycpp/common.h:14:
../symengine/utilities/matchpycpp/substitution.h:51:50: warning: loop variable 'p' has type 'const pair<std::string, SymEngine::multiset_basic> &' (aka 'const pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> > &') but is initialized with type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<string, multiset_basic> &p : other) {
                                                 ^
../symengine/utilities/matchpycpp/substitution.h:51:14: note: use non-reference type 'pair<std::string, SymEngine::multiset_basic>' (aka 'pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> >') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > > &' to prevent copying
        for (const pair<string, multiset_basic> &p : other) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case004.cpp:23:
In file included from ../symengine/utilities/matchpycpp/many_to_one.h:5:
../symengine/utilities/matchpycpp/utils.h:100:49: warning: loop variable 'p' has type 'const pair<RCP<const SymEngine::Basic>, int> &' but is initialized with type 'std::pair<const SymEngine::RCP<const SymEngine::Basic>, int>' resulting in a copy [-Wrange-loop-construct]
        for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
                                                ^
../symengine/utilities/matchpycpp/utils.h:100:14: note: use non-reference type 'pair<RCP<const SymEngine::Basic>, int>' to keep the copy or type 'const std::pair<const SymEngine::RCP<const SymEngine::Basic>, int> &' to prevent copying
        for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/utils.h:163:45: warning: loop variable 'p' has type 'const pair<RCP<const SymEngine::Basic>, int> &' but is initialized with type 'std::pair<const SymEngine::RCP<const SymEngine::Basic>, int>' resulting in a copy [-Wrange-loop-construct]
    for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
                                            ^
../symengine/utilities/matchpycpp/utils.h:163:10: note: use non-reference type 'pair<RCP<const SymEngine::Basic>, int>' to keep the copy or type 'const std::pair<const SymEngine::RCP<const SymEngine::Basic>, int> &' to prevent copying
    for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case004.cpp:23:
../symengine/utilities/matchpycpp/many_to_one.h:123:75: warning: loop variable 'p' has type 'const pair<set<int>, tuple<int, multiset<int>, PatternSet> > &' (aka 'const pair<set<int>, tuple<int, multiset<int>, set<tuple<VariableWithCount, int>, lessVariableCount> > > &') but is initialized with type 'std::pair<const std::set<int, std::less<int>, std::allocator<int> >, std::tuple<int, std::multiset<int, std::less<int>, std::allocator<int> >, std::set<std::tuple<VariableWithCount, int>, lessVariableCount, std::allocator<std::tuple<VariableWithCount, int> > > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<set<int>, tuple<int, multiset<int>, PatternSet>> &p :
                                                                          ^
../symengine/utilities/matchpycpp/many_to_one.h:123:14: note: use non-reference type 'pair<set<int>, tuple<int, multiset<int>, PatternSet> >' (aka 'pair<set<int>, tuple<int, multiset<int>, set<tuple<VariableWithCount, int>, lessVariableCount> > >') to keep the copy or type 'const std::pair<const std::set<int, std::less<int>, std::allocator<int> >, std::tuple<int, std::multiset<int, std::less<int>, std::allocator<int> >, std::set<std::tuple<VariableWithCount, int>, lessVariableCount, std::allocator<std::tuple<VariableWithCount, int> > > > > &' to prevent copying
        for (const pair<set<int>, tuple<int, multiset<int>, PatternSet>> &p :
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:212:64: warning: loop variable 'p3' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
            for (const pair<tuple<int, int>, tuple<int, int>> &p3 : matching) {
                                                               ^
../symengine/utilities/matchpycpp/many_to_one.h:212:18: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
            for (const pair<tuple<int, int>, tuple<int, int>> &p3 : matching) {
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:222:68: warning: loop variable 'p3' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
                for (const pair<tuple<int, int>, tuple<int, int>> &p3 :
                                                                   ^
../symengine/utilities/matchpycpp/many_to_one.h:222:22: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
                for (const pair<tuple<int, int>, tuple<int, int>> &p3 :
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:281:64: warning: loop variable 'pair2' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
            for (const pair<tuple<int, int>, tuple<int, int>> &pair2 :
                                                               ^
../symengine/utilities/matchpycpp/many_to_one.h:281:18: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
            for (const pair<tuple<int, int>, tuple<int, int>> &pair2 :
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:275:60: warning: loop variable 'pair1' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<tuple<int, int>, tuple<int, int>> &pair1 : matching) {
                                                           ^
../symengine/utilities/matchpycpp/many_to_one.h:275:14: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
        for (const pair<tuple<int, int>, tuple<int, int>> &pair1 : matching) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:309:36: warning: loop variable 'p' has type 'const pair<int, int> &' but is initialized with type 'std::pair<const int, int>' resulting in a copy [-Wrange-loop-construct]
        for (const pair<int, int> &p : count_multiset(subjects)) {
                                   ^
../symengine/utilities/matchpycpp/many_to_one.h:309:14: note: use non-reference type 'pair<int, int>' to keep the copy or type 'const std::pair<const int, int> &' to prevent copying
        for (const pair<int, int> &p : count_multiset(subjects)) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~
9 warnings generated.
[101/157] Building CXX object symengine/utilities/matchpycpp/autogen_tests/CMakeFiles/test_case003.dir/test_case003.cpp.o
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case003.cpp:20:
In file included from ../symengine/utilities/matchpycpp/common.h:14:
../symengine/utilities/matchpycpp/substitution.h:51:50: warning: loop variable 'p' has type 'const pair<std::string, SymEngine::multiset_basic> &' (aka 'const pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> > &') but is initialized with type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<string, multiset_basic> &p : other) {
                                                 ^
../symengine/utilities/matchpycpp/substitution.h:51:14: note: use non-reference type 'pair<std::string, SymEngine::multiset_basic>' (aka 'pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> >') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > > &' to prevent copying
        for (const pair<string, multiset_basic> &p : other) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[102/157] Building CXX object symengine/utilities/matchpycpp/autogen_tests/CMakeFiles/test_case006.dir/test_case006.cpp.o
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case006.cpp:21:
In file included from ../symengine/utilities/matchpycpp/bipartite.h:9:
In file included from ../symengine/utilities/matchpycpp/common.h:14:
../symengine/utilities/matchpycpp/substitution.h:51:50: warning: loop variable 'p' has type 'const pair<std::string, SymEngine::multiset_basic> &' (aka 'const pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> > &') but is initialized with type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<string, multiset_basic> &p : other) {
                                                 ^
../symengine/utilities/matchpycpp/substitution.h:51:14: note: use non-reference type 'pair<std::string, SymEngine::multiset_basic>' (aka 'pair<basic_string<char>, multiset<RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess> >') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, std::multiset<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCPBasicKeyLess, std::allocator<SymEngine::RCP<const SymEngine::Basic> > > > &' to prevent copying
        for (const pair<string, multiset_basic> &p : other) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case006.cpp:23:
In file included from ../symengine/utilities/matchpycpp/many_to_one.h:5:
../symengine/utilities/matchpycpp/utils.h:100:49: warning: loop variable 'p' has type 'const pair<RCP<const SymEngine::Basic>, int> &' but is initialized with type 'std::pair<const SymEngine::RCP<const SymEngine::Basic>, int>' resulting in a copy [-Wrange-loop-construct]
        for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
                                                ^
../symengine/utilities/matchpycpp/utils.h:100:14: note: use non-reference type 'pair<RCP<const SymEngine::Basic>, int>' to keep the copy or type 'const std::pair<const SymEngine::RCP<const SymEngine::Basic>, int> &' to prevent copying
        for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/utils.h:163:45: warning: loop variable 'p' has type 'const pair<RCP<const SymEngine::Basic>, int> &' but is initialized with type 'std::pair<const SymEngine::RCP<const SymEngine::Basic>, int>' resulting in a copy [-Wrange-loop-construct]
    for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
                                            ^
../symengine/utilities/matchpycpp/utils.h:163:10: note: use non-reference type 'pair<RCP<const SymEngine::Basic>, int>' to keep the copy or type 'const std::pair<const SymEngine::RCP<const SymEngine::Basic>, int> &' to prevent copying
    for (const pair<RCP<const Basic>, int> &p : count_multiset(values)) {
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../symengine/utilities/matchpycpp/autogen_tests/test_case006.cpp:23:
../symengine/utilities/matchpycpp/many_to_one.h:123:75: warning: loop variable 'p' has type 'const pair<set<int>, tuple<int, multiset<int>, PatternSet> > &' (aka 'const pair<set<int>, tuple<int, multiset<int>, set<tuple<VariableWithCount, int>, lessVariableCount> > > &') but is initialized with type 'std::pair<const std::set<int, std::less<int>, std::allocator<int> >, std::tuple<int, std::multiset<int, std::less<int>, std::allocator<int> >, std::set<std::tuple<VariableWithCount, int>, lessVariableCount, std::allocator<std::tuple<VariableWithCount, int> > > > >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<set<int>, tuple<int, multiset<int>, PatternSet>> &p :
                                                                          ^
../symengine/utilities/matchpycpp/many_to_one.h:123:14: note: use non-reference type 'pair<set<int>, tuple<int, multiset<int>, PatternSet> >' (aka 'pair<set<int>, tuple<int, multiset<int>, set<tuple<VariableWithCount, int>, lessVariableCount> > >') to keep the copy or type 'const std::pair<const std::set<int, std::less<int>, std::allocator<int> >, std::tuple<int, std::multiset<int, std::less<int>, std::allocator<int> >, std::set<std::tuple<VariableWithCount, int>, lessVariableCount, std::allocator<std::tuple<VariableWithCount, int> > > > > &' to prevent copying
        for (const pair<set<int>, tuple<int, multiset<int>, PatternSet>> &p :
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:212:64: warning: loop variable 'p3' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
            for (const pair<tuple<int, int>, tuple<int, int>> &p3 : matching) {
                                                               ^
../symengine/utilities/matchpycpp/many_to_one.h:212:18: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
            for (const pair<tuple<int, int>, tuple<int, int>> &p3 : matching) {
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:222:68: warning: loop variable 'p3' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
                for (const pair<tuple<int, int>, tuple<int, int>> &p3 :
                                                                   ^
../symengine/utilities/matchpycpp/many_to_one.h:222:22: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
                for (const pair<tuple<int, int>, tuple<int, int>> &p3 :
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:281:64: warning: loop variable 'pair2' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
            for (const pair<tuple<int, int>, tuple<int, int>> &pair2 :
                                                               ^
../symengine/utilities/matchpycpp/many_to_one.h:281:18: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
            for (const pair<tuple<int, int>, tuple<int, int>> &pair2 :
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:275:60: warning: loop variable 'pair1' has type 'const pair<tuple<int, int>, tuple<int, int> > &' but is initialized with type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> >' resulting in a copy [-Wrange-loop-construct]
        for (const pair<tuple<int, int>, tuple<int, int>> &pair1 : matching) {
                                                           ^
../symengine/utilities/matchpycpp/many_to_one.h:275:14: note: use non-reference type 'pair<tuple<int, int>, tuple<int, int> >' to keep the copy or type 'const std::pair<const std::tuple<int, int>, std::tuple<int, int> > &' to prevent copying
        for (const pair<tuple<int, int>, tuple<int, int>> &pair1 : matching) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../symengine/utilities/matchpycpp/many_to_one.h:309:36: warning: loop variable 'p' has type 'const pair<int, int> &' but is initialized with type 'std::pair<const int, int>' resulting in a copy [-Wrange-loop-construct]
        for (const pair<int, int> &p : count_multiset(subjects)) {
                                   ^
../symengine/utilities/matchpycpp/many_to_one.h:309:14: note: use non-reference type 'pair<int, int>' to keep the copy or type 'const std::pair<const int, int> &' to prevent copying
        for (const pair<int, int> &p : count_multiset(subjects)) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~
9 warnings generated.
```