### PR TITLE
Better symbols for number sets in LaTeX printing

### DIFF
--- a/symengine/printers/latex.cpp
+++ b/symengine/printers/latex.cpp
@@ -371,17 +371,17 @@ void LatexPrinter::bvisit(const EmptySet &x)
 
 void LatexPrinter::bvisit(const Reals &x)
 {
-    str_ = "\\mathbf{R}";
+    str_ = "\\mathbb{R}";
 }
 
 void LatexPrinter::bvisit(const Rationals &x)
 {
-    str_ = "\\mathbf{Q}";
+    str_ = "\\mathbb{Q}";
 }
 
 void LatexPrinter::bvisit(const Integers &x)
 {
-    str_ = "\\mathbf{Z}";
+    str_ = "\\mathbb{Z}";
 }
 
 void LatexPrinter::bvisit(const FiniteSet &x)

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -719,7 +719,7 @@ TEST_CASE("test_latex_printing()", "[latex]")
     CHECK(latex(*l21) == "\\xi_1 + \\alpha + xi2");
     CHECK(latex(*l22) == "2 + 3 x^{10}");
     CHECK(latex(*l23) == "e^{x - y}");
-    CHECK(latex(*l24) == "\\mathbf{R}");
-    CHECK(latex(*l25) == "\\mathbf{Z}");
-    CHECK(latex(*l26) == "\\mathbf{Q}");
+    CHECK(latex(*l24) == "\\mathbb{R}");
+    CHECK(latex(*l25) == "\\mathbb{Z}");
+    CHECK(latex(*l26) == "\\mathbb{Q}");
 }


### PR DESCRIPTION
Fix symbols for Reals, Rationals and Integers sets in LaTeX printing. 
I.e. R now becomes 
![\mathbb{R}](https://latex.codecogs.com/svg.latex?\mathbb{R})
instead of 
![\mathbf{R}](https://latex.codecogs.com/svg.latex?\mathbf{R})