### PR TITLE
Add elementwise_mul_matrix method for Dense and CSR matrices

### DIFF
--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -100,6 +100,19 @@ void DenseMatrix::mul_matrix(const MatrixBase &other, MatrixBase &result) const
     }
 }
 
+void DenseMatrix::elementwise_mul_matrix(const MatrixBase &other,
+                                         MatrixBase &result) const
+{
+    SYMENGINE_ASSERT(row_ == result.nrows() and col_ == result.ncols()
+                     and row_ == other.nrows() and col_ == other.ncols());
+
+    if (is_a<DenseMatrix>(other) and is_a<DenseMatrix>(result)) {
+        const DenseMatrix &o = down_cast<const DenseMatrix &>(other);
+        DenseMatrix &r = down_cast<DenseMatrix &>(result);
+        elementwise_mul_dense_dense(*this, o, r);
+    }
+}
+
 // Add a scalar
 void DenseMatrix::add_scalar(const RCP<const Basic> &k,
                              MatrixBase &result) const
@@ -420,6 +433,21 @@ void mul_dense_dense(const DenseMatrix &A, const DenseMatrix &B, DenseMatrix &C)
         DenseMatrix tmp = DenseMatrix(A.row_, B.col_);
         mul_dense_dense(A, B, tmp);
         C = tmp;
+    }
+}
+
+void elementwise_mul_dense_dense(const DenseMatrix &A, const DenseMatrix &B,
+                                 DenseMatrix &C)
+{
+    SYMENGINE_ASSERT(A.row_ == B.row_ and A.col_ == B.col_ and A.row_ == C.row_
+                     and A.col_ == C.col_);
+
+    unsigned row = A.row_, col = A.col_;
+
+    for (unsigned i = 0; i < row; i++) {
+        for (unsigned j = 0; j < col; j++) {
+            C.m_[i * col + j] = mul(A.m_[i * col + j], B.m_[i * col + j]);
+        }
     }
 }
 

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -46,6 +46,10 @@ public:
     virtual void mul_matrix(const MatrixBase &other,
                             MatrixBase &result) const = 0;
 
+    // Matrix elementwise Multiplication
+    virtual void elementwise_mul_matrix(const MatrixBase &other,
+                                        MatrixBase &result) const = 0;
+
     // Add a scalar
     virtual void add_scalar(const RCP<const Basic> &k,
                             MatrixBase &result) const = 0;
@@ -135,6 +139,10 @@ public:
     // Matrix multiplication
     virtual void mul_matrix(const MatrixBase &other, MatrixBase &result) const;
 
+    // Matrix elementwise Multiplication
+    virtual void elementwise_mul_matrix(const MatrixBase &other,
+                                        MatrixBase &result) const;
+
     // Add a scalar
     virtual void add_scalar(const RCP<const Basic> &k,
                             MatrixBase &result) const;
@@ -200,6 +208,9 @@ public:
                                  const RCP<const Basic> &k, DenseMatrix &B);
     friend void mul_dense_dense(const DenseMatrix &A, const DenseMatrix &B,
                                 DenseMatrix &C);
+    friend void elementwise_mul_dense_dense(const DenseMatrix &A,
+                                            const DenseMatrix &B,
+                                            DenseMatrix &C);
     friend void mul_dense_scalar(const DenseMatrix &A,
                                  const RCP<const Basic> &k, DenseMatrix &C);
     friend void conjugate_dense(const DenseMatrix &A, DenseMatrix &B);
@@ -350,6 +361,10 @@ public:
 
     // Matrix Multiplication
     virtual void mul_matrix(const MatrixBase &other, MatrixBase &result) const;
+
+    // Matrix elementwise Multiplication
+    virtual void elementwise_mul_matrix(const MatrixBase &other,
+                                        MatrixBase &result) const;
 
     // Add a scalar
     virtual void add_scalar(const RCP<const Basic> &k,

--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -185,6 +185,16 @@ void CSRMatrix::mul_matrix(const MatrixBase &other, MatrixBase &result) const
     throw NotImplementedError("Not Implemented");
 }
 
