### PR TITLE
Assumptions for is_zero and is_nonzero

### DIFF
--- a/symengine/assumptions.cpp
+++ b/symengine/assumptions.cpp
@@ -40,6 +40,7 @@ Assumptions::Assumptions(const set_basic &statements)
                     set_map(negative_, arg2, false);
                     set_map(nonpositive_, arg2, false);
                     set_map(nonzero_, arg2, true);
+                    set_map(zero_, arg2, false);
                 } else if (down_cast<const Number &>(*arg1).is_zero()) {
                     set_map(nonnegative_, arg2, true);
                     set_map(negative_, arg2, false);
@@ -52,6 +53,7 @@ Assumptions::Assumptions(const set_basic &statements)
                     set_map(negative_, arg1, true);
                     set_map(nonpositive_, arg1, true);
                     set_map(nonzero_, arg1, true);
+                    set_map(zero_, arg1, false);
                 } else if (down_cast<const Number &>(*arg2).is_zero()) {
                     set_map(nonpositive_, arg1, true);
                     set_map(positive_, arg1, false);
@@ -70,6 +72,7 @@ Assumptions::Assumptions(const set_basic &statements)
                     set_map(negative_, arg2, false);
                     set_map(nonpositive_, arg2, false);
                     set_map(nonzero_, arg2, true);
+                    set_map(zero_, arg2, false);
                 }
             } else if (is_a<Symbol>(*arg1) and is_a_Number(*arg2)) {
                 real_symbols_.insert(arg1);
@@ -79,6 +82,38 @@ Assumptions::Assumptions(const set_basic &statements)
                     set_map(negative_, arg1, true);
                     set_map(nonpositive_, arg1, true);
                     set_map(nonzero_, arg1, true);
+                    set_map(zero_, arg1, false);
+                }
+            }
+        } else if (is_a<Equality>(*s)) {
+            const Equality &equals = down_cast<const Equality &>(*s);
+            const auto arg1 = equals.get_arg1();
+            const auto arg2 = equals.get_arg2();
+            if (is_a_Number(*arg1) and is_a<Symbol>(*arg2)) {
+                complex_symbols_.insert(arg2);
+                if (down_cast<const Number &>(*arg1).is_zero()) {
+                    set_map(zero_, arg2, true);
+                    real_symbols_.insert(arg2);
+                    rational_symbols_.insert(arg2);
+                    integer_symbols_.insert(arg2);
+                    set_map(positive_, arg2, false);
+                    set_map(negative_, arg2, false);
+                    set_map(nonpositive_, arg2, true);
+                    set_map(nonnegative_, arg2, true);
+                    set_map(nonzero_, arg2, false);
+                } else {
+                    set_map(zero_, arg2, false);
+                    set_map(nonzero_, arg2, true);
+                }
+            }
+        } else if (is_a<Unequality>(*s)) {
+            const Unequality &uneq = down_cast<const Unequality &>(*s);
+            const auto arg1 = uneq.get_arg1();
+            const auto arg2 = uneq.get_arg2();
+            if (is_a_Number(*arg1) and is_a<Symbol>(*arg2)) {
+                if (down_cast<const Number &>(*arg1).is_zero()) {
+                    set_map(zero_, arg2, false);
+                    set_map(nonzero_, arg2, true);
                 }
             }
         }
@@ -156,4 +191,10 @@ tribool Assumptions::is_nonzero(const RCP<const Basic> &symbol) const
 {
     return from_map(nonzero_, symbol);
 }
+
+tribool Assumptions::is_zero(const RCP<const Basic> &symbol) const
+{
+    return from_map(zero_, symbol);
+}
+
 } // namespace SymEngine

--- a/symengine/assumptions.h
+++ b/symengine/assumptions.h
@@ -22,6 +22,7 @@ private:
     umap_basic_bool negative_;
     umap_basic_bool nonpositive_;
     umap_basic_bool nonzero_;
+    umap_basic_bool zero_;
 
     void set_map(umap_basic_bool &map, const RCP<const Basic> &symbol,
                  bool value);
