### PR TITLE
Fix broken test created by change in is_zero function

### DIFF
--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -71,7 +71,7 @@ bool DenseMatrix::is_lower() const
     unsigned n = A.nrows();
     for (unsigned i = 1; i < n; ++i) {
         for (unsigned j = 0; j < i; ++j) {
-            if (not is_true(is_zero(*A.get(i, j)))) {
+            if (not is_number_and_zero(*A.get(i, j))) {
                 return false;
             }
         }
@@ -85,7 +85,7 @@ bool DenseMatrix::is_upper() const
     unsigned n = A.nrows();
     for (unsigned i = 0; i < n - 1; ++i) {
         for (unsigned j = i + 1; j < n; ++j) {
-            if (not is_true(is_zero(*A.get(i, j)))) {
+            if (not is_number_and_zero(*A.get(i, j))) {
                 return false;
             }
         }

--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -71,7 +71,7 @@ bool DenseMatrix::is_lower() const
     unsigned n = A.nrows();
     for (unsigned i = 1; i < n; ++i) {
         for (unsigned j = 0; j < i; ++j) {
-            if (not is_zero(*A.get(i, j))) {
+            if (not is_true(is_zero(*A.get(i, j)))) {
                 return false;
             }
         }
@@ -85,7 +85,7 @@ bool DenseMatrix::is_upper() const
     unsigned n = A.nrows();
     for (unsigned i = 0; i < n - 1; ++i) {
         for (unsigned j = i + 1; j < n; ++j) {
-            if (not is_zero(*A.get(i, j))) {
+            if (not is_true(is_zero(*A.get(i, j)))) {
                 return false;
             }
         }


### PR DESCRIPTION
The author of PR #1698 modified the code for is_zero in all the locations, however since #1651 was merged after that, the is_zero modification which had been made for all other functions by @rikardn was not there. This short PR fixes that issue.

Also, there is no `is_false(tribool x)`, would it be a good idea to have one, @isuruf ?  