### PR TITLE
Add conjugate, conjugate_transpose and is_square for matrices

### DIFF
--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -1,5 +1,6 @@
 #include <symengine/matrix.h>
 #include <symengine/add.h>
+#include <symengine/functions.h>
 #include <symengine/pow.h>
 #include <symengine/subs.h>
 #include <symengine/symengine_exception.h>
@@ -119,12 +120,30 @@ void DenseMatrix::mul_scalar(const RCP<const Basic> &k,
     }
 }
 
+// Matrix conjugate
+void DenseMatrix::conjugate(MatrixBase &result) const
+{
+    if (is_a<DenseMatrix>(result)) {
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
+        conjugate_dense(*this, r);
+    }
+}
+
 // Matrix transpose
 void DenseMatrix::transpose(MatrixBase &result) const
 {
     if (is_a<DenseMatrix>(result)) {
         DenseMatrix &r = down_cast<DenseMatrix &>(result);
         transpose_dense(*this, r);
+    }
+}
+
+// Matrix conjugate transpose
+void DenseMatrix::conjugate_transpose(MatrixBase &result) const
+{
+    if (is_a<DenseMatrix>(result)) {
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
+        conjugate_transpose_dense(*this, r);
     }
 }
 
@@ -302,6 +321,16 @@ void sdiff(const DenseMatrix &A, const RCP<const Basic> &x, DenseMatrix &result,
     }
 }
 
+// ----------------------------- Matrix Conjugate ----------------------------//
+void conjugate_dense(const DenseMatrix &A, DenseMatrix &B)
+{
+    SYMENGINE_ASSERT(B.col_ == A.col_ and B.row_ == A.row_);
+
+    for (unsigned i = 0; i < A.row_; i++)
+        for (unsigned j = 0; j < A.col_; j++)
+            B.m_[i * B.col_ + j] = conjugate(A.m_[i * A.col_ + j]);
+}
+
 // ----------------------------- Matrix Transpose ----------------------------//
 void transpose_dense(const DenseMatrix &A, DenseMatrix &B)
 {
@@ -310,6 +339,16 @@ void transpose_dense(const DenseMatrix &A, DenseMatrix &B)
     for (unsigned i = 0; i < A.row_; i++)
         for (unsigned j = 0; j < A.col_; j++)
             B.m_[j * B.col_ + i] = A.m_[i * A.col_ + j];
+}
+
+// ----------------------------- Matrix Conjugate Transpose -----------------//
+void conjugate_transpose_dense(const DenseMatrix &A, DenseMatrix &B)
+{
+    SYMENGINE_ASSERT(B.row_ == A.col_ and B.col_ == A.row_);
+
+    for (unsigned i = 0; i < A.row_; i++)
+        for (unsigned j = 0; j < A.col_; j++)
+            B.m_[j * B.col_ + i] = conjugate(A.m_[i * A.col_ + j]);
 }
 
 // ------------------------------- Submatrix ---------------------------------//

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -13,6 +13,11 @@ class MatrixBase
 public:
     virtual ~MatrixBase(){};
 
+    bool is_square() const
+    {
+        return ncols() == nrows();
+    }
+
     // Below methods should be implemented by the derived classes. If not
     // applicable, raise an exception
 
@@ -49,8 +54,14 @@ public:
     virtual void mul_scalar(const RCP<const Basic> &k,
                             MatrixBase &result) const = 0;
 
+    // Matrix conjugate
+    virtual void conjugate(MatrixBase &result) const = 0;
+
     // Matrix transpose
     virtual void transpose(MatrixBase &result) const = 0;
