### PR TITLE
Mark `RCP<T>::operator!=` as const

### DIFF
--- a/symengine/symengine_rcp.h
+++ b/symengine/symengine_rcp.h
@@ -173,13 +173,11 @@ public:
     {
         return ptr_ == p2.ptr_;
     }
-#if !defined(__clang__) || __cplusplus <= 201703L
     template <class T2>
-    bool operator!=(const RCP<T2> &p2)
+    bool operator!=(const RCP<T2> &p2) const
     {
         return ptr_ != p2.ptr_;
     }
-#endif
     // Copy assignment
     RCP<T> &operator=(const RCP<T> &r_ptr)
     {

--- a/symengine/symengine_rcp.h
+++ b/symengine/symengine_rcp.h
@@ -169,7 +169,7 @@ public:
         return ptr_ == nullptr;
     }
     template <class T2>
-    bool operator==(const RCP<T2> &p2)
+    bool operator==(const RCP<T2> &p2) const
     {
         return ptr_ == p2.ptr_;
     }

--- a/symengine/symengine_rcp.h
+++ b/symengine/symengine_rcp.h
@@ -173,11 +173,13 @@ public:
     {
         return ptr_ == p2.ptr_;
     }
+#if !defined(__clang__) || __cplusplus <= 201703L
     template <class T2>
     bool operator!=(const RCP<T2> &p2)
     {
         return ptr_ != p2.ptr_;
     }
+#endif
     // Copy assignment
     RCP<T> &operator=(const RCP<T> &r_ptr)
     {


### PR DESCRIPTION
This is necessary in order for code compiled with `clang -std=c++20` to include the symengine headers.

To reproduce the issue (sorry I wasn't sure how best to make a test for this):
```
mkdir build
cd build
cmake ..
make

echo "#include <symengine/visitor.h>" > test.cpp
clang++ -I. -I.. -std=c++20 -Wno-ambiguous-reversed-operator -c test.cpp
```

This generates the errors:
```
In file included from test.cpp:1:
../symengine/visitor.h:262:19: error: use of overloaded operator '!=' is ambiguous (with operand types 'SymEngine::RCP<const SymEngine::Basic>' and 'SymEngine::RCP<const SymEngine::Basic>')
        if (farg1 != newarg1 or farg2 != newarg2) {
            ~~~~~ ^  ~~~~~~~
../symengine/type_codes.inc:63:1: note: in instantiation of function template specialization 'SymEngine::TransformVisitor::bvisit<SymEngine::Function>' requested here
SYMENGINE_ENUM(SYMENGINE_ATAN2, ATan2)
^
../symengine/visitor.h:70:37: note: expanded from macro 'SYMENGINE_ENUM'
        down_cast<Derived *>(this)->bvisit(x);                                 \
                                    ^
../symengine/visitor.h:245:5: note: in instantiation of member function 'SymEngine::BaseVisitor<SymEngine::TransformVisitor, SymEngine::Visitor>::visit' requested here
    TransformVisitor()
    ^
../symengine/symengine_rcp.h:178:10: note: candidate function [with T2 = const SymEngine::Basic]
    bool operator!=(const RCP<T2> &p2)
         ^
../symengine/symengine_rcp.h:172:10: note: candidate function [with T2 = const SymEngine::Basic]
    bool operator==(const RCP<T2> &p2)
         ^
../symengine/symengine_rcp.h:172:10: note: candidate function (with reversed parameter order) [with T2 = const SymEngine::Basic]
In file included from test.cpp:1:
../symengine/visitor.h:262:19: error: use of overloaded operator '!=' is ambiguous (with operand types 'SymEngine::RCP<const SymEngine::Basic>' and 'SymEngine::RCP<const SymEngine::Basic>')
        if (farg1 != newarg1 or farg2 != newarg2) {
            ~~~~~ ^  ~~~~~~~
../symengine/type_codes.inc:114:1: note: in instantiation of function template specialization 'SymEngine::TransformVisitor::bvisit<SymEngine::Boolean>' requested here
SYMENGINE_ENUM(SYMENGINE_EQUALITY, Equality)
^
../symengine/visitor.h:70:37: note: expanded from macro 'SYMENGINE_ENUM'
        down_cast<Derived *>(this)->bvisit(x);                                 \
                                    ^
../symengine/visitor.h:245:5: note: in instantiation of member function 'SymEngine::BaseVisitor<SymEngine::TransformVisitor, SymEngine::Visitor>::visit' requested here
    TransformVisitor()
    ^
../symengine/symengine_rcp.h:178:10: note: candidate function [with T2 = const SymEngine::Basic]
    bool operator!=(const RCP<T2> &p2)
         ^
../symengine/symengine_rcp.h:172:10: note: candidate function [with T2 = const SymEngine::Basic]
    bool operator==(const RCP<T2> &p2)
         ^
../symengine/symengine_rcp.h:172:10: note: candidate function (with reversed parameter order) [with T2 = const SymEngine::Basic]
2 errors generated.
```

With gcc or MSVC the code compiles fine; it is just clang that doesn't like it (and clang is happy to deduce operator!= from operator==). I don't know which compiler is "correct"; the difference may just reflect different levels of C++20 support.

The `-Wno-ambiguous-reversed-operator` is just to suppress some other warnings, which do however look somewhat related.