### PR TITLE
is_positive_definite for DenseMatrix

### DIFF
--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -256,7 +256,7 @@ tribool DenseMatrix::shortcut_to_posdef() const
 {
     tribool is_diagonal_positive = tribool::tritrue;
     unsigned offset = 0;
-    for (unsigned i = 1; i < row_; i++) {
+    for (unsigned i = 0; i < row_; i++) {
         is_diagonal_positive
             = and_tribool(is_diagonal_positive, is_positive(*m_[offset]));
         if (is_false(is_diagonal_positive))
@@ -312,6 +312,13 @@ tribool DenseMatrix::is_positive_definite() const
         B = std::unique_ptr<DenseMatrix>(new DenseMatrix(A));
     }
     return B->is_positive_definite_GE();
+}
+
+tribool DenseMatrix::is_negative_definite() const
+{
+    auto res = DenseMatrix(row_, col_);
+    mul_dense_scalar(*this, integer(-1), res);
+    return res.is_positive_definite();
 }
 
 RCP<const Basic> DenseMatrix::det() const

--- a/symengine/dense_matrix.cpp
+++ b/symengine/dense_matrix.cpp
@@ -194,6 +194,64 @@ tribool DenseMatrix::is_hermitian() const
     return cur;
 }
 
+tribool DenseMatrix::is_weakly_diagonally_dominant() const
+{
+    auto A = *this;
+    if (not A.is_square()) {
+        return tribool::trifalse;
+    }
+
+    unsigned ncols = A.ncols();
+    RCP<const Basic> diag;
+    RCP<const Basic> sum;
+    tribool diagdom = tribool::tritrue;
+    for (unsigned i = 0; i < ncols; i++) {
+        sum = zero;
+        for (unsigned j = 0; j < ncols; j++) {
+            auto &e = m_[i * ncols + j];
+            if (i == j) {
+                diag = abs(e);
+            } else {
+                sum = add(sum, abs(e));
+            }
+        }
+        diagdom = and_tribool(diagdom, is_nonnegative(*sub(diag, sum)));
+        if (is_false(diagdom)) {
+            return diagdom;
+        }
+    }
+    return diagdom;
+}
+
+tribool DenseMatrix::is_strictly_diagonally_dominant() const
+{
+    auto A = *this;
+    if (not A.is_square()) {
+        return tribool::trifalse;
+    }
+
+    unsigned ncols = A.ncols();
+    RCP<const Basic> diag;
+    RCP<const Basic> sum;
+    tribool diagdom = tribool::tritrue;
+    for (unsigned i = 0; i < ncols; i++) {
+        sum = zero;
+        for (unsigned j = 0; j < ncols; j++) {
+            auto &e = m_[i * ncols + j];
+            if (i == j) {
+                diag = abs(e);
+            } else {
+                sum = add(sum, abs(e));
+            }
+        }
+        diagdom = and_tribool(diagdom, is_positive(*sub(diag, sum)));
+        if (is_false(diagdom)) {
+            return diagdom;
+        }
+    }
+    return diagdom;
+}
+
 RCP<const Basic> DenseMatrix::det() const
 {
     return det_bareis(*this);

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -138,6 +138,7 @@ public:
     virtual tribool is_hermitian() const;
     virtual tribool is_weakly_diagonally_dominant() const;
     virtual tribool is_strictly_diagonally_dominant() const;
+    virtual tribool is_positive_definite() const;
 
     virtual unsigned rank() const;
     virtual RCP<const Basic> det() const;
@@ -329,6 +330,9 @@ private:
     // Stores the dimension of the Matrix
     unsigned row_;
     unsigned col_;
+
+    tribool shortcut_to_posdef() const;
+    tribool is_positive_definite_GE();
 };
 
 // ----------------------------- Sparse Matrices -----------------------------//

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -136,6 +136,8 @@ public:
     virtual tribool is_real() const;
     virtual tribool is_symmetric() const;
     virtual tribool is_hermitian() const;
+    virtual tribool is_weakly_diagonally_dominant() const;
+    virtual tribool is_strictly_diagonally_dominant() const;
 
     virtual unsigned rank() const;
     virtual RCP<const Basic> det() const;