@@ -39,6 +40,7 @@ public:
     tribool is_negative(const RCP<const Basic> &symbol) const;
     tribool is_nonpositive(const RCP<const Basic> &symbol) const;
     tribool is_nonzero(const RCP<const Basic> &symbol) const;
+    tribool is_zero(const RCP<const Basic> &symbol) const;
 };
 } // namespace SymEngine
 

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -141,8 +141,8 @@ inline bool is_number_and_zero(const Basic &b)
     return is_a_Number(b) and down_cast<const Number &>(b).is_zero();
 }
 
-tribool is_zero(const Basic &b);
-tribool is_nonzero(const Basic &b);
+tribool is_zero(const Basic &b, const Assumptions *assumptions = nullptr);
+tribool is_nonzero(const Basic &b, const Assumptions *assumptions = nullptr);
 tribool is_positive(const Basic &b);
 tribool is_nonpositive(const Basic &b);
 tribool is_negative(const Basic &b);

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -141,7 +141,23 @@ inline bool is_number_and_zero(const Basic &b)
     return is_a_Number(b) and down_cast<const Number &>(b).is_zero();
 }
 
+/**
+ * @brief Check if a number is zero
+ * @param b Basic
+ * @param assumptions Assumptions
+ * @returns tribool
+ *
+ * Check if b is zero. If b is not numeric an exception will be thrown.
+ */
 tribool is_zero(const Basic &b, const Assumptions *assumptions = nullptr);
