### PR TITLE
Add is_real function

### DIFF
--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -242,7 +242,7 @@ inline tribool and_tribool(tribool a, tribool b)
     if (!(a & b)) {
         return tribool::trifalse;
     } else {
-        return (tribool) (a | b);
+        return (tribool)(a | b);
     }
 };
 
@@ -251,7 +251,7 @@ inline tribool not_tribool(tribool a)
     if (is_indeterminate(a))
         return a;
     else
-        return (tribool) !a;
+        return (tribool)!a;
 };
 
 // The weak kleene conjunction
@@ -261,7 +261,7 @@ inline tribool andwk_tribool(tribool a, tribool b)
     if (is_indeterminate(a) or is_indeterminate(b))
         return tribool::indeterminate;
     else
-        return (tribool) (a && b);
+        return (tribool)(a && b);
 };
 
 // Convenience functions

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -227,6 +227,43 @@ inline bool is_true(tribool x)
     return x == tribool::tritrue;
 };
 
+inline bool is_false(tribool x)
+{
+    return x == tribool::trifalse;
+};
+
+inline bool is_indeterminate(tribool x)
+{
+    return x == tribool::indeterminate;
+};
+
+inline tribool and_tribool(tribool a, tribool b)
+{
+    if (!(a & b)) {
+        return tribool::trifalse;
+    } else {
+        return (tribool) (a | b);
+    }
+};
+
+inline tribool not_tribool(tribool a)
+{
+    if (is_indeterminate(a))
+        return a;
+    else
+        return (tribool) !a;
+};
+
+// The weak kleene conjunction
+// Indeterminate if any indeterminate otherwise like regular and
+inline tribool andwk_tribool(tribool a, tribool b)
+{
+    if (is_indeterminate(a) or is_indeterminate(b))
+        return tribool::indeterminate;
+    else
+        return (tribool) (a && b);
+};
+
 // Convenience functions
 //! Checks equality for `a` and `b`
 bool eq(const Basic &a, const Basic &b);

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -141,6 +141,7 @@ inline bool is_number_and_zero(const Basic &b)
 }
 
 tribool is_zero(const Basic &b);
+tribool is_real(const Basic &b);
 
 class NumberWrapper : public Number
 {

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -23,4 +23,46 @@ tribool is_zero(const Basic &b)
     ZeroVisitor visitor;
     return visitor.apply(b);
 }
+
+void RealVisitor::bvisit(const Number &x)
+{
+    if (is_a<Complex>(x) or is_a<Infty>(x) or is_a<NaN>(x)) {
+        is_real_ = tribool::trifalse;
+    } else {
+        is_real_ = tribool::tritrue;
+    }
+}
+
+void RealVisitor::bvisit(const Constant &x)
+{
+    if (eq(x, *pi) or eq(x, *E) or eq(x, *EulerGamma) or eq(x, *Catalan)
+        or eq(x, *GoldenRatio)) {
+        is_real_ = tribool::tritrue;
+    } else {
+        is_real_ = tribool::indeterminate;
+    }
+}
+
+void RealVisitor::bvisit(const Add &x)
+{
+    tribool b = tribool::tritrue;
+    for (const auto &arg : x.get_args()) {
+        arg->accept(*this);
+        b = andwk_tribool(b, is_real_);
+        if (is_indeterminate(b))
+            return;
+    }
+}
+
+tribool RealVisitor::apply(const Basic &b)
+{
+    b.accept(*this);
+    return is_real_;
+}
+
+tribool is_real(const Basic &b)
+{
+    RealVisitor visitor;
+    return visitor.apply(b);
+}
 }

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -40,6 +40,39 @@ public:
 
     tribool apply(const Basic &b);
 };
