### PR TITLE
fix compiler warnings

### DIFF
--- a/symengine/complex_mpc.cpp
+++ b/symengine/complex_mpc.cpp
@@ -654,7 +654,7 @@ RCP<const Number> ComplexMPC::rpow(const RealMPFR &other) const
 //! Evaluate functions with double precision
 class EvaluateMPC : public Evaluate
 {
-    virtual RCP<const Basic> sin(const Basic &x) const
+    virtual RCP<const Basic> sin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -663,7 +663,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> cos(const Basic &x) const
+    virtual RCP<const Basic> cos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -672,7 +672,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> tan(const Basic &x) const
+    virtual RCP<const Basic> tan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -681,7 +681,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> cot(const Basic &x) const
+    virtual RCP<const Basic> cot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -691,7 +691,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> sec(const Basic &x) const
+    virtual RCP<const Basic> sec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -701,7 +701,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> csc(const Basic &x) const
+    virtual RCP<const Basic> csc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -711,7 +711,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> asin(const Basic &x) const
+    virtual RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -720,7 +720,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acos(const Basic &x) const
+    virtual RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -729,7 +729,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> atan(const Basic &x) const
+    virtual RCP<const Basic> atan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -738,7 +738,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acot(const Basic &x) const
+    virtual RCP<const Basic> acot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -748,7 +748,7 @@ class EvaluateMPC : public Evaluate
         mpc_atan(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> asec(const Basic &x) const
+    virtual RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -758,7 +758,7 @@ class EvaluateMPC : public Evaluate
         mpc_acos(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acsc(const Basic &x) const
+    virtual RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -768,7 +768,7 @@ class EvaluateMPC : public Evaluate
         mpc_asin(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> sinh(const Basic &x) const
+    virtual RCP<const Basic> sinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -777,7 +777,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> csch(const Basic &x) const
+    virtual RCP<const Basic> csch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -787,7 +787,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> cosh(const Basic &x) const
+    virtual RCP<const Basic> cosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -796,7 +796,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> sech(const Basic &x) const
+    virtual RCP<const Basic> sech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -806,7 +806,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> tanh(const Basic &x) const
+    virtual RCP<const Basic> tanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -815,7 +815,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> coth(const Basic &x) const
+    virtual RCP<const Basic> coth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -825,7 +825,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> asinh(const Basic &x) const
+    virtual RCP<const Basic> asinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -834,7 +834,7 @@ class EvaluateMPC : public Evaluate
                   MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acsch(const Basic &x) const
+    virtual RCP<const Basic> acsch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -844,7 +844,7 @@ class EvaluateMPC : public Evaluate
         mpc_asinh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acosh(const Basic &x) const
+    virtual RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -853,7 +853,7 @@ class EvaluateMPC : public Evaluate
                   MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> atanh(const Basic &x) const
+    virtual RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -862,7 +862,7 @@ class EvaluateMPC : public Evaluate
                   MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acoth(const Basic &x) const
+    virtual RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -872,7 +872,7 @@ class EvaluateMPC : public Evaluate
         mpc_atanh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> asech(const Basic &x) const
+    virtual RCP<const Basic> asech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -882,7 +882,7 @@ class EvaluateMPC : public Evaluate
         mpc_acosh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> log(const Basic &x) const
+    virtual RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -891,7 +891,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> abs(const Basic &x) const
+    virtual RCP<const Basic> abs(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpfr_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -900,7 +900,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> gamma(Basic const &aConst) const
+    virtual RCP<const Basic> gamma(Basic const &aConst) const override
     {
         throw NotImplementedError("Not Implemented.");
     }

--- a/symengine/polys/uintpoly_piranha.h
+++ b/symengine/polys/uintpoly_piranha.h
@@ -184,7 +184,7 @@ public:
             if (it.second != 0)
                 p.insert(term(it.second, pmonomial{it.first}));
 
-        return std::move(p);
+        return p;
     }
 
     static RCP<const Poly> from_vec(const RCP<const Basic> &var,

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -300,9 +300,9 @@ public:
         return static_cast<Wrapper &>(*this);
     }
 
-    bool operator==(const Wrapper &other) const
+    friend bool operator==(const Wrapper &a, const Wrapper &b)
     {
-        return dict_ == other.dict_;
+        return a.dict_ == b.dict_;
     }
 
     bool operator!=(const Wrapper &other) const
@@ -590,9 +590,10 @@ protected:
 public:
     ContainerBaseIter(RCP<const T> ptr, long x) : ptr_{ptr}, i_{x} {}
 
-    bool operator==(const ContainerBaseIter &rhs)
+    friend bool operator==(const ContainerBaseIter &lhs,
+                           const ContainerBaseIter &rhs)
     {
-        return (ptr_ == rhs.ptr_) and (i_ == rhs.i_);
+        return (lhs.ptr_ == rhs.ptr_) and (lhs.i_ == rhs.i_);
     }
 
     bool operator!=(const ContainerBaseIter &rhs)

--- a/symengine/series_flint.cpp
+++ b/symengine/series_flint.cpp
@@ -48,7 +48,7 @@ RCP<const Basic> URatPSeriesFlint::as_basic() const
             zcoef = integer(0);
     }
     mpq_clear(gc);
-    return std::move(Add::from_dict(zcoef, std::move(dict_)));
+    return Add::from_dict(zcoef, std::move(dict_));
 }
 
 umap_int_basic URatPSeriesFlint::as_dict() const

--- a/symengine/series_piranha.cpp
+++ b/symengine/series_piranha.cpp
@@ -84,7 +84,7 @@ RCP<const Basic> URatPSeriesPiranha::as_basic() const
             Add::coef_dict_add_term(outArg(co_basic), dict_, one, term);
         }
     }