+/**
+ * @brief Check if a number is non-zero
+ * @param b Basic
+ * @param assumptions Assumptions
+ * @returns tribool
+ *
+ * Check if b is non-zero. If b is not numeric an exception will be thrown.
+ */
 tribool is_nonzero(const Basic &b, const Assumptions *assumptions = nullptr);
 tribool is_positive(const Basic &b);
 tribool is_nonpositive(const Basic &b);

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -2,6 +2,59 @@
 
 namespace SymEngine
 {
+
+void ZeroVisitor::error()
+{
+    throw SymEngineException(
+        "Only numeric types allowed for is_zero/is_nonzero");
+}
+
+void ZeroVisitor::bvisit(const Basic &x)
+{
+    is_zero_ = tribool::indeterminate;
+}
+
+void ZeroVisitor::bvisit(const Set &x)
+{
+    error();
+}
+
+void ZeroVisitor::bvisit(const Relational &x)
+{
+    error();
+}
+
+void ZeroVisitor::bvisit(const Boolean &x)
+{
+    error();
+}
+
+void ZeroVisitor::bvisit(const Constant &x)
+{
+    is_zero_ = tribool::trifalse;
+}
+
+void ZeroVisitor::bvisit(const Abs &x)
+{
+    x.get_arg()->accept(*this);
+}
+
+void ZeroVisitor::bvisit(const Conjugate &x)
+{
+    x.get_arg()->accept(*this);
+}
+
+void ZeroVisitor::bvisit(const Sign &x)
+{
+    x.get_arg()->accept(*this);
+}
+
+void ZeroVisitor::bvisit(const PrimePi &x)
+{
+    // First prime is 2 so pi(x) is zero for x < 2
+    is_zero_ = is_negative(*sub(x.get_arg(), integer(2)));
+}
+
 void ZeroVisitor::bvisit(const Number &x)
 {
     if (bool(x.is_zero())) {

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -11,26 +11,31 @@ void ZeroVisitor::bvisit(const Number &x)
     }
 }
 
+void ZeroVisitor::bvisit(const Symbol &x)
+{
+    if (assumptions_) {
+        is_zero_ = assumptions_->is_zero(x.rcp_from_this());
+    } else {
+        is_zero_ = tribool::indeterminate;
+    }
+}
+
 tribool ZeroVisitor::apply(const Basic &b)
 {
     b.accept(*this);
-    tribool result = is_zero_;
-    if (not zero_ and not neither_) {
-        result = not_tribool(result);
-    }
-    return result;
+    return is_zero_;
 }
 
-tribool is_zero(const Basic &b)
+tribool is_zero(const Basic &b, const Assumptions *assumptions)
 {
-    ZeroVisitor visitor(true);
+    ZeroVisitor visitor(assumptions);
     return visitor.apply(b);
 }
 
-tribool is_nonzero(const Basic &b)
+tribool is_nonzero(const Basic &b, const Assumptions *assumptions)
 {
-    ZeroVisitor visitor(false);
-    return visitor.apply(b);
+    ZeroVisitor visitor(assumptions);
+    return not_tribool(visitor.apply(b));
 }
 
 void PositiveVisitor::bvisit(const Number &x)

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -12,54 +12,22 @@ private:
     tribool is_zero_;
     const Assumptions *assumptions_;
 
-    void error()
-    {
-        throw SymEngineException(
-            "Only numeric types allowed for is_zero/is_nonzero");
-    };
+    void error();
 
 public:
     ZeroVisitor(const Assumptions *assumptions) : assumptions_(assumptions) {}
 
-    void bvisit(const Basic &x)
-    {
-        is_zero_ = tribool::indeterminate;
-    };
+    void bvisit(const Basic &x);
     void bvisit(const Symbol &x);
     void bvisit(const Number &x);
-    void bvisit(const Set &x)
-    {
-        error();
-    };
-    void bvisit(const Relational &x)
-    {
-        error();
-    };
-    void bvisit(const Boolean &x)
-    {
-        error();
-    };
-    void bvisit(const Constant &x)
-    {
-        is_zero_ = tribool::trifalse;
-    };
-    void bvisit(const Abs &x)
-    {
-        x.get_arg()->accept(*this);
-    };
-    void bvisit(const Conjugate &x)
-    {
-        x.get_arg()->accept(*this);
-    };
-    void bvisit(const Sign &x)
-    {
-        x.get_arg()->accept(*this);
-    };
-    void bvisit(const PrimePi &x)
-    {
-        // First prime is 2 so pi(x) is zero for x < 2
-        is_zero_ = is_negative(*sub(x.get_arg(), integer(2)));
-    };
+    void bvisit(const Set &x);
+    void bvisit(const Relational &x);
+    void bvisit(const Boolean &x);
+    void bvisit(const Constant &x);
+    void bvisit(const Abs &x);
+    void bvisit(const Conjugate &x);
+    void bvisit(const Sign &x);
+    void bvisit(const PrimePi &x);
 
     tribool apply(const Basic &b);
 };

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -9,35 +9,35 @@ namespace SymEngine
 class ZeroVisitor : public BaseVisitor<ZeroVisitor>
 {
 private:
-    bool zero_; // true = testing for zero, false = testing for nonzero
     tribool is_zero_;
-    bool neither_ = false; // Neither zero nor non-zero, i.e. not a number
+    const Assumptions *assumptions_;
+
+    void error()
+    {
+        throw SymEngineException(
+            "Only numeric types allowed for is_zero/is_nonzero");
+    };
 
 public:
-    ZeroVisitor(bool zero) : zero_{zero} {}
+    ZeroVisitor(const Assumptions *assumptions) : assumptions_(assumptions) {}
+
     void bvisit(const Basic &x)
     {
         is_zero_ = tribool::indeterminate;
     };
-    void bvisit(const Symbol &x)
-    {
-        is_zero_ = tribool::indeterminate;
-    };
+    void bvisit(const Symbol &x);
     void bvisit(const Number &x);
     void bvisit(const Set &x)
     {
-        is_zero_ = tribool::trifalse;
-        neither_ = true;
+        error();
     };
     void bvisit(const Relational &x)
     {
-        is_zero_ = tribool::trifalse;
-        neither_ = true;
+        error();
     };
     void bvisit(const Boolean &x)
     {
-        is_zero_ = tribool::trifalse;
-        neither_ = true;
+        error();
     };
     void bvisit(const Constant &x)
     {

--- a/symengine/tests/basic/test_assumptions.cpp
+++ b/symengine/tests/basic/test_assumptions.cpp
@@ -37,6 +37,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     RCP<const Basic> rel12 = Gt(x, integer(-2));
     RCP<const Basic> rel13 = Eq(x, integer(0));
     RCP<const Basic> rel14 = Ne(x, integer(0));
+    RCP<const Basic> rel;
 
     auto a1 = Assumptions({s1->contains(x)});
     REQUIRE(is_true(a1.is_real(x)));
@@ -201,6 +202,11 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_indeterminate(a18.is_positive(x)));
     REQUIRE(is_true(a18.is_nonzero(x)));
     REQUIRE(is_false(a18.is_zero(x)));
+
+    rel = Eq(x, integer(1));
+    auto a = Assumptions({rel});
+    REQUIRE(is_true(a.is_nonzero(x)));
+    REQUIRE(is_false(a.is_zero(x)));
 
     CHECK_THROWS_AS(Assumptions({rel5, rel6}), SymEngineException &);
 }

