### PR TITLE
Fix LambdaRealDoubleVisitor use-after-free issue

### DIFF
--- a/symengine/lambda_double.h
+++ b/symengine/lambda_double.h
@@ -120,8 +120,8 @@ public:
         auto it = cse_intermediate_fns_map.find(x.rcp_from_this());
         if (it != cse_intermediate_fns_map.end()) {
             auto index = it->second;
-            result_
-                = [=](const T *x) { return cse_intermediate_results[index]; };
+            T *cse_intermediate_result = &(cse_intermediate_results[index]);
+            result_ = [=](const T *x) { return *cse_intermediate_result; };
             return;
         }
         throw SymEngineException("Symbol not in the symbols vector.");

--- a/symengine/lambda_double.h
+++ b/symengine/lambda_double.h
@@ -33,6 +33,14 @@ protected:
     vec_basic symbols;
 
 public:
+    LambdaDoubleVisitor() = default;
+    LambdaDoubleVisitor(LambdaDoubleVisitor &&) = default;
+    LambdaDoubleVisitor &operator=(LambdaDoubleVisitor &&) = default;
+    // delete copy constructor:
+    // https://github.com/symengine/symengine/issues/1674
+    LambdaDoubleVisitor(const LambdaDoubleVisitor &) = delete;
+    LambdaDoubleVisitor &operator=(const LambdaDoubleVisitor &) = delete;
+
     void init(const vec_basic &x, const Basic &b, bool cse = false)
     {
         vec_basic outputs = {b.rcp_from_this()};

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -155,7 +155,8 @@ TEST_CASE("Evaluate double cse", "[lambda_double_cse]")
     REQUIRE(::fabs(d[1] - 45.0) < 1e-12);
 }
 
-TEST_CASE("LambdaRealDoubleVisitor with cse can be moved", "[lambda_double_cse]")
+TEST_CASE("LambdaRealDoubleVisitor with cse can be moved",
+          "[lambda_double_cse]")
 {
     RCP<const Basic> x, y, z, r, s;
     x = symbol("x");

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -155,6 +155,33 @@ TEST_CASE("Evaluate double cse", "[lambda_double_cse]")
     REQUIRE(::fabs(d[1] - 45.0) < 1e-12);
 }
 
+TEST_CASE("LambdaRealDoubleVisitor with cse can be moved", "[lambda_double_cse]")
+{
+    RCP<const Basic> x, y, z, r, s;
+    x = symbol("x");
+    y = symbol("y");
+    z = symbol("z");
+
+    r = add(x, add(mul(y, z), pow(mul(y, z), integer(2))));
+    s = add(mul(integer(2), x), add(mul(y, z), pow(mul(y, z), integer(2))));
+
+    double d[2];
+    double inps[] = {1.5, 2.0, 3.0};
+    LambdaRealDoubleVisitor v2;
+    {
+        LambdaRealDoubleVisitor v;
+        v.init({x, y, z}, {r, s}, true);
+        v.call(d, inps);
+        v.call(d, inps);
+        REQUIRE(::fabs(d[0] - 43.5) < 1e-12);
+        REQUIRE(::fabs(d[1] - 45.0) < 1e-12);
+        v2 = std::move(v); // Move-construct another visitor
+    }
+    v2.call(d, inps);
+    REQUIRE(::fabs(d[0] - 43.5) < 1e-12);
+    REQUIRE(::fabs(d[1] - 45.0) < 1e-12);
+}
+
 TEST_CASE("Evaluate to std::complex<double>", "[lambda_complex_double]")
 {
     RCP<const Basic> x, y, z, r;


### PR DESCRIPTION
- delete `LambdaRealDoubleVisitor` copy constructor as discussed here: https://github.com/symengine/symengine/pull/1680#issuecomment-682826644
   - this resolves #1674
- add (initially failing) test of move-constructor
   - test copied from https://github.com/symengine/symengine/pull/1673 but replacing copy construction with move construction
   - test segfaults on this line: https://github.com/symengine/symengine/blob/master/symengine/lambda_double.h#L116
- fix segfault
   - `return cse_intermediate_results[index]` in the lambda is presumably equivalent to `return *(cse_intermediate_results.data() + index);`
   - if the `cse_intermediate_results` vector is moved from it is left in an undefined state, e.g. `cse_intermediate_results.data()` can be `NULL`
   - so instead capture a direct pointer to the data in the lambda
   - the data itself is preserved by the move