+
+class RealVisitor : public BaseVisitor<RealVisitor>
+{
+private:
+    tribool is_real_;
+
+public:
+    void bvisit(const Basic &x)
+    {
+        is_real_ = tribool::indeterminate;
+    };
+    void bvisit(const Symbol &x)
+    {
+        is_real_ = tribool::indeterminate;
+    };
+    void bvisit(const Number &x);
+    void bvisit(const Set &x)
+    {
+        is_real_ = tribool::trifalse;
+    };
+    void bvisit(const Relational &x)
+    {
+        is_real_ = tribool::trifalse;
+    };
+    void bvisit(const Boolean &x)
+    {
+        is_real_ = tribool::trifalse;
+    };
+    void bvisit(const Constant &x);
+    void bvisit(const Add &x);
+
+    tribool apply(const Basic &b);
+};
 }
 
 #endif // SYMENGINE_TEST_VISITORS_H

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -1121,9 +1121,12 @@ TEST_CASE("tribool", "[basic]")
     REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::tritrue)));
     REQUIRE(is_false(and_tribool(tribool::indeterminate, tribool::trifalse)));
     REQUIRE(is_false(and_tribool(tribool::tritrue, tribool::trifalse)));
-    REQUIRE(is_indeterminate(and_tribool(tribool::indeterminate, tribool::indeterminate)));
-    REQUIRE(is_indeterminate(and_tribool(tribool::tritrue, tribool::indeterminate)));
-    REQUIRE(is_indeterminate(and_tribool(tribool::indeterminate, tribool::tritrue)));
+    REQUIRE(is_indeterminate(
+        and_tribool(tribool::indeterminate, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        and_tribool(tribool::tritrue, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        and_tribool(tribool::indeterminate, tribool::tritrue)));
     REQUIRE(is_true(and_tribool(tribool::tritrue, tribool::tritrue)));
 
     REQUIRE(is_true(not_tribool(tribool::trifalse)));
@@ -1131,12 +1134,17 @@ TEST_CASE("tribool", "[basic]")
     REQUIRE(is_indeterminate(not_tribool(tribool::indeterminate)));
 
     REQUIRE(is_false(andwk_tribool(tribool::trifalse, tribool::trifalse)));
-    REQUIRE(is_indeterminate(andwk_tribool(tribool::trifalse, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::trifalse, tribool::indeterminate)));
     REQUIRE(is_false(andwk_tribool(tribool::trifalse, tribool::tritrue)));
-    REQUIRE(is_indeterminate(andwk_tribool(tribool::indeterminate, tribool::trifalse)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::indeterminate, tribool::trifalse)));
     REQUIRE(is_false(andwk_tribool(tribool::tritrue, tribool::trifalse)));
-    REQUIRE(is_indeterminate(andwk_tribool(tribool::indeterminate, tribool::indeterminate)));
-    REQUIRE(is_indeterminate(andwk_tribool(tribool::tritrue, tribool::indeterminate)));
-    REQUIRE(is_indeterminate(andwk_tribool(tribool::indeterminate, tribool::tritrue)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::indeterminate, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::tritrue, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::indeterminate, tribool::tritrue)));
     REQUIRE(is_true(andwk_tribool(tribool::tritrue, tribool::tritrue)));
 }

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include <symengine/basic.h>
 #include <symengine/visitor.h>
 #include <symengine/eval_double.h>
 #include <symengine/derivative.h>
@@ -51,6 +52,7 @@ using SymEngine::ComplexInf;
 using SymEngine::Nan;
 using SymEngine::EulerGamma;
 using SymEngine::atoms;
+using SymEngine::tribool;
 
 using namespace SymEngine::literals;
 
@@ -1098,4 +1100,43 @@ TEST_CASE("args: Basic", "[basic]")
 
     r1 = log(pi);
     REQUIRE(vec_basic_eq_perm(r1->get_args(), {pi}));
