### PR TITLE
use token for codecov coverage uploads

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,4 +4,6 @@ coverage:
   - symengine/utilities/.*
   - benchmarks/.*
 
+  token: e049a7ee-c9f2-4e48-87b4-fca397853ce8
+
 comment: off


### PR DESCRIPTION
try using a token for codecov uploads to avoid this intermittent issue: https://github.com/symengine/symengine/pull/1747#issuecomment-803453562﻿
