### PR TITLE
Add Assumptions class

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -79,6 +79,7 @@ set(SRC
     symengine_rcp.cpp
     visitor.cpp
     test_visitors.cpp
+    assumptions.cpp
 )
 
 if ("${SYMENGINE_INTEGER_CLASS}" STREQUAL "BOOSTMP")
@@ -192,6 +193,7 @@ set(HEADERS
     type_codes.inc
     visitor.h
     test_visitors.h
+    assumptions.h
 )
 
 include(GNUInstallDirs)

--- a/symengine/assumptions.cpp
+++ b/symengine/assumptions.cpp
@@ -1,0 +1,48 @@
+#include <symengine/logic.h>
+#include <symengine/assumptions.h>
+
+namespace SymEngine
+{
+
+Assumptions::Assumptions(const set_basic &statements)
+{
+    // Convert a set of statements into a faster and easier internal form
+    for (const auto &s : statements) {
+        if (is_a<Contains>(*s)) {
+            const Contains &contains = down_cast<const Contains &>(*s);
+            const auto expr = contains.get_expr();
+            const auto set = contains.get_set();
+            if (is_a<Symbol>(*expr)) {
+                if (is_a<Reals>(*set)) {
+                    real_symbols_.insert(expr);
+                } else if (is_a<Rationals>(*set)) {
+                    real_symbols_.insert(expr);
+                    rational_symbols_.insert(expr);
+                } else if (is_a<Integers>(*set)) {
+                    real_symbols_.insert(expr);
+                    rational_symbols_.insert(expr);
+                    integer_symbols_.insert(expr);
+                }
+            }
+        }
+    }
+}
+
+tribool Assumptions::is_real(const RCP<const Basic> &symbol) const
+{
+    bool real = real_symbols_.find(symbol) != real_symbols_.end();
+    return real ? tribool::tritrue : tribool::indeterminate;
+}
+
+tribool Assumptions::is_rational(const RCP<const Basic> &symbol) const
+{
+    bool rational = rational_symbols_.find(symbol) != rational_symbols_.end();
+    return rational ? tribool::tritrue : tribool::indeterminate;
+}
+
+tribool Assumptions::is_integer(const RCP<const Basic> &symbol) const
+{
+    bool integer = integer_symbols_.find(symbol) != integer_symbols_.end();
+    return integer ? tribool::tritrue : tribool::indeterminate;
+}
+}

--- a/symengine/assumptions.h
+++ b/symengine/assumptions.h
@@ -1,0 +1,24 @@
+#ifndef SYMENGINE_ASSUMPTIONS_H
+#define SYMENGINE_ASSUMPTIONS_H
+
+#include <symengine/basic.h>
+
+namespace SymEngine
+{
+
+class Assumptions
+{
+private:
+    set_basic real_symbols_;
+    set_basic rational_symbols_;
+    set_basic integer_symbols_;
+
+public:
+    Assumptions(const set_basic &statements);
+    tribool is_real(const RCP<const Basic> &symbol) const;
+    tribool is_rational(const RCP<const Basic> &symbol) const;
+    tribool is_integer(const RCP<const Basic> &symbol) const;
+};
+}
+
+#endif // SYMENGINE_ASSUMPTIONS_H

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -8,6 +8,7 @@
 #define SYMENGINE_NUMBER_H
 
 #include <symengine/basic.h>
