### PR TITLE
use DeadCodeEliminationPass instead of DeadInstEliminationPass

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -146,7 +146,7 @@ std::vector<llvm::Pass *> LLVMVisitor::create_default_passes(int optlevel)
 #else
     passes.push_back(llvm::createInstructionCombiningPass(optlevel > 1));
 #endif
-    passes.push_back(llvm::createDeadInstEliminationPass());
+    passes.push_back(llvm::createDeadCodeEliminationPass());
     passes.push_back(llvm::createPromoteMemoryToRegisterPass());
     passes.push_back(llvm::createReassociatePass());
     passes.push_back(llvm::createGVNPass());


### PR DESCRIPTION
- `DeadInstEliminationPass` has been removed from llvm trunk
- see https://reviews.llvm.org/D87933