### PR TITLE
remove generate parser script, duplicated existing `-DWITH_GENERATE_PARSER` cmake option

### DIFF
--- a/symengine/parser/generate_tokenizer_and_parser.sh
+++ b/symengine/parser/generate_tokenizer_and_parser.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# commands to generate the files tokenizer.cpp, parser.tab.cc, parser.tab.hh
-# requires re2c and bison to be installed
-
-re2c tokenizer.re -s -b --no-generation-date -o tokenizer.cpp
-bison parser.yy -d -o parser.tab.cc


### PR DESCRIPTION
I didn't see the `WITH_GENERATE_PARSER` cmake option when I added this script﻿