+void CSRMatrix::elementwise_mul_matrix(const MatrixBase &other,
+                                       MatrixBase &result) const
+{
+    if (is_a<CSRMatrix>(result)) {
+        auto &o = down_cast<const CSRMatrix &>(other);
+        auto &r = down_cast<CSRMatrix &>(result);
+        csr_binop_csr_canonical(*this, o, r, mul);
+    }
+}
+
 // Add a scalar
 void CSRMatrix::add_scalar(const RCP<const Basic> &k, MatrixBase &result) const
 {

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -243,6 +243,43 @@ TEST_CASE("test_dense_dense_multiplication(): matrices", "[matrices]")
                                         mul(symbol("w"), symbol("z")))}));
 }
 
+TEST_CASE("test_elementwise_dense_dense_multiplication(): matrices",
+          "[matrices]")
+{
+    DenseMatrix A
+        = DenseMatrix(2, 2, {integer(1), integer(0), integer(0), integer(1)});
+    DenseMatrix B
+        = DenseMatrix(2, 2, {integer(1), integer(2), integer(3), integer(4)});
+    elementwise_mul_dense_dense(A, B, A);
+
+    REQUIRE(A == DenseMatrix(2, 2,
+                             {integer(1), integer(0), integer(0), integer(4)}));
+
+    A = DenseMatrix(1, 4, {integer(1), integer(3), integer(7), integer(-5)});
+    B = DenseMatrix(1, 4, {integer(1), integer(2), integer(3), integer(4)});
+    DenseMatrix C = DenseMatrix(1, 4);
+    A.elementwise_mul_matrix(B, C);
+
+    REQUIRE(C == DenseMatrix(1, 4, {integer(1), integer(6), integer(21),
+                                    integer(-20)}));
+
+    A = DenseMatrix(3, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("p"),
+                           symbol("q"), symbol("r")});
+    B = DenseMatrix(3, 2, {symbol("x"), symbol("y"), symbol("z"), symbol("w"),
+                           symbol("k"), symbol("f")});
+    C = DenseMatrix(3, 2);
+    B.elementwise_mul_matrix(A, C);
+
+    REQUIRE(C == DenseMatrix(3, 2, {
+                                       mul(symbol("a"), symbol("x")),
+                                       mul(symbol("b"), symbol("y")),
+                                       mul(symbol("c"), symbol("z")),
+                                       mul(symbol("p"), symbol("w")),
+                                       mul(symbol("q"), symbol("k")),
+                                       mul(symbol("r"), symbol("f")),
+                                   }));
+}
+
 TEST_CASE("test_mul_dense_scalar(): matrices", "[matrices]")
 {
     // More tests should be added
@@ -1789,6 +1826,19 @@ TEST_CASE("test_csr_binop_csr_canonical(): matrices", "[matrices]")
                            {integer(1), integer(7), integer(2), integer(8),
                             integer(9), integer(3), integer(4), integer(5),
                             integer(6)}));
+}
+
+TEST_CASE("test_csr_elementwise_mul(): matrices", "[matrices]")
+{
+    CSRMatrix A = CSRMatrix(3, 3, {0, 2, 3, 6}, {0, 2, 2, 0, 1, 2},
+                            {integer(1), integer(2), integer(3), integer(4),
+                             integer(5), integer(6)});
+    CSRMatrix B = CSRMatrix(3, 3);
+
+    A.elementwise_mul_matrix(A, B);
+    REQUIRE(B == CSRMatrix(3, 3, {0, 2, 3, 6}, {0, 2, 2, 0, 1, 2},
+                           {integer(1), integer(4), integer(9), integer(16),
+                            integer(25), integer(36)}));
 }
 
 TEST_CASE("test_eye(): matrices", "[matrices]")


### PR DESCRIPTION
Implement elementwise matrix multiplication for both ```DenseMatrix``` and ```CSRMatrix```

Addressing #1675