### PR TITLE
Let 0 * real be exactly 0 (fix #1559)

### DIFF
--- a/symengine/real_double.h
+++ b/symengine/real_double.h
@@ -228,6 +228,9 @@ public:
      * */
     RCP<const Number> mulreal(const Integer &other) const
     {
+        if (other.is_zero()) {
+            return zero;
+        }
         return make_rcp<const RealDouble>(i
                                           * mp_get_d(other.as_integer_class()));
     }

--- a/symengine/real_mpfr.cpp
+++ b/symengine/real_mpfr.cpp
@@ -271,6 +271,9 @@ RCP<const Number> RealMPFR::rsubreal(const ComplexDouble &other) const
  * */
 RCP<const Number> RealMPFR::mulreal(const Integer &other) const
 {
+    if (other.is_zero()) {
+        return zero;
+    }
     mpfr_class t(get_prec());
     mpfr_mul_z(t.get_mpfr_t(), i.get_mpfr_t(),
                get_mpz_t(other.as_integer_class()), MPFR_RNDN);


### PR DESCRIPTION
Fix the issue of `integer(0)` times a real number being real 0.0 instead of `integer(0)`. Both `real_double` and `real_mpfr` are fixed.