### PR TITLE
Add tests for diagonal dominance for DenseMatrix

### DIFF
--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -194,6 +194,64 @@ tribool DenseMatrix::is_hermitian() const
     return cur;
 }
 
+tribool DenseMatrix::is_weakly_diagonally_dominant() const
+{
+    auto A = *this;
+    if (not A.is_square()) {
+        return tribool::trifalse;
+    }
+
+    unsigned ncols = A.ncols();
+    RCP<const Basic> diag;
+    RCP<const Basic> sum;
+    tribool diagdom = tribool::tritrue;
+    for (unsigned i = 0; i < ncols; i++) {
+        sum = zero;
+        for (unsigned j = 0; j < ncols; j++) {
+            auto &e = m_[i * ncols + j];
+            if (i == j) {
+                diag = abs(e);
+            } else {
+                sum = add(sum, abs(e));
+            }
+        }
+        diagdom = and_tribool(diagdom, is_nonnegative(*sub(diag, sum)));
+        if (is_false(diagdom)) {
+            return diagdom;
+        }
+    }
+    return diagdom;
+}
+
+tribool DenseMatrix::is_strictly_diagonally_dominant() const
+{
+    auto A = *this;
+    if (not A.is_square()) {
+        return tribool::trifalse;
+    }
+
+    unsigned ncols = A.ncols();
+    RCP<const Basic> diag;
+    RCP<const Basic> sum;
+    tribool diagdom = tribool::tritrue;
+    for (unsigned i = 0; i < ncols; i++) {
+        sum = zero;
+        for (unsigned j = 0; j < ncols; j++) {
+            auto &e = m_[i * ncols + j];
+            if (i == j) {
+                diag = abs(e);
+            } else {
+                sum = add(sum, abs(e));
+            }
+        }
+        diagdom = and_tribool(diagdom, is_positive(*sub(diag, sum)));
+        if (is_false(diagdom)) {
+            return diagdom;
+        }
+    }
+    return diagdom;
+}
+
 RCP<const Basic> DenseMatrix::det() const
 {
     return det_bareis(*this);

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -136,6 +136,8 @@ public:
     virtual tribool is_real() const;
     virtual tribool is_symmetric() const;
     virtual tribool is_hermitian() const;
+    virtual tribool is_weakly_diagonally_dominant() const;
+    virtual tribool is_strictly_diagonally_dominant() const;
 
     virtual unsigned rank() const;
     virtual RCP<const Basic> det() const;

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -2212,3 +2212,67 @@ TEST_CASE("is_hermitian(): DenseMatrix", "[matrices]")
     REQUIRE(is_true(G.is_hermitian()));
     REQUIRE(is_false(H.is_hermitian()));
 }
+
+TEST_CASE("is_weakly_diagonally_dominant(): DenseMatrix", "[matrices]")
+{
+    auto c1 = complex_double(std::complex<double>(2, 1));
+    auto c2 = complex_double(std::complex<double>(2, -1));
+    auto c3 = complex_double(std::complex<double>(2, -2));
+    DenseMatrix A
+        = DenseMatrix(2, 2, {integer(0), integer(0), integer(0), integer(0)});
+    DenseMatrix B = DenseMatrix(2, 2, {integer(2), c1, c2, integer(3)});
+    DenseMatrix C = DenseMatrix(2, 2, {symbol("z"), c1, c2, integer(3)});
+    DenseMatrix D = DenseMatrix(3, 4);
+    DenseMatrix E = DenseMatrix(1, 1, {c1});
+    DenseMatrix F = DenseMatrix(1, 1, {integer(2)});
+    DenseMatrix G = DenseMatrix(2, 2, {integer(2), c1, c1, integer(3)});
+    DenseMatrix H
+        = DenseMatrix(2, 2, {integer(2), symbol("z"), c1, integer(3)});
+    DenseMatrix K = DenseMatrix(1, 1, {integer(0)});
+    DenseMatrix L = DenseMatrix(3, 3, {integer(2), integer(-1), integer(1),
+                                       integer(2), integer(4), rational(1, 2),
+                                       integer(7), integer(-3), integer(5)});
+
+    REQUIRE(is_true(A.is_weakly_diagonally_dominant()));
+    REQUIRE(is_false(B.is_weakly_diagonally_dominant()));
+    REQUIRE(is_indeterminate(C.is_weakly_diagonally_dominant()));
+    REQUIRE(is_false(D.is_weakly_diagonally_dominant()));
+    REQUIRE(is_true(E.is_weakly_diagonally_dominant()));
+    REQUIRE(is_true(F.is_weakly_diagonally_dominant()));
+    REQUIRE(is_false(G.is_weakly_diagonally_dominant()));
+    REQUIRE(is_indeterminate(H.is_weakly_diagonally_dominant()));
+    REQUIRE(is_true(K.is_weakly_diagonally_dominant()));
+    REQUIRE(is_false(L.is_weakly_diagonally_dominant()));
+}
+
+TEST_CASE("is_strictly_diagonally_dominant(): DenseMatrix", "[matrices]")
+{
+    auto c1 = complex_double(std::complex<double>(2, 1));
+    auto c2 = complex_double(std::complex<double>(2, -1));
+    auto c3 = complex_double(std::complex<double>(2, -2));
+    DenseMatrix A
+        = DenseMatrix(2, 2, {integer(0), integer(0), integer(0), integer(0)});
+    DenseMatrix B = DenseMatrix(2, 2, {integer(2), c1, c2, integer(3)});
+    DenseMatrix C = DenseMatrix(2, 2, {symbol("z"), c1, c2, integer(3)});
+    DenseMatrix D = DenseMatrix(3, 4);
+    DenseMatrix E = DenseMatrix(1, 1, {c1});
+    DenseMatrix F = DenseMatrix(1, 1, {integer(2)});
+    DenseMatrix G = DenseMatrix(2, 2, {integer(2), c1, c1, integer(3)});
+    DenseMatrix H
+        = DenseMatrix(2, 2, {integer(2), symbol("z"), c1, integer(3)});
+    DenseMatrix K = DenseMatrix(1, 1, {integer(0)});
+    DenseMatrix L = DenseMatrix(3, 3, {integer(2), integer(-1), integer(1),
+                                       integer(2), integer(4), rational(1, 2),
+                                       integer(7), integer(-3), integer(5)});
+
+    REQUIRE(is_false(A.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(B.is_strictly_diagonally_dominant()));
+    REQUIRE(is_indeterminate(C.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(D.is_strictly_diagonally_dominant()));
+    REQUIRE(is_true(E.is_strictly_diagonally_dominant()));
+    REQUIRE(is_true(F.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(G.is_strictly_diagonally_dominant()));
+    REQUIRE(is_indeterminate(H.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(K.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(L.is_strictly_diagonally_dominant()));
+}


### PR DESCRIPTION
Add the `is_weakly_diagonally_dominant` and `is_strictly_diagonally_dominant` member functions for `DenseMatrix`. The code for the two functions is duplicated except for one function call. I failed to find a way of avoiding code duplication that was as performant and easy to read.