-    return std::move(Add::from_dict(zcoef, std::move(dict_)));
+    return Add::from_dict(zcoef, std::move(dict_));
 }
 
 umap_int_basic URatPSeriesPiranha::as_dict() const
@@ -232,7 +232,7 @@ RCP<const Basic> UPSeriesPiranha::as_basic() const
             Add::coef_dict_add_term(outArg(coef), dict_, one, term);
         }
     }
-    return std::move(Add::from_dict(one, std::move(dict_)));
+    return Add::from_dict(one, std::move(dict_));
 }
 
 umap_int_basic UPSeriesPiranha::as_dict() const

--- a/symengine/tests/basic/test_fields.cpp
+++ b/symengine/tests/basic/test_fields.cpp
@@ -246,6 +246,9 @@ TEST_CASE("GaloisFieldDict Division, GCD, LCM, Shifts, Negation : Basic",
     REQUIRE(d1 == d2);
     a = {};
     d1 = GaloisFieldDict::from_vec(a, 7_z);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+    // suppress this clang warning, since self-assignment here is intentional
     d2 -= d2;
     REQUIRE(d2.dict_.empty());
     d1 = GaloisFieldDict::from_vec({1_z}, 7_z);
@@ -254,6 +257,7 @@ TEST_CASE("GaloisFieldDict Division, GCD, LCM, Shifts, Negation : Basic",
     REQUIRE(d1 == d2);
     d2 = GaloisFieldDict::from_vec(b, 7_z);
     d2 %= d2;
+#pragma clang diagnostic pop
     REQUIRE(d2.dict_.empty());
     a = {0_z, 1_z, 2_z, 3_z, 4_z, 5_z};
     b = {3_z, 2_z, 1_z};

--- a/symengine/tests/polynomial/test_uintpoly_flint.cpp
+++ b/symengine/tests/polynomial/test_uintpoly_flint.cpp
@@ -296,7 +296,7 @@ TEST_CASE("Factors of UIntPolyFlint", "[UIntPolyFlint]")
     if (__FLINT_RELEASE <= 20502) {
         CHECK_THROWS_AS(
             factors(*UIntPolyFlint::from_dict(x, {{0, 1_z}, {1, 2_z}})),
-            std::runtime_error);
+            std::runtime_error &);
     } else {
         auto factorcheck
             = [](const std::vector<std::pair<RCP<const UIntPolyFlint>, long>>

--- a/symengine/utilities/matchpycpp/bipartite.h
+++ b/symengine/utilities/matchpycpp/bipartite.h
@@ -34,7 +34,7 @@ public:
     BipartiteGraph(map<Edge, TEdgeValue> &edges)
     {
         _edges = edges;
-        for (const pair<Edge, TEdgeValue> &p : edges) {
+        for (const pair<const Edge, TEdgeValue> &p : edges) {
             TLeft nl = get<0>(p.first);
             TRight nr = get<1>(p.first);
             _left.insert(nl);
@@ -81,14 +81,14 @@ public:
     void __delitem__(const Edge &key)
     {
         _edges.erase(key);
-        for (const pair<Edge, TEdgeValue> &p : _edges) {
+        for (const pair<const Edge, TEdgeValue> &p : _edges) {
             TLeft l = get<0>(p.first);
             if (l == get<0>(key)) {
                 _left.erase(get<0>(key));
                 break;
             }
         }
-        for (const pair<Edge, TEdgeValue> &p : _edges) {
+        for (const pair<const Edge, TEdgeValue> &p : _edges) {
             TRight l = get<1>(p.first);
             if (l == get<1>(key)) {
                 _right.erase(get<0>(key));
@@ -105,7 +105,7 @@ public:
     without_nodes(const Edge &edge) const
     {
         BipartiteGraph<TLeft, TRight, TEdgeValue> new_graph;
-        for (const pair<Edge, TEdgeValue> &p : _edges) {
+        for (const pair<const Edge, TEdgeValue> &p : _edges) {
             Edge node = p.first;
             TEdgeValue v = p.second;
             TLeft &n1 = get<0>(node);
@@ -124,7 +124,7 @@ public:
     without_edge(const Edge &edge) const
     {
         BipartiteGraph<TLeft, TRight, TEdgeValue> new_graph;
-        for (const pair<Edge, TEdgeValue> &p : _edges) {
+        for (const pair<const Edge, TEdgeValue> &p : _edges) {
             Edge e2 = p.first;
             TEdgeValue v = p.second;
             if (edge == e2) {
@@ -139,7 +139,7 @@ public:
     {
         map<TLeft, set<TRight>> directed_graph;
 
-        for (const pair<Edge, TEdgeValue> &p : _edges) {
+        for (const pair<const Edge, TEdgeValue> &p : _edges) {
             TLeft left = get<0>(p.first);
             TRight right = get<1>(p.first);
             auto elem = directed_graph.find(left);
@@ -181,7 +181,7 @@ public:
     _DirectedMatchGraph(BipartiteGraph<TLeft, TRight, TEdgeValue> graph,
                         map<TLeft, TRight> matching)
     {
-        for (const pair<Edge, TEdgeValue> &p : graph._edges) {
+        for (const pair<const Edge, TEdgeValue> &p : graph._edges) {
             TLeft tail = get<0>(p.first);
             TRight head = get<1>(p.first);
             auto elem = matching.find(tail);
@@ -204,7 +204,7 @@ public:
     NodeList find_cycle() const
     {
         set<Node> visited;
-        for (const pair<Node, NodeSet> &n : _map) {
+        for (const pair<const Node, NodeSet> &n : _map) {
             NodeList node_list;
             NodeList cycle;
             cycle = _find_cycle(n.first, node_list, visited);
@@ -328,7 +328,7 @@ generator<map<TLeft, TRight>> _enum_maximum_matchings_iter(
 
         vector<tuple<TLeft, TRight, TEdgeValue>> edges;
 
-        for (const pair<Edge, TEdgeValue> &p : graph_plus._edges) {
+        for (const pair<const Edge, TEdgeValue> &p : graph_plus._edges) {
             TLeft left = get<0>(p.first);
             TRight right = get<1>(p.first);
             if ((left == get<0>(edge)) && (right == get<1>(edge))) {
@@ -362,7 +362,7 @@ generator<map<TLeft, TRight>> _enum_maximum_matchings_iter(
         bool left2found = false;
         TRight right;
 
-        for (const pair<Node, NodeSet> &p : directed_match_graph._map) {
+        for (const pair<const Node, NodeSet> &p : directed_match_graph._map) {
             int part1 = get<0>(p.first);
             TLeft node1 = get<1>(p.first);
             if ((part1 == LEFT)

--- a/symengine/utilities/matchpycpp/hopcroft_karp.h
+++ b/symengine/utilities/matchpycpp/hopcroft_karp.h
@@ -71,7 +71,7 @@ private:
     void get_left_indices_vector(const map<TLeft, set<TRight>> &m)
     {
         _left.reserve(m.size());
-        for (const pair<TLeft, set<TRight>> &p : m) {
+        for (const pair<const TLeft, set<TRight>> &p : m) {
             _left.push_back(p.first);
         }
     }


### PR DESCRIPTION
- suppress clang self-assignment warning for unit test with intentional self-assignment
- avoid unnecessary copies in loop variables (Wrange-loop-construct)
- don't move-return temporary objects (Wpessimizing-move)
- add missing 'override' (Winconsistent-missing-override)
- catch exception by reference
- make operator== symmetric (c++20 Wambiguous-reversed-operator)
