### PR TITLE
Add is_rational and is_irrational

### DIFF
--- a/symengine/number.h
+++ b/symengine/number.h
@@ -149,6 +149,8 @@ tribool is_nonnegative(const Basic &b);
 tribool is_integer(const Basic &b, const Assumptions *assumptions = nullptr);
 tribool is_real(const Basic &b, const Assumptions *assumptions = nullptr);
 tribool is_complex(const Basic &b, const Assumptions *assumptions = nullptr);
+tribool is_rational(const Basic &b);
+tribool is_irrational(const Basic &b);
 
 class NumberWrapper : public Number
 {

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -423,9 +423,7 @@ private:
     bool neither_ = false; // Neither rational or irrational (i.e. not real)
 
 public:
-    RationalVisitor(bool rational) : rational_{rational}
-    {
-    }
+    RationalVisitor(bool rational) : rational_{rational} {}
     void bvisit(const Basic &x)
     {
         is_rational_ = tribool::indeterminate;

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -414,6 +414,55 @@ public:
  * are not variables will be considered to be constants.
  */
 bool is_polynomial(const Basic &b, const set_basic &variables = {});
+
+class RationalVisitor : public BaseVisitor<RationalVisitor>
+{
+private:
+    bool rational_; // are we testing for rational or irrational?
+    tribool is_rational_;
+    bool neither_ = false; // Neither rational or irrational (i.e. not real)
+
+public:
+    RationalVisitor(bool rational) : rational_{rational}
+    {
+    }
+    void bvisit(const Basic &x)
+    {
+        is_rational_ = tribool::indeterminate;
+    };
+    void bvisit(const Symbol &x)
+    {
+        is_rational_ = tribool::indeterminate;
+    };
+    void bvisit(const Integer &x)
+    {
+        is_rational_ = tribool::tritrue;
+    };
+    void bvisit(const Rational &x)
+    {
+        is_rational_ = tribool::tritrue;
+    };
+    void bvisit(const Number &x);
+    void bvisit(const Set &x)
+    {
+        is_rational_ = tribool::trifalse;
+        neither_ = true;
+    };
+    void bvisit(const Relational &x)
+    {
+        is_rational_ = tribool::trifalse;
+        neither_ = true;
+    };
+    void bvisit(const Boolean &x)
+    {
+        is_rational_ = tribool::trifalse;
+        neither_ = true;
+    };
+    void bvisit(const Constant &x);
+    void bvisit(const Add &x);
+
+    tribool apply(const Basic &b);
+};
 } // namespace SymEngine
 
 #endif // SYMENGINE_TEST_VISITORS_H

--- a/symengine/tests/basic/test_test_visitors.cpp
+++ b/symengine/tests/basic/test_test_visitors.cpp
@@ -6,6 +6,7 @@ using SymEngine::Assumptions;
 using SymEngine::Basic;
 using SymEngine::boolTrue;
 using SymEngine::Complex;
+using SymEngine::constant;
 using SymEngine::cos;
 using SymEngine::Inf;
 using SymEngine::integer;
@@ -17,19 +18,13 @@ using SymEngine::pi;
 using SymEngine::Rational;
 using SymEngine::rationals;
 using SymEngine::RCP;
+using SymEngine::real_double;
 using SymEngine::reals;
 using SymEngine::Set;
 using SymEngine::sin;
 using SymEngine::symbol;
 using SymEngine::Symbol;
 using SymEngine::tribool;
-using SymEngine::Complex;
-using SymEngine::pi;
-using SymEngine::constant;
-using SymEngine::boolTrue;
-using SymEngine::Inf;
-using SymEngine::Nan;
-using SymEngine::real_double;
 
 TEST_CASE("Test is zero", "[is_zero]")
 {

--- a/symengine/tests/basic/test_test_visitors.cpp
+++ b/symengine/tests/basic/test_test_visitors.cpp
@@ -23,6 +23,13 @@ using SymEngine::sin;
 using SymEngine::symbol;
 using SymEngine::Symbol;
 using SymEngine::tribool;
+using SymEngine::Complex;
+using SymEngine::pi;
+using SymEngine::constant;
+using SymEngine::boolTrue;
+using SymEngine::Inf;
+using SymEngine::Nan;
+using SymEngine::real_double;
 
 TEST_CASE("Test is zero", "[is_zero]")
 {
@@ -495,4 +502,76 @@ TEST_CASE("Test is_polynomial", "[is_polynomial]")
     REQUIRE(!is_polynomial(*e23));
     REQUIRE(is_polynomial(*e23, {y}));
     REQUIRE(!is_polynomial(*rel1));
+}
+
+TEST_CASE("Test is_rational", "[is_rational]")
+{
+    RCP<const Basic> x = symbol("x");
+    RCP<const Number> i1 = integer(0);
+    RCP<const Number> i2 = integer(3);
+    RCP<const Basic> rat1 = Rational::from_two_ints(*integer(5), *integer(6));
+    RCP<const Basic> irr1 = real_double(2.0);
+    RCP<const Basic> s1 = interval(i1, i2);
+    RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
+    RCP<const Basic> rel1 = Eq(x, i1);
+    RCP<const Symbol> t = symbol("t");
+    RCP<const Basic> f = function_symbol("f", t);
+    RCP<const Basic> d1 = f->diff(t);
+    RCP<const Basic> e1 = add(x, x);
+    RCP<const Basic> e2 = add(x, Inf);
+    RCP<const Basic> e3 = add(x, c1);
+
+    REQUIRE(is_indeterminate(is_rational(*x)));
+    REQUIRE(is_true(is_rational(*i1)));
+    REQUIRE(is_true(is_rational(*i2)));
+    REQUIRE(is_true(is_rational(*rat1)));
+    REQUIRE(is_false(is_rational(*s1)));
+    REQUIRE(is_false(is_rational(*c1)));
+    REQUIRE(is_false(is_rational(*rel1)));
+    REQUIRE(is_false(is_rational(*pi)));
+    REQUIRE(is_indeterminate(is_rational(*d1)));
+    REQUIRE(is_false(is_rational(*boolTrue)));
+    REQUIRE(is_indeterminate(is_rational(*e1)));
+    REQUIRE(is_indeterminate(is_rational(*e2)));
+    REQUIRE(is_indeterminate(is_rational(*e3)));
+    REQUIRE(is_false(is_rational(*Inf)));
+    REQUIRE(is_false(is_rational(*Nan)));
+    REQUIRE(is_false(is_rational(*irr1)));
+    REQUIRE(is_indeterminate(is_rational(*constant("catalan"))));
+}
+
+TEST_CASE("Test is_irrational", "[is_irrational]")
+{
+    RCP<const Basic> x = symbol("x");
+    RCP<const Number> i1 = integer(0);
+    RCP<const Number> i2 = integer(3);
+    RCP<const Basic> rat1 = Rational::from_two_ints(*integer(5), *integer(6));
+    RCP<const Basic> irr1 = real_double(2.0);
+    RCP<const Basic> s1 = interval(i1, i2);
+    RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
+    RCP<const Basic> rel1 = Eq(x, i1);
+    RCP<const Symbol> t = symbol("t");
+    RCP<const Basic> f = function_symbol("f", t);
+    RCP<const Basic> d1 = f->diff(t);
+    RCP<const Basic> e1 = add(x, x);
+    RCP<const Basic> e2 = add(x, Inf);
+    RCP<const Basic> e3 = add(x, c1);
+
+    REQUIRE(is_indeterminate(is_irrational(*x)));
+    REQUIRE(is_false(is_irrational(*i1)));
+    REQUIRE(is_false(is_irrational(*i2)));
+    REQUIRE(is_false(is_irrational(*rat1)));
+    REQUIRE(is_false(is_irrational(*s1)));
+    REQUIRE(is_false(is_irrational(*c1)));
+    REQUIRE(is_false(is_irrational(*rel1)));
+    REQUIRE(is_true(is_irrational(*pi)));
+    REQUIRE(is_indeterminate(is_irrational(*d1)));
+    REQUIRE(is_false(is_irrational(*boolTrue)));
+    REQUIRE(is_indeterminate(is_irrational(*e1)));
+    REQUIRE(is_indeterminate(is_irrational(*e2)));
+    REQUIRE(is_indeterminate(is_irrational(*e3)));
+    REQUIRE(is_false(is_irrational(*Inf)));
+    REQUIRE(is_false(is_irrational(*Nan)));
+    REQUIRE(is_true(is_irrational(*irr1)));
+    REQUIRE(is_indeterminate(is_irrational(*constant("catalan"))));
 }


### PR DESCRIPTION
Adding functions `is_rational` and `is_irrational`. Both are implemented using the same visitor.

non-exact numbers, e.g. `RealDouble`, are considered to be irrational. This is because almost all real numbers are irrational.