+}
+
+TEST_CASE("tribool", "[basic]")
+{
+    REQUIRE(!is_true(tribool::indeterminate));
+    REQUIRE(!is_true(tribool::trifalse));
+    REQUIRE(is_true(tribool::tritrue));
+
+    REQUIRE(!is_false(tribool::indeterminate));
+    REQUIRE(is_false(tribool::trifalse));
+    REQUIRE(!is_false(tribool::tritrue));
+
+    REQUIRE(is_indeterminate(tribool::indeterminate));
+    REQUIRE(!is_indeterminate(tribool::trifalse));
+    REQUIRE(!is_indeterminate(tribool::tritrue));
+
+    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::trifalse)));
+    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::indeterminate)));
+    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::tritrue)));
+    REQUIRE(is_false(and_tribool(tribool::indeterminate, tribool::trifalse)));
+    REQUIRE(is_false(and_tribool(tribool::tritrue, tribool::trifalse)));
+    REQUIRE(is_indeterminate(and_tribool(tribool::indeterminate, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(and_tribool(tribool::tritrue, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(and_tribool(tribool::indeterminate, tribool::tritrue)));
+    REQUIRE(is_true(and_tribool(tribool::tritrue, tribool::tritrue)));
+
+    REQUIRE(is_true(not_tribool(tribool::trifalse)));
+    REQUIRE(is_false(not_tribool(tribool::tritrue)));
+    REQUIRE(is_indeterminate(not_tribool(tribool::indeterminate)));
+
+    REQUIRE(is_false(andwk_tribool(tribool::trifalse, tribool::trifalse)));
+    REQUIRE(is_indeterminate(andwk_tribool(tribool::trifalse, tribool::indeterminate)));
+    REQUIRE(is_false(andwk_tribool(tribool::trifalse, tribool::tritrue)));
+    REQUIRE(is_indeterminate(andwk_tribool(tribool::indeterminate, tribool::trifalse)));
+    REQUIRE(is_false(andwk_tribool(tribool::tritrue, tribool::trifalse)));
+    REQUIRE(is_indeterminate(andwk_tribool(tribool::indeterminate, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(andwk_tribool(tribool::tritrue, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(andwk_tribool(tribool::indeterminate, tribool::tritrue)));
+    REQUIRE(is_true(andwk_tribool(tribool::tritrue, tribool::tritrue)));
 }

--- a/symengine/tests/basic/test_test_visitors.cpp
+++ b/symengine/tests/basic/test_test_visitors.cpp
@@ -15,6 +15,8 @@ using SymEngine::Set;
 using SymEngine::Complex;
 using SymEngine::pi;
 using SymEngine::boolTrue;
+using SymEngine::Inf;
+using SymEngine::Nan;
 
 TEST_CASE("Test is zero", "[is_zero]")
 {
@@ -44,4 +46,37 @@ TEST_CASE("Test is zero", "[is_zero]")
     REQUIRE(is_zero(*d1) == tribool::indeterminate);
     REQUIRE(is_zero(*boolTrue) == tribool::trifalse);
     REQUIRE(is_zero(*pi) == tribool::trifalse);
+}
+
+TEST_CASE("Test is_real", "[is_real]")
+{
+    RCP<const Basic> x = symbol("x");
+    RCP<const Number> i1 = integer(0);
+    RCP<const Number> i2 = integer(3);
+    RCP<const Basic> rat1 = Rational::from_two_ints(*integer(5), *integer(6));
+    RCP<const Basic> s1 = interval(i1, i2);
+    RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
+    RCP<const Basic> rel1 = Eq(x, i1);
+    RCP<const Symbol> t = symbol("t");
+    RCP<const Basic> f = function_symbol("f", t);
+    RCP<const Basic> d1 = f->diff(t);
+    RCP<const Basic> e1 = add(x, x);
+    RCP<const Basic> e2 = add(x, Inf);
+    RCP<const Basic> e3 = add(x, c1);
+
+    REQUIRE(is_indeterminate(is_real(*x)));
+    REQUIRE(is_true(is_real(*i1)));
+    REQUIRE(is_true(is_real(*i2)));
+    REQUIRE(is_true(is_real(*rat1)));
+    REQUIRE(is_false(is_real(*s1)));
+    REQUIRE(is_false(is_real(*c1)));
+    REQUIRE(is_false(is_real(*rel1)));
+    REQUIRE(is_true(is_real(*pi)));
+    REQUIRE(is_indeterminate(is_real(*d1)));
+    REQUIRE(is_false(is_real(*boolTrue)));
+    REQUIRE(is_indeterminate(is_real(*e1)));
+    REQUIRE(is_indeterminate(is_real(*e2)));
+    REQUIRE(is_indeterminate(is_real(*e3)));
+    REQUIRE(is_false(is_real(*Inf)));
+    REQUIRE(is_false(is_real(*Nan)));
 }


### PR DESCRIPTION
Add is_real function and more  helper functions for tribool.

The implementation of ```is_real``` is mostly trivial except for the visit of ```Add```. It uses the weak Kleene conjunction which is just a fancy name for what is called  ```fuzzy_group``` in sympy.