### PR TITLE
add longer timeout & retry to curl in travis: codecov.io can be flaky

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -168,7 +168,7 @@ ctest --output-on-failure
 
 if [[ "${WITH_COVERAGE}" == "yes" ]]; then
     echo "=== Collecting coverage data"
-    curl -L https://codecov.io/bash -o codecov.sh
+    curl --connect-timeout 10 --retry 5 -L https://codecov.io/bash -o codecov.sh
     bash codecov.sh -x $GCOV_EXECUTABLE 2>&1 | grep -v "has arcs to entry block" | grep -v "has arcs from exit block"
     exit 0;
 fi


### PR DESCRIPTION
see this build which failed due to codecov.io timeout:
https://travis-ci.org/github/symengine/symengine/jobs/719990104#L8807