### PR TITLE
csr_binop_csr_canonical bugfixes

### DIFF
--- a/symengine/sparse_matrix.cpp
+++ b/symengine/sparse_matrix.cpp
@@ -393,7 +393,7 @@ bool CSRMatrix::csr_has_duplicates(const std::vector<unsigned> &p_,
                                    unsigned row_)
 {
     for (unsigned i = 0; i < row_; i++) {
-        for (unsigned j = p_[i]; j < p_[i + 1] - 1; j++) {
+        for (unsigned j = p_[i]; j + 1 < p_[i + 1]; j++) {
             if (j_[j] == j_[j + 1])
                 return true;
         }
@@ -685,6 +685,8 @@ void csr_binop_csr_canonical(
 
     // Method that works for canonical CSR matrices
     C.p_[0] = 0;
+    C.j_.clear();
+    C.x_.clear();
     unsigned nnz = 0;
     unsigned A_pos, B_pos, A_end, B_end;
 

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -1855,6 +1855,12 @@ TEST_CASE("test_csr_binop_csr_canonical(): matrices", "[matrices]")
                            {integer(1), integer(7), integer(2), integer(8),
                             integer(9), integer(3), integer(4), integer(5),
                             integer(6)}));
+
+    A = CSRMatrix(2, 2, {0, 1, 2}, {0, 1}, {integer(1), integer(2)});
+    B = CSRMatrix(2, 2, {0, 1, 2}, {1, 0}, {integer(3), integer(4)});
+    C = CSRMatrix(2, 2);
+    csr_binop_csr_canonical(A, B, C, mul);
+    REQUIRE(C == CSRMatrix(2, 2));
 }
 
 TEST_CASE("test_csr_elementwise_mul(): matrices", "[matrices]")


### PR DESCRIPTION
  - don't subtract 1 from an unsigned int that may be 0
  - clear any existing data/indices before appending new values
  - add test case copied from #1694
  - resolves #1694