--- a/symengine/tests/basic/test_assumptions.cpp
+++ b/symengine/tests/basic/test_assumptions.cpp
@@ -35,6 +35,8 @@ TEST_CASE("Test assumptions", "[assumptions]")
     RCP<const Basic> rel10 = Ge(x, integer(-2));
     RCP<const Basic> rel11 = Lt(x, integer(-2));
     RCP<const Basic> rel12 = Gt(x, integer(-2));
+    RCP<const Basic> rel13 = Eq(x, integer(0));
+    RCP<const Basic> rel14 = Ne(x, integer(0));
 
     auto a1 = Assumptions({s1->contains(x)});
     REQUIRE(is_true(a1.is_real(x)));
@@ -64,6 +66,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_indeterminate(a5.is_nonnegative(x)));
     REQUIRE(is_false(a5.is_positive(x)));
     REQUIRE(is_indeterminate(a5.is_nonzero(x)));
+    REQUIRE(is_indeterminate(a5.is_zero(x)));
     REQUIRE(is_indeterminate(a5.is_rational(x)));
 
     auto a6 = Assumptions({rel2});
@@ -73,6 +76,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_true(a6.is_nonnegative(x)));
     REQUIRE(is_indeterminate(a6.is_positive(x)));
     REQUIRE(is_indeterminate(a6.is_nonzero(x)));
+    REQUIRE(is_indeterminate(a6.is_zero(x)));
     REQUIRE(is_indeterminate(a6.is_rational(x)));
 
     auto a7 = Assumptions({rel3});
@@ -82,6 +86,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_indeterminate(a7.is_nonnegative(x)));
     REQUIRE(is_indeterminate(a7.is_positive(x)));
     REQUIRE(is_indeterminate(a7.is_nonzero(x)));
+    REQUIRE(is_indeterminate(a7.is_zero(x)));
     REQUIRE(is_indeterminate(a7.is_rational(x)));
 
     auto a8 = Assumptions({rel4});
@@ -100,6 +105,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_false(a9.is_nonnegative(x)));
     REQUIRE(is_false(a9.is_positive(x)));
     REQUIRE(is_true(a9.is_nonzero(x)));
+    REQUIRE(is_false(a9.is_zero(x)));
     REQUIRE(is_indeterminate(a9.is_rational(x)));
 
     auto a10 = Assumptions({rel6});
@@ -109,6 +115,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_true(a10.is_nonnegative(x)));
     REQUIRE(is_true(a10.is_positive(x)));
     REQUIRE(is_true(a10.is_nonzero(x)));
+    REQUIRE(is_false(a10.is_zero(x)));
     REQUIRE(is_indeterminate(a10.is_rational(x)));
 
     auto a11 = Assumptions({rel7});
@@ -118,6 +125,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_indeterminate(a11.is_nonnegative(x)));
     REQUIRE(is_indeterminate(a11.is_positive(x)));
     REQUIRE(is_indeterminate(a11.is_nonzero(x)));
+    REQUIRE(is_indeterminate(a11.is_zero(x)));
     REQUIRE(is_indeterminate(a11.is_rational(x)));
 
     auto a12 = Assumptions({rel8});
@@ -127,6 +135,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_true(a12.is_nonnegative(x)));
     REQUIRE(is_true(a12.is_positive(x)));
     REQUIRE(is_true(a12.is_nonzero(x)));