+#include <symengine/assumptions.h>
 
 namespace SymEngine
 {
@@ -145,7 +146,7 @@ tribool is_positive(const Basic &b);
 tribool is_nonpositive(const Basic &b);
 tribool is_negative(const Basic &b);
 tribool is_nonnegative(const Basic &b);
-tribool is_real(const Basic &b);
+tribool is_real(const Basic &b, const Assumptions *assumptions = nullptr);
 
 class NumberWrapper : public Number
 {

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -115,6 +115,15 @@ tribool is_nonnegative(const Basic &b)
     return visitor.apply(b);
 }
 
+void RealVisitor::bvisit(const Symbol &x)
+{
+    if (assumptions_) {
+        is_real_ = assumptions_->is_real(x.rcp_from_this());
+    } else {
+        is_real_ = tribool::indeterminate;
+    }
+}
+
 void RealVisitor::bvisit(const Number &x)
 {
     if (is_a_Complex(x) or is_a<Infty>(x) or is_a<NaN>(x)) {
@@ -151,9 +160,9 @@ tribool RealVisitor::apply(const Basic &b)
     return is_real_;
 }
 
-tribool is_real(const Basic &b)
+tribool is_real(const Basic &b, const Assumptions *assumptions)
 {
-    RealVisitor visitor;
+    RealVisitor visitor(assumptions);
     return visitor.apply(b);
 }
 

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -185,16 +185,15 @@ class RealVisitor : public BaseVisitor<RealVisitor>
 {
 private:
     tribool is_real_;
+    const Assumptions *assumptions_;
 
 public:
+    RealVisitor(const Assumptions *assumptions) : assumptions_(assumptions){};
     void bvisit(const Basic &x)
     {
         is_real_ = tribool::indeterminate;
     };
-    void bvisit(const Symbol &x)
-    {
-        is_real_ = tribool::indeterminate;
-    };
+    void bvisit(const Symbol &x);
     void bvisit(const Number &x);
     void bvisit(const Set &x)
     {

--- a/symengine/tests/basic/CMakeLists.txt
+++ b/symengine/tests/basic/CMakeLists.txt
@@ -110,3 +110,7 @@ add_test(test_count_ops ${PROJECT_BINARY_DIR}/test_count_ops)
 add_executable(test_test_visitors test_test_visitors.cpp)
 target_link_libraries(test_test_visitors symengine catch)
 add_test(test_test_visitors ${PROJECT_BINARY_DIR}/test_test_visitors)
+
+add_executable(test_assumptions test_assumptions.cpp)
+target_link_libraries(test_assumptions symengine catch)
+add_test(test_assumptions ${PROJECT_BINARY_DIR}/test_assumptions)

--- a/symengine/tests/basic/test_assumptions.cpp
+++ b/symengine/tests/basic/test_assumptions.cpp
@@ -1,0 +1,42 @@
+#include "catch.hpp"
+#include <symengine/assumptions.h>
+#include <symengine/sets.h>
+
+using SymEngine::RCP;
+using SymEngine::symbol;
+using SymEngine::Set;
+using SymEngine::Basic;
+using SymEngine::reals;
+using SymEngine::rationals;
+using SymEngine::integers;
+using SymEngine::Assumptions;
+
+TEST_CASE("Test assumptions", "[assumptions]")
+{
+    RCP<const Basic> x = symbol("x");
+    RCP<const Basic> y = symbol("y");
+    RCP<const Set> s1 = reals();
+    RCP<const Set> s2 = integers();
+    RCP<const Set> s3 = rationals();
+
+    auto a1 = Assumptions({s1->contains(x)});
+    REQUIRE(is_true(a1.is_real(x)));
+    REQUIRE(is_indeterminate(a1.is_integer(x)));
+    REQUIRE(is_indeterminate(a1.is_real(y)));
+
+    auto a2 = Assumptions({s2->contains(x)});
+    REQUIRE(is_true(a2.is_real(x)));
+    REQUIRE(is_true(a2.is_integer(x)));
+    REQUIRE(is_indeterminate(a2.is_real(y)));
+    REQUIRE(is_indeterminate(a2.is_integer(y)));
+
+    auto a3 = Assumptions({s1->contains(x), s2->contains(y)});
+    REQUIRE(is_indeterminate(a3.is_integer(x)));
+    REQUIRE(is_true(a3.is_integer(y)));
+    REQUIRE(is_true(a3.is_real(x)));
+    REQUIRE(is_true(a3.is_real(y)));
+
+    auto a4 = Assumptions({s3->contains(x)});
+    REQUIRE(is_true(a4.is_rational(x)));
+    REQUIRE(is_indeterminate(a4.is_rational(y)));
+}

--- a/symengine/tests/basic/test_test_visitors.cpp
+++ b/symengine/tests/basic/test_test_visitors.cpp
@@ -17,6 +17,10 @@ using SymEngine::pi;
 using SymEngine::boolTrue;
 using SymEngine::Inf;
 using SymEngine::Nan;
+using SymEngine::reals;
+using SymEngine::rationals;
+using SymEngine::integers;
+using SymEngine::Assumptions;
 
 TEST_CASE("Test is zero", "[is_zero]")
 {
@@ -191,6 +195,7 @@ TEST_CASE("Test is nonnegative", "[is_nonnegative]")
 TEST_CASE("Test is_real", "[is_real]")
 {
     RCP<const Basic> x = symbol("x");
+    RCP<const Basic> y = symbol("y");
     RCP<const Number> i1 = integer(0);
     RCP<const Number> i2 = integer(3);
     RCP<const Basic> rat1 = Rational::from_two_ints(*integer(5), *integer(6));
@@ -203,6 +208,7 @@ TEST_CASE("Test is_real", "[is_real]")
     RCP<const Basic> e1 = add(x, x);
     RCP<const Basic> e2 = add(x, Inf);
     RCP<const Basic> e3 = add(x, c1);
+    RCP<const Basic> e4 = add(x, y);
 
     REQUIRE(is_indeterminate(is_real(*x)));
     REQUIRE(is_true(is_real(*i1)));
@@ -219,6 +225,16 @@ TEST_CASE("Test is_real", "[is_real]")
     REQUIRE(is_indeterminate(is_real(*e3)));
     REQUIRE(is_false(is_real(*Inf)));
     REQUIRE(is_false(is_real(*Nan)));
+
+    const auto a1 = Assumptions({reals()->contains(x)});
+    REQUIRE(is_true(is_real(*x, &a1)));
+
+    const auto a2 = Assumptions({integers()->contains(x)});
+    REQUIRE(is_true(is_real(*x, &a2)));
+
+    const auto a3
+        = Assumptions({rationals()->contains(x), rationals()->contains(y)});
+    REQUIRE(is_true(is_real(*e4, &a3)));
 }
 
 TEST_CASE("Test is_polynomial", "[is_polynomial]")


### PR DESCRIPTION
This PR adds the first version of an Assumptions class and use it in the `is_real` function.

* An assumptions object is constructed from symengine statements.
* The statements are parsed at construction into an internal form that is easier and faster to work with
* Methods on the assumptions object can be used to do basic queries on symbols. To for example check if a symbol is real.
* A function that wants to support assumptions can have an optional assumptions object argument.
* If no assumptions object is used default assumptions will be used

Benefits of design:
* Any symengine statements can be input as an assumption. The assumptions system can grow gradually and support more and more statements. For example `x > 0` would potentially mean that x is real and that x is positive and that x is non-negative
* Even though symengine statements are input to the assumptions object it is free to internally organize or cache the information in the most efficient way.
* Assumptions are not global state and can be optionally used by any function or method. Different function calls can use different assumptions.
* Assumptions are separated from the symbol objects
* Assumptions can be used both for query functions like `is_real` and for functions creating new expressions like `expand`.

Drawbacks of design:
* The assumptions object needs to be forwarded to all functions that need it. E.g `is_real` for matrices would need to take an assumptions argument and forward it to the scalar `is_real` function.
* more?