### PR TITLE
add bench_llvm_double benchmark

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -79,8 +79,14 @@ if (BUILD_BENCHMARKS_NONIUS)
     add_executable(bench_eval_double bench_eval_double.cpp)
     target_link_libraries(bench_eval_double symengine)
 
-    add_executable(bench_lambda_double bench_lambda_double.cpp)
+    add_executable(bench_lambda_double bench_lambda_double.cpp bench_common.cpp)
     target_link_libraries(bench_lambda_double symengine)
+
+    add_executable(bench_llvm_double bench_llvm_double.cpp bench_common.cpp)
+    target_link_libraries(bench_llvm_double symengine)
+
+    add_executable(bench_native_double bench_native_double.cpp bench_common.cpp)
+    target_link_libraries(bench_native_double symengine)
 endif()
 
 add_executable(parsing parsing.cpp)

--- a/benchmarks/bench_common.cpp
+++ b/benchmarks/bench_common.cpp
@@ -1,0 +1,60 @@
+#ifndef SYMENGINE_BENCH_EXPRESSIONS_H
+#define SYMENGINE_BENCH_EXPRESSIONS_H
+
+#include "bench_common.h"
+#include <cmath>
+#include <symengine/add.h>
+#include <symengine/integer.h>
+#include <symengine/mul.h>
+#include <symengine/pow.h>
+#include <symengine/symbol.h>
+
+using SymEngine::add;
+using SymEngine::Basic;
+using SymEngine::cos;
+using SymEngine::integer;
+using SymEngine::mul;
+using SymEngine::pow;
+using SymEngine::RCP;
+using SymEngine::sin;
+using SymEngine::symbol;
+using SymEngine::vec_basic;
+
+vec_basic get_vec()
+{
+    return {symbol("x"), symbol("y"), symbol("z")};
+}
+
+vec_basic get_expression_1(const vec_basic &v)
+{
+    vec_basic r{symbol("r0")};
+    r[0] = sin(add(v[0], cos(add(mul(v[1], v[2]), pow(v[0], integer(2))))));
+    r[0] = mul(add(integer(3), r[0]), add(integer(2), r[0]));
+    r[0] = pow(add(integer(5), r[0]), add(integer(-2), r[0]));
+    return r;
+}
+
+void call_compiled_expression_1(double *d, const double *v)
+{
+    double r1 = std::sin(v[0] + std::cos((v[1] * v[2]) + std::pow(v[0], 2)));
+    double r2 = (3 + r1) * (2 + r1);
+    *d = std::pow((5 + r2), (r2 - 2));
+}
+
+vec_basic get_expression_2(const vec_basic &v)
+{
+    vec_basic r{symbol("r0"), symbol("r1"), symbol("r2")};
+    r[0] = mul(integer(2), add(v[0], add(v[0], mul(v[1], v[2]))));
+    r[1] = add(v[0], add(v[0], mul(v[2], v[1])));
+    r[2] = mul(integer(-2), add(v[0], add(v[0], mul(v[1], v[2]))));
+    return r;
+}
+
+void call_compiled_expression_2(double *d, const double *v)
+{
+    d[0] = 2.0 * (v[0] + v[0] + (v[1] * v[2]));
+    d[1] = v[0] + v[0] + (v[2] * v[1]);
+    d[2] = -2.0 * (v[0] + v[0] + (v[1] * v[2]));
+}
+
+#endif

--- a/benchmarks/bench_common.h
+++ b/benchmarks/bench_common.h
@@ -1,0 +1,19 @@
+#ifndef SYMENGINE_BENCH_EXPRESSIONS_H
+#define SYMENGINE_BENCH_EXPRESSIONS_H
+
+#include <symengine/basic.h>
+#include <symengine/dict.h>
+
+const std::size_t call_iterations{1000000};
+
+SymEngine::vec_basic get_vec();
+
+SymEngine::vec_basic get_expression_1(const SymEngine::vec_basic &v);
+
+void call_compiled_expression_1(double *d, const double *v);
+
+SymEngine::vec_basic get_expression_2(const SymEngine::vec_basic &v);
+
+void call_compiled_expression_2(double *d, const double *v);
+
+#endif

