### PR TITLE
fix #1639 boost rational number bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
             WITH_BFD: yes
             INTEGER_CLASS: boostmp
             OS: ubuntu-16.04
+            WITH_LATEST_GCC: yes
             CC: gcc
 
           # Debug build shared lib (with BFD)

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -41,9 +41,9 @@ if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ "${CC}" == "gcc" ]]; then
         export CXX=g++-4.8
         export GCOV_EXECUTABLE=gcov-4.8
     elif [[ "${WITH_LATEST_GCC}" == "yes" ]]; then
-        export CC=gcc-8
-        export CXX=g++-8
-        export GCOV_EXECUTABLE=gcov-8
+        export CC=gcc-9
+        export CXX=g++-9
+        export GCOV_EXECUTABLE=gcov-9
     elif [[ "${WITH_GCC_6}" == "yes" ]]; then
         export CC=gcc-6
         export CXX=g++-6
@@ -86,13 +86,13 @@ conda info -a
 # conda_pkgs="$conda_pkgs ccache"
 
 if [[ "${INTEGER_CLASS}" == "boostmp" ]]; then
-    conda_pkgs="$conda_pkgs boost=1.62";
+    conda_pkgs="$conda_pkgs boost=1.68";
 else
     conda_pkgs="$conda_pkgs gmp=6.1.1";
 fi
 
 if [[ "${WITH_BENCHMARKS_NONIUS}" == "yes" ]]; then
-    conda_pkgs="${conda_pkgs} boost=1.62"
+    conda_pkgs="${conda_pkgs} boost=1.68"
 fi
 
 if [[ "${WITH_PIRANHA}" == "yes" ]]; then

--- a/symengine/mp_boost.cpp
+++ b/symengine/mp_boost.cpp
@@ -293,6 +293,7 @@ struct two_by_two_matrix {
     {
     }
     two_by_two_matrix() : data{{0, 0}, {0, 0}} {}
+    two_by_two_matrix(const two_by_two_matrix &other) = default;
     two_by_two_matrix &operator=(const two_by_two_matrix &other)
     {
         this->data[0][0] = other.data[0][0];

--- a/symengine/rational.cpp
+++ b/symengine/rational.cpp
@@ -50,8 +50,17 @@ RCP<const Number> Rational::from_two_ints(const Integer &n, const Integer &d)
             return ComplexInf;
         }
     }
+#if SYMENGINE_INTEGER_CLASS == SYMENGINE_BOOSTMP
+    // workaround https://github.com/boostorg/rational/issues/27
+    rational_class q;
+    if (d.as_integer_class() < 0) {
+        q = rational_class(-n.as_integer_class(), -d.as_integer_class());
+    } else {
+        q = rational_class(n.as_integer_class(), d.as_integer_class());
+    }
+#else
     rational_class q(n.as_integer_class(), d.as_integer_class());
-
+#endif
     // This is potentially slow, but has to be done, since 'n/d' might not be
     // in canonical form.
     canonicalize(q);
@@ -68,6 +77,13 @@ RCP<const Number> Rational::from_two_ints(long n, long d)
             return ComplexInf;
         }
     }
+#if SYMENGINE_INTEGER_CLASS == SYMENGINE_BOOSTMP
+    // workaround https://github.com/boostorg/rational/issues/27
+    if (d < 0) {
+        d *= -1;
+        n *= -1;
+    }
+#endif
     rational_class q(n, d);
 
     // This is potentially slow, but has to be done, since 'n/d' might not be


### PR DESCRIPTION
- change boost version on CI to trigger #1639
  - ci job [here](https://github.com/symengine/symengine/runs/2558611418?check_suite_focus=true#step:5:4363)
- fix unrelated compiler warning
- when `INTEGER_CLASS=boostmp` and denominator is negative, multiply top & bottom of rational by -1 to avoid this boost bug
