### PR TITLE
separate workflow for each coverage ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.OS }}
+    name: "${{ matrix.BUILD_TYPE }}-${{ matrix.OS }}-${{ matrix.CC }} (${{ toJSON(matrix) }})"
     strategy:
       fail-fast: false
       matrix:
@@ -81,18 +82,6 @@ jobs:
             OS: ubuntu-16.04
             CC: gcc
 
-          - BUILD_TYPE: Debug
-            WITH_BFD: yes
-            WITH_LATEST_GCC: yes
-            WITH_COVERAGE: yes
-            WITH_MPC: yes
-            WITH_LLVM: 8.0
-            USE_GLIBCXX_DEBUG: yes
-            OS: ubuntu-16.04
-            CC: gcc
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
-            EXTRA_APT_PACKAGES: "clang-8 llvm-8-dev binutils-dev g++-8"
-
           - TEST_CLANG_FORMAT: yes
             OS: ubuntu-16.04
             CC: gcc
@@ -109,18 +98,6 @@ jobs:
             EXTRA_APT_PACKAGES: "binutils-dev g++-4.8"
             # This is not used, but was in travis config
             # WITH_GCC_6: yes
-
-          - BUILD_TYPE: Debug
-            WITH_BFD: yes
-            WITH_COVERAGE: yes
-            TEST_IN_TREE: yes
-            WITH_FLINT: yes
-            WITH_FLINT_DEV: yes
-            WITH_MPC: yes
-            BUILD_BENCHMARKS: no
-            MAKEFLAGS: -j2
-            CC: gcc
-            OS: ubuntu-16.04
 
           - BUILD_TYPE: Debug
             WITH_BFD: yes

--- a/.github/workflows/coverage1.yml
+++ b/.github/workflows/coverage1.yml
@@ -1,0 +1,27 @@
+name: Code coverage 1
+on: [push, pull_request]
+
+jobs:
+  coverage1:
+    runs-on: ubuntu-16.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - name: Build and test symengine
+      shell: bash
+      run: |
+        source bin/test_symengine_unix.sh
+      env:
+        BUILD_TYPE: Debug
+        WITH_BFD: yes
+        WITH_LATEST_GCC: yes
+        WITH_COVERAGE: yes
+        WITH_MPC: yes
+        WITH_LLVM: 8.0
+        USE_GLIBCXX_DEBUG: yes
+        OS: ubuntu-16.04
+        CC: gcc
+        EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+        EXTRA_APT_PACKAGES: "clang-8 llvm-8-dev binutils-dev g++-8"

--- a/.github/workflows/coverage2.yml
+++ b/.github/workflows/coverage2.yml
@@ -1,0 +1,27 @@
+name: Code coverage 2
+on: [push, pull_request]
+
+jobs:
+  coverage2:
+    runs-on: ubuntu-16.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - name: Build and test symengine
+      shell: bash
+      run: |
+        source bin/test_symengine_unix.sh
+      env:
+        BUILD_TYPE: Debug
+        WITH_BFD: yes
+        WITH_COVERAGE: yes
+        TEST_IN_TREE: yes
+        WITH_FLINT: yes
+        WITH_FLINT_DEV: yes
+        WITH_MPC: yes
+        BUILD_BENCHMARKS: no
+        MAKEFLAGS: -j2
+        CC: gcc
+        OS: ubuntu-16.04


### PR DESCRIPTION
this seems to avoid the codecov upload issue without having to expose the codecov token (see #1752), although with more boilerplate yml.

(I also added a name to the build jobs to see more easily which job is which, but this is unrelated)