+
+    // Matrix conjugate transpose
+    virtual void conjugate_transpose(MatrixBase &result) const = 0;
 
     // Extract out a submatrix
     virtual void submatrix(MatrixBase &result, unsigned row_start,
@@ -132,8 +143,14 @@ public:
     virtual void mul_scalar(const RCP<const Basic> &k,
                             MatrixBase &result) const;
 
+    // Matrix conjugate
+    virtual void conjugate(MatrixBase &result) const;
+
     // Matrix transpose
     virtual void transpose(MatrixBase &result) const;
+
+    // Matrix conjugate transpose
+    virtual void conjugate_transpose(MatrixBase &result) const;
 
     // Extract out a submatrix
     virtual void submatrix(MatrixBase &result, unsigned row_start,
@@ -185,7 +202,9 @@ public:
                                 DenseMatrix &C);
     friend void mul_dense_scalar(const DenseMatrix &A,
                                  const RCP<const Basic> &k, DenseMatrix &C);
+    friend void conjugate_dense(const DenseMatrix &A, DenseMatrix &B);
     friend void transpose_dense(const DenseMatrix &A, DenseMatrix &B);
+    friend void conjugate_transpose_dense(const DenseMatrix &A, DenseMatrix &B);
     friend void submatrix_dense(const DenseMatrix &A, DenseMatrix &B,
                                 unsigned row_start, unsigned col_start,
                                 unsigned row_end, unsigned col_end,
@@ -340,9 +359,15 @@ public:
     virtual void mul_scalar(const RCP<const Basic> &k,
                             MatrixBase &result) const;
 
+    // Matrix conjugate
+    virtual void conjugate(MatrixBase &result) const;
+
     // Matrix transpose
     virtual void transpose(MatrixBase &result) const;
-    CSRMatrix transpose() const;
+    CSRMatrix transpose(bool conjugate = false) const;
+
+    // Matrix conjugate transpose
+    virtual void conjugate_transpose(MatrixBase &result) const;
 
     // Extract out a submatrix
     virtual void submatrix(MatrixBase &result, unsigned row_start,

--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -1,6 +1,7 @@
 #include <numeric>
 #include <symengine/matrix.h>
 #include <symengine/add.h>
+#include <symengine/functions.h>
 #include <symengine/mul.h>
 #include <symengine/constants.h>
 #include <symengine/symengine_exception.h>
@@ -196,6 +197,22 @@ void CSRMatrix::mul_scalar(const RCP<const Basic> &k, MatrixBase &result) const
     throw NotImplementedError("Not Implemented");
 }
 
+// Matrix conjugate
+void CSRMatrix::conjugate(MatrixBase &result) const
+{
+    if (is_a<CSRMatrix>(result)) {
+        auto &r = down_cast<CSRMatrix &>(result);
+        std::vector<unsigned> p(p_), j(j_);
+        vec_basic x(x_.size());
+        for (unsigned i = 0; i < x_.size(); ++i) {
+            x[i] = SymEngine::conjugate(x_[i]);
+        }
+        r = CSRMatrix(col_, row_, std::move(p), std::move(j), std::move(x));
+    } else {
+        throw NotImplementedError("Not Implemented");
+    }
+}
+
 // Matrix transpose
 void CSRMatrix::transpose(MatrixBase &result) const
 {
@@ -207,7 +224,7 @@ void CSRMatrix::transpose(MatrixBase &result) const
     }
 }
 
-CSRMatrix CSRMatrix::transpose() const
+CSRMatrix CSRMatrix::transpose(bool conjugate) const
 {
     const auto nnz = j_.size();
     std::vector<unsigned> p(col_ + 1, 0), j(nnz), tmp(col_, 0);
@@ -222,11 +239,26 @@ CSRMatrix CSRMatrix::transpose() const
             const auto ci = j_[i];
             const unsigned k = p[ci] + tmp[ci];
             j[k] = ri;
-            x[k] = x_[i];
+            if (conjugate) {
+                x[k] = SymEngine::conjugate(x_[i]);
+            } else {
+                x[k] = x_[i];
+            }
             tmp[ci]++;
         }
     }
     return CSRMatrix(col_, row_, std::move(p), std::move(j), std::move(x));
+}
+
+// Matrix conjugate transpose
+void CSRMatrix::conjugate_transpose(MatrixBase &result) const
+{
+    if (is_a<CSRMatrix>(result)) {
+        auto &r = down_cast<CSRMatrix &>(result);
+        r = this->transpose(true);
+    } else {
+        throw NotImplementedError("Not Implemented");
+    }
 }
 
 // Extract out a submatrix


### PR DESCRIPTION
Add non-virtual method ```is_square``` and virtual methods ```conjugate``` and ```conjugate_transpose``` to both ```DenseMatrix``` and ```CSRMatrix```.