### PR TITLE
add support for newer versions of binutils - resolves #1712

### DIFF
--- a/symengine/utilities/teuchos/Teuchos_stacktrace.cpp
+++ b/symengine/utilities/teuchos/Teuchos_stacktrace.cpp
@@ -208,8 +208,8 @@ void process_section(bfd *abfd, asection *section, void *_data)
     return;
   }
 
-#ifdef bfd_get_section_size
-  bfd_size_type section_size = bfd_get_section_size(abfd, section);
+#ifdef bfd_section_size
+  bfd_size_type section_size = bfd_section_size(abfd, section);
 #else
   bfd_size_type section_size = bfd_section_size(section);
 #endif

--- a/symengine/utilities/teuchos/Teuchos_stacktrace.cpp
+++ b/symengine/utilities/teuchos/Teuchos_stacktrace.cpp
@@ -190,17 +190,29 @@ void process_section(bfd *abfd, asection *section, void *_data)
     // If we already found the line, exit
     return;
   }
+#ifdef bfd_get_section_flags
   if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0) {
-    return;
-  }
+#else
+  if ((bfd_section_flags(section) & SEC_ALLOC) == 0) {
+#endif
+  return;
+}
 
+#ifdef bfd_get_section_vma
   bfd_vma section_vma = bfd_get_section_vma(abfd, section);
+#else
+  bfd_vma section_vma = bfd_section_vma(section);
+#endif
   if (data->addr < section_vma) {
     // If the addr lies above the section, exit
     return;
   }
 
-  bfd_size_type section_size = bfd_section_size(abfd, section);
+#ifdef bfd_get_section_size
+  bfd_size_type section_size = bfd_get_section_size(abfd, section);
+#else
+  bfd_size_type section_size = bfd_section_size(section);
+#endif
   if (data->addr >= section_vma + section_size) {
     // If the addr lies below the section, exit
     return;


### PR DESCRIPTION
these macros have been replaced with functions in newer versions of binutils: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=fd3619828e94a24a92cddec42cbc0ab33352eeb4﻿
