### PR TITLE
Simplify floor(constant + integer) to integer

### DIFF
--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -609,9 +609,9 @@ RCP<const Basic> floor(const RCP<const Basic> &arg)
     if (is_a<Add>(*arg)) {
         RCP<const Number> s = down_cast<const Add &>(*arg).get_coef();
         umap_basic_num d = down_cast<const Add &>(*arg).get_dict();
-        if (is_a<Integer>(*s)) {
-            return add(
-                s, make_rcp<const Floor>(Add::from_dict(zero, std::move(d))));
+        if (is_a<Integer>(*s)
+            and not down_cast<const Integer &>(*s).is_zero()) {
+            return add(s, floor(Add::from_dict(zero, std::move(d))));
         }
     }
     return make_rcp<const Floor>(arg);

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -4253,6 +4253,9 @@ TEST_CASE("test_floor", "[Floor]")
     r = floor(pi);
     CHECK(eq(*r, *integer(3)));
 
+    r = floor(add(pi, integer(4)));
+    CHECK(eq(*r, *integer(7)));
+
     r = floor(E);
     CHECK(eq(*r, *integer(2)));
 


### PR DESCRIPTION
Automatic simplification of `floor(constant + integer)` to `integer`

Sympy does this automatically:

```python
>>> import sympy

>>> sympy.floor(sympy.pi + 4)
7
```

symengine (before this PR) did

```python
>>> import symengine

>>> symengine.floor(symengine.pi + 4)
floor(pi) + 4
```