### PR TITLE
Add tribool type and update is_zero to return tribool

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SRC
     symbol.cpp
     symengine_rcp.cpp
     visitor.cpp
+    test_visitors.cpp
 )
 
 if ("${SYMENGINE_INTEGER_CLASS}" STREQUAL "BOOSTMP")
@@ -190,6 +191,7 @@ set(HEADERS
     symengine_rcp.h
     type_codes.inc
     visitor.h
+    test_visitors.h
 )
 
 include(GNUInstallDirs)

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -220,6 +220,13 @@ struct RCPBasicKeyLess {
     }
 };
 
+enum tribool { indeterminate = -1, trifalse = 0, tritrue = 1 };
+
+inline bool is_true(tribool x)
+{
+    return x == tribool::tritrue;
+};
+
 // Convenience functions
 //! Checks equality for `a` and `b`
 bool eq(const Basic &a, const Basic &b);

--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -6,6 +6,7 @@
 #include <symengine/symengine_exception.h>
 #include <symengine/polys/uexprpoly.h>
 #include <symengine/solve.h>
+#include <symengine/test_visitors.h>
 
 namespace SymEngine
 {
@@ -831,7 +832,7 @@ void pivoted_fraction_free_gauss_jordan_elimination(const DenseMatrix &A,
 unsigned pivot(DenseMatrix &B, unsigned r, unsigned c)
 {
     for (unsigned k = r; k < B.row_; k++) {
-        if (not is_zero(*(B.m_[k * B.col_ + c]))) {
+        if (!is_true(is_zero(*(B.m_[k * B.col_ + c])))) {
             return k;
         }
     }
@@ -849,7 +850,7 @@ void reduced_row_echelon_form(const DenseMatrix &A, DenseMatrix &b,
     }
     unsigned row = 0;
     for (unsigned col = 0; col < b.col_ && row < b.row_; col++) {
-        if (is_zero(*b.get(row, col)))
+        if (is_true(is_zero(*b.get(row, col))))
             continue;
         pivot_cols.push_back(col);
         if (row == 0 and normalize_last) {
@@ -1170,7 +1171,7 @@ void pivoted_LU(const DenseMatrix &A, DenseMatrix &LU, permutelist &pl)
                 LU.m_[i * n + j] = sub(LU.m_[i * n + j],
                                        mul(LU.m_[i * n + k], LU.m_[k * n + j]));
             }
-            if (pivot == -1 and not is_zero(*LU.m_[i * n + j]))
+            if (pivot == -1 and !is_true(is_zero(*LU.m_[i * n + j])))
                 pivot = i;
         }
         if (pivot == -1)
@@ -1431,9 +1432,9 @@ RCP<const Basic> det_bareis(const DenseMatrix &A)
         RCP<const Basic> d;
 
         for (unsigned k = 0; k < n - 1; k++) {
-            if (is_zero(*B.m_[k * n + k])) {
+            if (is_true(is_zero(*B.m_[k * n + k]))) {
                 for (i = k + 1; i < n; i++)
-                    if (not is_zero(*B.m_[i * n + k])) {
+                    if (!is_true(is_zero(*B.m_[i * n + k]))) {
                         row_exchange_dense(B, i, k);
                         sign *= -1;
                         break;

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -2,6 +2,7 @@
 #include <symengine/pow.h>
 #include <symengine/complex.h>
 #include <symengine/symengine_exception.h>
+#include <symengine/test_visitors.h>
 
 namespace SymEngine
 {
@@ -166,7 +167,7 @@ void Mul::dict_add_term(map_basic_basic &d, const RCP<const Basic> &exp,
         } else {
             // General case:
             it->second = add(it->second, exp);
-            if (is_zero(*it->second)) {
+            if (is_number_and_zero(*it->second)) {
                 d.erase(it);
             }
         }
@@ -424,8 +425,8 @@ RCP<const Basic> mul(const vec_basic &a)
 
 RCP<const Basic> div(const RCP<const Basic> &a, const RCP<const Basic> &b)
 {
-    if (is_zero(*b)) {
-        if (is_zero(*a)) {
+    if (is_number_and_zero(*b)) {
+        if (is_number_and_zero(*a)) {
             return Nan;
         } else {
             return ComplexInf;

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -135,10 +135,12 @@ inline bool is_a_Number(const Basic &b)
 }
 
 //! \return true if 'b' is a Number and is zero
-inline bool is_zero(const Basic &b)
+inline bool is_number_and_zero(const Basic &b)
 {
     return is_a_Number(b) and down_cast<const Number &>(b).is_zero();
 }
+
+tribool is_zero(const Basic &b);
 
 class NumberWrapper : public Number
 {

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -2,6 +2,7 @@
 #include <symengine/add.h>
 #include <symengine/complex.h>
 #include <symengine/symengine_exception.h>
+#include <symengine/test_visitors.h>
 
 namespace SymEngine
 {
@@ -27,7 +28,7 @@ bool Pow::is_canonical(const Basic &base, const Basic &exp) const
     if (is_a<Integer>(base) and down_cast<const Integer &>(base).is_one())
         return false;
     // e.g. x**0.0
-    if (is_zero(exp))
+    if (is_number_and_zero(exp))
         return false;
     // e.g. x**1
     if (is_a<Integer>(exp) and down_cast<const Integer &>(exp).is_one())
@@ -89,7 +90,7 @@ int Pow::compare(const Basic &o) const
 
 RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
 {
-    if (is_zero(*b)) {
+    if (is_number_and_zero(*b)) {
         // addnum is used for converting to the type of `b`.
         return addnum(one, rcp_static_cast<const Number>(b));
     }

--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -6,6 +6,7 @@
 #include <symengine/constants.h>
 #include <symengine/symengine_exception.h>
 #include <symengine/visitor.h>
+#include <symengine/test_visitors.h>
 
 namespace SymEngine
 {
@@ -141,7 +142,7 @@ void CSRMatrix::set(unsigned i, unsigned j, const RCP<const Basic> &e)
         }
     }
 
-    if (not is_zero(*e)) {
+    if (!is_true(is_zero(*e))) {
         if (k < row_end and j_[k] == j) {
             x_[k] = e;
         } else { // j_[k] > j or k is the last non-zero element
@@ -490,7 +491,7 @@ CSRMatrix CSRMatrix::jacobian(const vec_basic &exprs, const vec_sym &x,
         p.push_back(p.back());
         for (unsigned ci = 0; ci < ncols; ++ci) {
             auto elem = exprs[ri]->diff(x[ci], diff_cache);
-            if (not is_zero(*elem)) {
+            if (!is_true(is_zero(*elem))) {
                 p.back()++;
                 j.push_back(ci);
                 elems.emplace_back(std::move(elem));
@@ -589,7 +590,7 @@ void csr_matmat_pass2(const CSRMatrix &A, const CSRMatrix &B, CSRMatrix &C)
 
         for (unsigned jj = 0; jj < length; jj++) {
 
-            if (not is_zero(*sums[head])) {
+            if (!is_true(is_zero(*sums[head]))) {
                 C.j_[nnz] = head;
                 C.x_[nnz] = sums[head];
                 nnz++;
@@ -646,7 +647,7 @@ void csr_scale_rows(CSRMatrix &A, const DenseMatrix &X)
     SYMENGINE_ASSERT(A.row_ == X.nrows() and X.ncols() == 1);
 
     for (unsigned i = 0; i < A.row_; i++) {
-        if (is_zero(*X.get(i, 0)))
+        if (is_true(is_zero(*X.get(i, 0))))
             throw SymEngineException("Scaling factor can't be zero");
         for (unsigned jj = A.p_[i]; jj < A.p_[i + 1]; jj++)
             A.x_[jj] = mul(A.x_[jj], X.get(i, 0));
@@ -663,7 +664,7 @@ void csr_scale_columns(CSRMatrix &A, const DenseMatrix &X)
     unsigned i;
 
     for (i = 0; i < A.col_; i++) {
-        if (is_zero(*X.get(i, 0)))
+        if (is_true(is_zero(*X.get(i, 0))))
             throw SymEngineException("Scaling factor can't be zero");
     }
 
@@ -700,7 +701,7 @@ void csr_binop_csr_canonical(
 
             if (A_j == B_j) {
                 RCP<const Basic> result = bin_op(A.x_[A_pos], B.x_[B_pos]);
-                if (not is_zero(*result)) {
+                if (!is_true(is_zero(*result))) {
                     C.j_.push_back(A_j);
                     C.x_.push_back(result);
                     nnz++;
@@ -709,7 +710,7 @@ void csr_binop_csr_canonical(
                 B_pos++;
             } else if (A_j < B_j) {
                 RCP<const Basic> result = bin_op(A.x_[A_pos], zero);
-                if (not is_zero(*result)) {
+                if (!is_true(is_zero(*result))) {
                     C.j_.push_back(A_j);
                     C.x_.push_back(result);
                     nnz++;
@@ -718,7 +719,7 @@ void csr_binop_csr_canonical(
             } else {
                 // B_j < A_j
                 RCP<const Basic> result = bin_op(zero, B.x_[B_pos]);
-                if (not is_zero(*result)) {
+                if (!is_true(is_zero(*result))) {
                     C.j_.push_back(B_j);
                     C.x_.push_back(result);
                     nnz++;
@@ -730,7 +731,7 @@ void csr_binop_csr_canonical(
         // tail
         while (A_pos < A_end) {
             RCP<const Basic> result = bin_op(A.x_[A_pos], zero);
-            if (not is_zero(*result)) {
+            if (!is_true(is_zero(*result))) {
                 C.j_.push_back(A.j_[A_pos]);
                 C.x_.push_back(result);
                 nnz++;
@@ -739,7 +740,7 @@ void csr_binop_csr_canonical(
         }
         while (B_pos < B_end) {
             RCP<const Basic> result = bin_op(zero, B.x_[B_pos]);
-            if (not is_zero(*result)) {
+            if (!is_true(is_zero(*result))) {
                 C.j_.push_back(B.j_[B_pos]);
                 C.x_.push_back(result);
                 nnz++;

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -1,0 +1,26 @@
+#include <symengine/test_visitors.h>
+
+namespace SymEngine
+{
+
+void ZeroVisitor::bvisit(const Number &x)
+{
+    if (bool(x.is_zero())) {
+        is_zero_ = tribool::tritrue;
+    } else {
+        is_zero_ = tribool::trifalse;
+    }
+}
+
+tribool ZeroVisitor::apply(const Basic &b)
+{
+    b.accept(*this);
+    return is_zero_;
+}
+
+tribool is_zero(const Basic &b)
+{
+    ZeroVisitor visitor;
+    return visitor.apply(b);
+}
+}

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -1,0 +1,45 @@
+#ifndef SYMENGINE_TEST_VISITORS_H
+#define SYMENGINE_TEST_VISITORS_H
+
+#include <symengine/visitor.h>
+
+namespace SymEngine
+{
+
+class ZeroVisitor : public BaseVisitor<ZeroVisitor>
+{
+private:
+    tribool is_zero_;
+
+public:
+    void bvisit(const Basic &x)
+    {
+        is_zero_ = tribool::indeterminate;
+    };
+    void bvisit(const Symbol &x)
+    {
+        is_zero_ = tribool::indeterminate;
+    };
+    void bvisit(const Number &x);
+    void bvisit(const Set &x)
+    {
+        is_zero_ = tribool::trifalse;
+    };
+    void bvisit(const Relational &x)
+    {
+        is_zero_ = tribool::trifalse;
+    };
+    void bvisit(const Boolean &x)
+    {
+        is_zero_ = tribool::trifalse;
+    };
+    void bvisit(const Constant &x)
+    {
+        is_zero_ = tribool::trifalse;
+    };
+
+    tribool apply(const Basic &b);
+};
+}
+
+#endif // SYMENGINE_TEST_VISITORS_H

--- a/symengine/tests/basic/CMakeLists.txt
+++ b/symengine/tests/basic/CMakeLists.txt
@@ -106,3 +106,7 @@ add_test(test_cse ${PROJECT_BINARY_DIR}/test_cse)
 add_executable(test_count_ops test_count_ops.cpp)
 target_link_libraries(test_count_ops symengine catch)
 add_test(test_count_ops ${PROJECT_BINARY_DIR}/test_count_ops)
+
+add_executable(test_test_visitors test_test_visitors.cpp)
+target_link_libraries(test_test_visitors symengine catch)
+add_test(test_test_visitors ${PROJECT_BINARY_DIR}/test_test_visitors)

--- a/symengine/tests/basic/test_test_visitors.cpp
+++ b/symengine/tests/basic/test_test_visitors.cpp
@@ -1,0 +1,47 @@
+#include "catch.hpp"
+#include <symengine/test_visitors.h>
+#include <symengine/sets.h>
+
+using SymEngine::symbol;
+using SymEngine::tribool;
+using SymEngine::integer;
+using SymEngine::Number;
+using SymEngine::Basic;
+using SymEngine::Symbol;
+using SymEngine::Rational;
+using SymEngine::RCP;
+using SymEngine::interval;
+using SymEngine::Set;
+using SymEngine::Complex;
+using SymEngine::pi;
+using SymEngine::boolTrue;
+
+TEST_CASE("Test is zero", "[is_zero]")
+{
+    RCP<const Basic> x = symbol("x");
+    RCP<const Number> i1 = integer(0);
+    RCP<const Number> i2 = integer(3);
+    RCP<const Basic> rat1 = Rational::from_two_ints(*integer(5), *integer(6));
+    RCP<const Basic> rat2 = Rational::from_two_ints(*integer(0), *integer(1));
+    RCP<const Basic> s1 = interval(i1, i2);
+    RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
+    RCP<const Basic> rel1 = Eq(x, i1);
+    RCP<const Basic> rel2 = Lt(x, i1);
+    RCP<const Symbol> t = symbol("t");
+    RCP<const Basic> f = function_symbol("f", t);
+    RCP<const Basic> d1 = f->diff(t);
+
+    REQUIRE(is_zero(*x) == tribool::indeterminate);
+    REQUIRE(is_true(is_zero(*i1)));
+    REQUIRE(is_zero(*i2) == tribool::trifalse);
+    REQUIRE(is_zero(*rat1) == tribool::trifalse);
+    REQUIRE(is_zero(*rat2) == tribool::tritrue);
+    REQUIRE(is_zero(*s1) == tribool::trifalse);
+    REQUIRE(is_zero(*c1) == tribool::trifalse);
+    REQUIRE(is_zero(*rel1) == tribool::trifalse);
+    REQUIRE(is_zero(*rel2) == tribool::trifalse);
+    REQUIRE(is_zero(*pi) == tribool::trifalse);
+    REQUIRE(is_zero(*d1) == tribool::indeterminate);
+    REQUIRE(is_zero(*boolTrue) == tribool::trifalse);
+    REQUIRE(is_zero(*pi) == tribool::trifalse);
+}


### PR DESCRIPTION
This is a reimplementation of the `is_zero` function. It can now return a `tribool` with an additional indeterminate value. It is implemented using a visitor, which so far doesn't have much more functionality than before, but has the potential. 

Future extension could be:
* Enable the visitor to use a context i.e. assumptions
* Other tests like `is_positive` and `is_real`
* More advanced zero-testing, e.g. for `mul` to check if any factor is zero etc