+    REQUIRE(is_false(a12.is_zero(x)));
     REQUIRE(is_indeterminate(a12.is_rational(x)));
 
     auto a13 = Assumptions({rel9});
@@ -136,6 +145,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_false(a13.is_nonnegative(x)));
     REQUIRE(is_false(a13.is_positive(x)));
     REQUIRE(is_true(a13.is_nonzero(x)));
+    REQUIRE(is_false(a13.is_zero(x)));
     REQUIRE(is_indeterminate(a13.is_rational(x)));
 
     auto a14 = Assumptions({rel10});
@@ -145,6 +155,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_indeterminate(a14.is_nonnegative(x)));
     REQUIRE(is_indeterminate(a14.is_positive(x)));
     REQUIRE(is_indeterminate(a14.is_nonzero(x)));
+    REQUIRE(is_indeterminate(a14.is_zero(x)));
     REQUIRE(is_indeterminate(a14.is_rational(x)));
 
     auto a15 = Assumptions({rel11});
@@ -154,6 +165,7 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_false(a15.is_nonnegative(x)));
     REQUIRE(is_false(a15.is_positive(x)));
     REQUIRE(is_true(a15.is_nonzero(x)));
+    REQUIRE(is_false(a15.is_zero(x)));
     REQUIRE(is_indeterminate(a15.is_rational(x)));
 
     auto a16 = Assumptions({rel12});
@@ -163,7 +175,32 @@ TEST_CASE("Test assumptions", "[assumptions]")
     REQUIRE(is_indeterminate(a16.is_nonnegative(x)));
     REQUIRE(is_indeterminate(a16.is_positive(x)));
     REQUIRE(is_indeterminate(a16.is_nonzero(x)));
+    REQUIRE(is_indeterminate(a16.is_zero(x)));
     REQUIRE(is_indeterminate(a16.is_rational(x)));
+
+    auto a17 = Assumptions({rel13});
+    REQUIRE(is_true(a17.is_real(x)));
+    REQUIRE(is_true(a17.is_rational(x)));
+    REQUIRE(is_true(a17.is_complex(x)));
+    REQUIRE(is_true(a17.is_integer(x)));
+    REQUIRE(is_true(a17.is_nonpositive(x)));
+    REQUIRE(is_false(a17.is_negative(x)));
+    REQUIRE(is_true(a17.is_nonnegative(x)));
+    REQUIRE(is_false(a17.is_positive(x)));
+    REQUIRE(is_false(a17.is_nonzero(x)));
+    REQUIRE(is_true(a17.is_zero(x)));
+
+    auto a18 = Assumptions({rel14});
+    REQUIRE(is_indeterminate(a18.is_real(x)));
+    REQUIRE(is_indeterminate(a18.is_rational(x)));
+    REQUIRE(is_indeterminate(a18.is_complex(x)));
+    REQUIRE(is_indeterminate(a18.is_integer(x)));
+    REQUIRE(is_indeterminate(a18.is_nonpositive(x)));
+    REQUIRE(is_indeterminate(a18.is_negative(x)));
+    REQUIRE(is_indeterminate(a18.is_nonnegative(x)));
+    REQUIRE(is_indeterminate(a18.is_positive(x)));
+    REQUIRE(is_true(a18.is_nonzero(x)));
+    REQUIRE(is_false(a18.is_zero(x)));
 
     CHECK_THROWS_AS(Assumptions({rel5, rel6}), SymEngineException &);
 }

--- a/symengine/tests/basic/test_test_visitors.cpp
+++ b/symengine/tests/basic/test_test_visitors.cpp
@@ -25,6 +25,7 @@ using SymEngine::Set;
 using SymEngine::sin;
 using SymEngine::symbol;
 using SymEngine::Symbol;
+using SymEngine::SymEngineException;
 using SymEngine::tribool;
 
 TEST_CASE("Test is zero", "[is_zero]")
@@ -37,7 +38,6 @@ TEST_CASE("Test is zero", "[is_zero]")
     RCP<const Basic> s1 = interval(i1, i2);
     RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
     RCP<const Basic> rel1 = Eq(x, i1);
