### PR TITLE
Construct IRBuilder directly instead of using copy constructor

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -218,7 +218,7 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
     // Create a basic block builder with default parameters.  The builder
     // will
     // automatically append instructions to the basic block `BB'.
-    llvm::IRBuilder<> _builder = llvm::IRBuilder<>(BB);
+    llvm::IRBuilder<> _builder(BB);
     builder = reinterpret_cast<IRBuilder *>(&_builder);
     builder->SetInsertPoint(BB);
     auto fmf = llvm::FastMathFlags();


### PR DESCRIPTION
IRBuilder copy constructor is deleted in llvm 11, causes compilation error:

```
../symengine/llvm_double.cpp:221:23: error: call to deleted constructor of 'llvm::IRBuilder<>'
    llvm::IRBuilder<> _builder = llvm::IRBuilder<>(BB);
                      ^          ~~~~~~~~~~~~~~~~~~~~~
/usr/lib/llvm-12/include/llvm/IR/IRBuilder.h:2629:3: note: 'IRBuilder' has been explicitly marked deleted here
  IRBuilder(const IRBuilder &) = delete;
```