--- a/benchmarks/bench_llvm_double.cpp
+++ b/benchmarks/bench_llvm_double.cpp
@@ -1,0 +1,65 @@
+#define NONIUS_RUNNER
+#include "nonius.h++"
+
+#include "bench_common.h"
+#include <symengine/llvm_double.h>
+
+using SymEngine::LLVMDoubleVisitor;
+
+#define SYMENGINE_LLVM_BENCH_CALL(NAME, EXPR, CSE, OPT)                        \
+    NONIUS_BENCHMARK(NAME, [](nonius::chronometer meter) {                     \
+        auto vec = get_vec();                                                  \
+        auto expr = get_expression_##EXPR(vec);                                \
+        LLVMDoubleVisitor v;                                                   \
+        v.init(vec, expr, CSE, OPT);                                           \
+        std::vector<double> s{0.0, 0.0, 0.0};                                  \
+        std::vector<double> d{0.0, 0.0, 0.0};                                  \
+        std::vector<double> x{1.0, 4.4365, 12.8};                              \
+        meter.measure([&]() {                                                  \
+            for (std::size_t j = 0; j < call_iterations; ++j) {                \
+                x[0] += 1.0;                                                   \
+                x[1] += 2.0;                                                   \
+                x[2] += 3.0;                                                   \
+                v.call(d.data(), x.data());                                    \
+                s[0] += d[0];                                                  \
+                s[1] += d[1];                                                  \
+                s[2] += d[2];                                                  \
+            }                                                                  \
+        });                                                                    \
+    })
+
+#define SYMENGINE_LLVM_BENCH_INIT(NAME, EXPR, CSE, OPT)                        \
+    NONIUS_BENCHMARK(NAME, [](nonius::chronometer meter) {                     \
+        auto vec = get_vec();                                                  \
+        auto expr = get_expression_##EXPR(vec);                                \
+        LLVMDoubleVisitor v;                                                   \
+        meter.measure([&]() { v.init(vec, expr, CSE, OPT); });                 \
+    })
+
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr1_O0_call", 1, false, 0);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr1_O0_cse_call", 1, true, 0);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr1_O1_call", 1, false, 1);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr1_O1_cse_call", 1, true, 1);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr1_O2_call", 1, false, 2);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr1_O2_cse_call", 1, true, 2);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr1_O3_call", 1, false, 3);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr1_O3_cse_call", 1, true, 3);
+
+SYMENGINE_LLVM_BENCH_INIT("llvm_double_visitor_expr1_O0_init", 1, false, 0);
+SYMENGINE_LLVM_BENCH_INIT("llvm_double_visitor_expr1_O1_init", 1, false, 1);
+SYMENGINE_LLVM_BENCH_INIT("llvm_double_visitor_expr1_O2_init", 1, false, 2);
+SYMENGINE_LLVM_BENCH_INIT("llvm_double_visitor_expr1_O3_init", 1, false, 3);
+
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr2_O0_call", 2, false, 0);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr2_O0_cse_call", 2, true, 0);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr2_O1_call", 2, false, 1);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr2_O1_cse_call", 2, true, 1);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr2_O2_call", 2, false, 2);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr2_O2_cse_call", 2, true, 2);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr2_O3_call", 2, false, 3);
+SYMENGINE_LLVM_BENCH_CALL("llvm_double_visitor_expr2_O3_cse_call", 2, true, 3);
+
+SYMENGINE_LLVM_BENCH_INIT("llvm_double_visitor_expr2_O0_init", 2, false, 0);
+SYMENGINE_LLVM_BENCH_INIT("llvm_double_visitor_expr2_O1_init", 2, false, 1);
+SYMENGINE_LLVM_BENCH_INIT("llvm_double_visitor_expr2_O2_init", 2, false, 2);
+SYMENGINE_LLVM_BENCH_INIT("llvm_double_visitor_expr2_O3_init", 2, false, 3);

--- a/benchmarks/bench_native_double.cpp
+++ b/benchmarks/bench_native_double.cpp
@@ -1,0 +1,38 @@
+#define NONIUS_RUNNER
+#include "nonius.h++"
+
+#include "bench_common.h"
+
+NONIUS_BENCHMARK("native_expr1_call", [](nonius::chronometer meter) {
+    std::vector<double> s{0.0, 0.0, 0.0};
+    std::vector<double> d{0.0, 0.0, 0.0};
+    std::vector<double> x{1.0, 4.4365, 12.8};
+    meter.measure([&]() {
+        for (std::size_t j = 0; j < call_iterations; ++j) {
+            x[0] += 1.0;
+            x[1] += 2.0;
+            x[2] += 3.0;
+            call_compiled_expression_1(d.data(), x.data());
+            s[0] += d[0];
+            s[1] += d[1];
+            s[2] += d[2];
+        }
+    });
+})
+
+NONIUS_BENCHMARK("native_expr2_call", [](nonius::chronometer meter) {
+    std::vector<double> s{0.0, 0.0, 0.0};
+    std::vector<double> d{0.0, 0.0, 0.0};
+    std::vector<double> x{1.0, 4.4365, 12.8};
+    meter.measure([&]() {
+        for (std::size_t j = 0; j < call_iterations; ++j) {
+            x[0] += 1.0;
+            x[1] += 2.0;
+            x[2] += 3.0;
+            call_compiled_expression_2(d.data(), x.data());
+            s[0] += d[0];
+            s[1] += d[1];
+            s[2] += d[2];
+        }
+    });
+})


### PR DESCRIPTION
  - benchmark `call()` and `init()` for two expressions, with/without CSE, O0-O3
  - do the same for `bench_lambda_double` to directly compare performance
  - add `bench_native_double` to do the same for natively compiled versions of expressions
  - add explicit loop inside lambda (since nonius typically only does 1 iteration per sample)
  - add bench_common.h with the common expressions used in the benchmarks