--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -139,6 +139,7 @@ public:
     virtual tribool is_weakly_diagonally_dominant() const;
     virtual tribool is_strictly_diagonally_dominant() const;
     virtual tribool is_positive_definite() const;
+    virtual tribool is_negative_definite() const;
 
     virtual unsigned rank() const;
     virtual RCP<const Basic> det() const;

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -2278,7 +2278,7 @@ TEST_CASE("is_strictly_diagonally_dominant(): DenseMatrix", "[matrices]")
     REQUIRE(is_false(L.is_strictly_diagonally_dominant()));
 }
 
-TEST_CASE("is_positive_definite(): DenseMatrix", "[matrices]")
+TEST_CASE("definiteness: DenseMatrix", "[matrices]")
 {
     DenseMatrix A = DenseMatrix(3, 3, {integer(2), integer(-1), integer(0),
                                        integer(-1), integer(2), integer(-1),
@@ -2315,17 +2315,37 @@ TEST_CASE("is_positive_definite(): DenseMatrix", "[matrices]")
     DenseMatrix N
         = DenseMatrix(2, 2, {integer(2), integer(0), integer(-1), integer(2)});
     DenseMatrix P = DenseMatrix(2, 1, {integer(2), integer(0)});
+    DenseMatrix Q = DenseMatrix(1, 1, {integer(-1)});
+    DenseMatrix R
+        = DenseMatrix(2, 2, {integer(1), integer(0), integer(0), integer(-23)});
 
     REQUIRE(is_true(A.is_positive_definite()));
+    REQUIRE(is_false(A.is_negative_definite()));
     REQUIRE(is_true(B.is_positive_definite()));
+    REQUIRE(is_false(B.is_negative_definite()));
     REQUIRE(is_false(C.is_positive_definite()));
+    REQUIRE(is_false(C.is_negative_definite()));
     REQUIRE(is_false(D.is_positive_definite()));
+    REQUIRE(is_false(D.is_negative_definite()));
     REQUIRE(is_true(E.is_positive_definite()));
+    REQUIRE(is_false(E.is_negative_definite()));
     REQUIRE(is_true(F.is_positive_definite()));
+    REQUIRE(is_false(F.is_negative_definite()));
     REQUIRE(is_indeterminate(G.is_positive_definite()));
+    REQUIRE(is_indeterminate(G.is_negative_definite()));
     REQUIRE(is_true(H.is_positive_definite()));
+    REQUIRE(is_false(H.is_negative_definite()));
     REQUIRE(is_false(L.is_positive_definite()));
+    REQUIRE(is_false(L.is_negative_definite()));
     REQUIRE(is_false(M.is_positive_definite()));
+    REQUIRE(is_false(M.is_negative_definite()));
+    REQUIRE(is_true(N.is_positive_definite()));
+    REQUIRE(is_false(N.is_negative_definite()));
     REQUIRE(is_true(N.is_positive_definite()));
     REQUIRE(is_false(P.is_positive_definite()));
+    REQUIRE(is_false(P.is_negative_definite()));
+    REQUIRE(is_false(Q.is_positive_definite()));
+    REQUIRE(is_true(Q.is_negative_definite()));
+    REQUIRE(is_false(R.is_positive_definite()));
+    REQUIRE(is_false(R.is_negative_definite()));
 }

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -2212,3 +2212,67 @@ TEST_CASE("is_hermitian(): DenseMatrix", "[matrices]")
     REQUIRE(is_true(G.is_hermitian()));
     REQUIRE(is_false(H.is_hermitian()));
 }
+
+TEST_CASE("is_weakly_diagonally_dominant(): DenseMatrix", "[matrices]")
+{
+    auto c1 = complex_double(std::complex<double>(2, 1));
+    auto c2 = complex_double(std::complex<double>(2, -1));
+    auto c3 = complex_double(std::complex<double>(2, -2));
+    DenseMatrix A
+        = DenseMatrix(2, 2, {integer(0), integer(0), integer(0), integer(0)});
+    DenseMatrix B = DenseMatrix(2, 2, {integer(2), c1, c2, integer(3)});
+    DenseMatrix C = DenseMatrix(2, 2, {symbol("z"), c1, c2, integer(3)});
+    DenseMatrix D = DenseMatrix(3, 4);
+    DenseMatrix E = DenseMatrix(1, 1, {c1});
+    DenseMatrix F = DenseMatrix(1, 1, {integer(2)});
+    DenseMatrix G = DenseMatrix(2, 2, {integer(2), c1, c1, integer(3)});
+    DenseMatrix H
+        = DenseMatrix(2, 2, {integer(2), symbol("z"), c1, integer(3)});
+    DenseMatrix K = DenseMatrix(1, 1, {integer(0)});
+    DenseMatrix L = DenseMatrix(3, 3, {integer(2), integer(-1), integer(1),
+                                       integer(2), integer(4), rational(1, 2),
+                                       integer(7), integer(-3), integer(5)});
+
+    REQUIRE(is_true(A.is_weakly_diagonally_dominant()));
+    REQUIRE(is_false(B.is_weakly_diagonally_dominant()));
+    REQUIRE(is_indeterminate(C.is_weakly_diagonally_dominant()));
+    REQUIRE(is_false(D.is_weakly_diagonally_dominant()));
+    REQUIRE(is_true(E.is_weakly_diagonally_dominant()));
+    REQUIRE(is_true(F.is_weakly_diagonally_dominant()));
+    REQUIRE(is_false(G.is_weakly_diagonally_dominant()));
+    REQUIRE(is_indeterminate(H.is_weakly_diagonally_dominant()));
+    REQUIRE(is_true(K.is_weakly_diagonally_dominant()));
+    REQUIRE(is_false(L.is_weakly_diagonally_dominant()));
+}
+
+TEST_CASE("is_strictly_diagonally_dominant(): DenseMatrix", "[matrices]")
+{
+    auto c1 = complex_double(std::complex<double>(2, 1));
+    auto c2 = complex_double(std::complex<double>(2, -1));
+    auto c3 = complex_double(std::complex<double>(2, -2));
+    DenseMatrix A
+        = DenseMatrix(2, 2, {integer(0), integer(0), integer(0), integer(0)});
+    DenseMatrix B = DenseMatrix(2, 2, {integer(2), c1, c2, integer(3)});
+    DenseMatrix C = DenseMatrix(2, 2, {symbol("z"), c1, c2, integer(3)});
+    DenseMatrix D = DenseMatrix(3, 4);
+    DenseMatrix E = DenseMatrix(1, 1, {c1});
+    DenseMatrix F = DenseMatrix(1, 1, {integer(2)});
+    DenseMatrix G = DenseMatrix(2, 2, {integer(2), c1, c1, integer(3)});
+    DenseMatrix H
+        = DenseMatrix(2, 2, {integer(2), symbol("z"), c1, integer(3)});
+    DenseMatrix K = DenseMatrix(1, 1, {integer(0)});
+    DenseMatrix L = DenseMatrix(3, 3, {integer(2), integer(-1), integer(1),
+                                       integer(2), integer(4), rational(1, 2),
+                                       integer(7), integer(-3), integer(5)});
+
+    REQUIRE(is_false(A.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(B.is_strictly_diagonally_dominant()));
+    REQUIRE(is_indeterminate(C.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(D.is_strictly_diagonally_dominant()));
+    REQUIRE(is_true(E.is_strictly_diagonally_dominant()));
+    REQUIRE(is_true(F.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(G.is_strictly_diagonally_dominant()));
+    REQUIRE(is_indeterminate(H.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(K.is_strictly_diagonally_dominant()));
+    REQUIRE(is_false(L.is_strictly_diagonally_dominant()));
+}

--- a/symengine/tests/matrix/test_matrix.cpp
+++ b/symengine/tests/matrix/test_matrix.cpp
@@ -16,6 +16,7 @@ using SymEngine::rational;
 using SymEngine::DenseMatrix;
 using SymEngine::Basic;
 using SymEngine::complex_double;
+using SymEngine::Complex;
 using SymEngine::symbol;
 using SymEngine::Symbol;
 using SymEngine::is_a;
@@ -2275,4 +2276,56 @@ TEST_CASE("is_strictly_diagonally_dominant(): DenseMatrix", "[matrices]")
     REQUIRE(is_indeterminate(H.is_strictly_diagonally_dominant()));
     REQUIRE(is_false(K.is_strictly_diagonally_dominant()));
     REQUIRE(is_false(L.is_strictly_diagonally_dominant()));
+}
+
+TEST_CASE("is_positive_definite(): DenseMatrix", "[matrices]")
+{
+    DenseMatrix A = DenseMatrix(3, 3, {integer(2), integer(-1), integer(0),
+                                       integer(-1), integer(2), integer(-1),
+                                       integer(0), integer(-1), integer(2)});
+    DenseMatrix B
+        = DenseMatrix(2, 2, {integer(5), integer(4), integer(4), integer(5)});
+    DenseMatrix C = DenseMatrix(3, 3, {integer(2), integer(-1), integer(-1),
+                                       integer(-1), integer(2), integer(-1),
+                                       integer(-1), integer(-1), integer(2)});
+    DenseMatrix D
+        = DenseMatrix(2, 2, {integer(1), integer(2), integer(2), integer(4)});
+    DenseMatrix E
+        = DenseMatrix(2, 2, {integer(2), integer(3), integer(4), integer(8)});
+    DenseMatrix F = DenseMatrix(
+        2, 2, {integer(1), Complex::from_two_nums(*integer(0), *integer(2)),
+               Complex::from_two_nums(*integer(0), *integer(-1)), integer(4)});
+    DenseMatrix G = DenseMatrix(
+        2, 2, {symbol("a"), symbol("b"), symbol("c"), symbol("d")});
+    DenseMatrix H = DenseMatrix(
+        4, 4,
+        {real_double(0.0228202735623867), real_double(0.00518748979085398),
+         real_double(-0.0743036351048907), real_double(-0.00709135324903921),
+         real_double(0.00518748979085398), real_double(0.0349045359786350),
+         real_double(0.0830317991056637), real_double(0.00233147902806909),
+         real_double(-0.0743036351048907), real_double(0.0830317991056637),
+         real_double(1.15859676366277), real_double(0.340359081555988),
+         real_double(-0.00709135324903921), real_double(0.00233147902806909),
+         real_double(0.340359081555988), real_double(0.928147644848199)});
+    DenseMatrix L = DenseMatrix(3, 3, {integer(0), integer(0), integer(0),
+                                       integer(0), integer(1), integer(2),
+                                       integer(0), integer(2), integer(1)});
+    DenseMatrix M
+        = DenseMatrix(2, 2, {integer(-1), integer(0), integer(0), integer(23)});
+    DenseMatrix N
+        = DenseMatrix(2, 2, {integer(2), integer(0), integer(-1), integer(2)});
+    DenseMatrix P = DenseMatrix(2, 1, {integer(2), integer(0)});
+
+    REQUIRE(is_true(A.is_positive_definite()));
+    REQUIRE(is_true(B.is_positive_definite()));
+    REQUIRE(is_false(C.is_positive_definite()));
+    REQUIRE(is_false(D.is_positive_definite()));
+    REQUIRE(is_true(E.is_positive_definite()));
+    REQUIRE(is_true(F.is_positive_definite()));
+    REQUIRE(is_indeterminate(G.is_positive_definite()));
+    REQUIRE(is_true(H.is_positive_definite()));
+    REQUIRE(is_false(L.is_positive_definite()));
+    REQUIRE(is_false(M.is_positive_definite()));
+    REQUIRE(is_true(N.is_positive_definite()));
+    REQUIRE(is_false(P.is_positive_definite()));
 }


### PR DESCRIPTION
Depending on PR #1707.

Implement the same algorithm as in sympy:
1. First "hermitify" (A + A.H) if non hermitian but square
2. Check if any non-positive diagonals. Shortcut to False in that case.
3. Check if diagonally dominant. Shortcut to True if True and only positive diagonals
4. If still undecided use gaussian elimination and check for positive diagonals

Most unit tests were copied from sympy.