-    RCP<const Basic> rel2 = Lt(x, i1);
     RCP<const Symbol> t = symbol("t");
     RCP<const Basic> f = function_symbol("f", t);
     RCP<const Basic> d1 = f->diff(t);
@@ -47,18 +47,26 @@ TEST_CASE("Test is zero", "[is_zero]")
     REQUIRE(is_zero(*i2) == tribool::trifalse);
     REQUIRE(is_zero(*rat1) == tribool::trifalse);
     REQUIRE(is_zero(*rat2) == tribool::tritrue);
-    REQUIRE(is_zero(*s1) == tribool::trifalse);
+    REQUIRE_THROWS_AS(is_zero(*s1), SymEngineException &);
     REQUIRE(is_zero(*c1) == tribool::trifalse);
-    REQUIRE(is_zero(*rel1) == tribool::trifalse);
-    REQUIRE(is_zero(*rel2) == tribool::trifalse);
+    REQUIRE_THROWS_AS(is_zero(*rel1), SymEngineException &);
     REQUIRE(is_zero(*pi) == tribool::trifalse);
     REQUIRE(is_zero(*d1) == tribool::indeterminate);
-    REQUIRE(is_zero(*boolTrue) == tribool::trifalse);
+    REQUIRE_THROWS_AS(is_zero(*boolTrue), SymEngineException &);
     REQUIRE(is_zero(*pi) == tribool::trifalse);
     REQUIRE(is_indeterminate(is_zero(*abs(x))));
     REQUIRE(is_indeterminate(is_zero(*conjugate(x))));
     REQUIRE(is_indeterminate(is_zero(*sign(x))));
     REQUIRE(is_indeterminate(is_zero(*primepi(x))));
+
+    const auto a1 = Assumptions({Eq(x, integer(0))});
+    REQUIRE(is_true(is_zero(*x, &a1)));
+
+    const auto a2 = Assumptions({Gt(x, integer(0))});
+    REQUIRE(is_false(is_zero(*x, &a2)));
+
+    const auto a3 = Assumptions({Ne(x, integer(0))});
+    REQUIRE(is_false(is_zero(*x, &a3)));
 }
 
 TEST_CASE("Test is nonzero", "[is_nonzero]")
@@ -71,7 +79,6 @@ TEST_CASE("Test is nonzero", "[is_nonzero]")
     RCP<const Basic> s1 = interval(i1, i2);
     RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
     RCP<const Basic> rel1 = Eq(x, i1);
-    RCP<const Basic> rel2 = Lt(x, i1);
     RCP<const Symbol> t = symbol("t");
     RCP<const Basic> f = function_symbol("f", t);
     RCP<const Basic> d1 = f->diff(t);
@@ -81,13 +88,12 @@ TEST_CASE("Test is nonzero", "[is_nonzero]")
     REQUIRE(is_true(is_nonzero(*i2)));
     REQUIRE(is_true(is_nonzero(*rat1)));
     REQUIRE(is_false(is_nonzero(*rat2)));
-    REQUIRE(is_false(is_nonzero(*s1)));
+    REQUIRE_THROWS_AS(is_nonzero(*s1), SymEngineException &);
     REQUIRE(is_true(is_nonzero(*c1)));
-    REQUIRE(is_false(is_nonzero(*rel1)));
-    REQUIRE(is_false(is_nonzero(*rel2)));
+    REQUIRE_THROWS_AS(is_nonzero(*rel1), SymEngineException &);
     REQUIRE(is_true(is_nonzero(*pi)));
     REQUIRE(is_indeterminate(is_nonzero(*d1)));
-    REQUIRE(is_false(is_nonzero(*boolTrue)));
+    REQUIRE_THROWS_AS(is_nonzero(*boolTrue), SymEngineException &);
     REQUIRE(is_true(is_nonzero(*pi)));
 }
 


### PR DESCRIPTION
This will replace #1790.

* Handle symbol equal to or not equal to zero in `Assumptions`
* Use assumptions in `is_zero` and `is_nonzero`
* throw exception for non-numeric expression in `is_zero` and `is_nonzero`