### PR TITLE
Allow assumptions in is_positive etc

### DIFF
--- a/symengine/number.h
+++ b/symengine/number.h
@@ -159,10 +159,12 @@ tribool is_zero(const Basic &b, const Assumptions *assumptions = nullptr);
  * Check if b is non-zero. If b is not numeric an exception will be thrown.
  */
 tribool is_nonzero(const Basic &b, const Assumptions *assumptions = nullptr);
-tribool is_positive(const Basic &b);
-tribool is_nonpositive(const Basic &b);
-tribool is_negative(const Basic &b);
-tribool is_nonnegative(const Basic &b);
+tribool is_positive(const Basic &b, const Assumptions *assumptions = nullptr);
+tribool is_nonpositive(const Basic &b,
+                       const Assumptions *assumptions = nullptr);
+tribool is_negative(const Basic &b, const Assumptions *assumptions = nullptr);
+tribool is_nonnegative(const Basic &b,
+                       const Assumptions *assumptions = nullptr);
 tribool is_integer(const Basic &b, const Assumptions *assumptions = nullptr);
 tribool is_real(const Basic &b, const Assumptions *assumptions = nullptr);
 tribool is_complex(const Basic &b, const Assumptions *assumptions = nullptr);

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -91,6 +91,15 @@ tribool is_nonzero(const Basic &b, const Assumptions *assumptions)
     return not_tribool(visitor.apply(b));
 }
 
+void PositiveVisitor::bvisit(const Symbol &x)
+{
+    if (assumptions_) {
+        is_positive_ = assumptions_->is_positive(x.rcp_from_this());
+    } else {
+        is_positive_ = tribool::indeterminate;
+    }
+}
+
 void PositiveVisitor::bvisit(const Number &x)
 {
     if (is_a_Complex(x)) {
@@ -108,10 +117,19 @@ tribool PositiveVisitor::apply(const Basic &b)
     return is_positive_;
 }
 
-tribool is_positive(const Basic &b)
+tribool is_positive(const Basic &b, const Assumptions *assumptions)
 {
-    PositiveVisitor visitor;
+    PositiveVisitor visitor(assumptions);
     return visitor.apply(b);
+}
+
+void NonPositiveVisitor::bvisit(const Symbol &x)
+{
+    if (assumptions_) {
+        is_nonpositive_ = assumptions_->is_nonpositive(x.rcp_from_this());
+    } else {
+        is_nonpositive_ = tribool::indeterminate;
+    }
 }
 
 void NonPositiveVisitor::bvisit(const Number &x)
@@ -131,10 +149,19 @@ tribool NonPositiveVisitor::apply(const Basic &b)
     return is_nonpositive_;
 }
 
-tribool is_nonpositive(const Basic &b)
+tribool is_nonpositive(const Basic &b, const Assumptions *assumptions)
 {
-    NonPositiveVisitor visitor;
+    NonPositiveVisitor visitor(assumptions);
     return visitor.apply(b);
+}
+
+void NegativeVisitor::bvisit(const Symbol &x)
+{
+    if (assumptions_) {
+        is_negative_ = assumptions_->is_negative(x.rcp_from_this());
+    } else {
+        is_negative_ = tribool::indeterminate;
+    }
 }
 
 void NegativeVisitor::bvisit(const Number &x)
@@ -154,10 +181,19 @@ tribool NegativeVisitor::apply(const Basic &b)
     return is_negative_;
 }
 
-tribool is_negative(const Basic &b)
+tribool is_negative(const Basic &b, const Assumptions *assumptions)
 {
-    NegativeVisitor visitor;
+    NegativeVisitor visitor(assumptions);
     return visitor.apply(b);
+}
+
+void NonNegativeVisitor::bvisit(const Symbol &x)
+{
+    if (assumptions_) {
+        is_nonnegative_ = assumptions_->is_nonnegative(x.rcp_from_this());
+    } else {
+        is_nonnegative_ = tribool::indeterminate;
+    }
 }
 
 void NonNegativeVisitor::bvisit(const Number &x)
@@ -177,9 +213,9 @@ tribool NonNegativeVisitor::apply(const Basic &b)
     return is_nonnegative_;
 }
 
-tribool is_nonnegative(const Basic &b)
+tribool is_nonnegative(const Basic &b, const Assumptions *assumptions)
 {
-    NonNegativeVisitor visitor;
+    NonNegativeVisitor visitor(assumptions);
     return visitor.apply(b);
 }
 

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -91,6 +91,36 @@ tribool is_nonzero(const Basic &b, const Assumptions *assumptions)
     return not_tribool(visitor.apply(b));
 }
 
+void PositiveVisitor::error()
+{
+    throw SymEngineException("Only numeric types allowed for is_positive");
+}
+
+void PositiveVisitor::bvisit(const Constant &x)
+{
+    is_positive_ = tribool::tritrue;
+}
+
+void PositiveVisitor::bvisit(const Basic &x)
+{
+    is_positive_ = tribool::indeterminate;
+}
+
+void PositiveVisitor::bvisit(const Set &x)
+{
+    error();
+}
+
+void PositiveVisitor::bvisit(const Relational &x)
+{
+    error();
+}
+
+void PositiveVisitor::bvisit(const Boolean &x)
+{
+    error();
+}
+
 void PositiveVisitor::bvisit(const Symbol &x)
 {
     if (assumptions_) {
@@ -121,6 +151,36 @@ tribool is_positive(const Basic &b, const Assumptions *assumptions)
 {
     PositiveVisitor visitor(assumptions);
     return visitor.apply(b);
+}
+
+void NonPositiveVisitor::error()
+{
+    throw SymEngineException("Only numeric types allowed for is_negative");
+}
+
+void NonPositiveVisitor::bvisit(const Constant &x)
+{
+    is_nonpositive_ = tribool::trifalse;
+}
+
+void NonPositiveVisitor::bvisit(const Basic &x)
+{
+    is_nonpositive_ = tribool::indeterminate;
+}
+
+void NonPositiveVisitor::bvisit(const Set &x)
+{
+    error();
+}
+
+void NonPositiveVisitor::bvisit(const Relational &x)
+{
+    error();
+}
+
+void NonPositiveVisitor::bvisit(const Boolean &x)
+{
+    error();
 }
 
 void NonPositiveVisitor::bvisit(const Symbol &x)
@@ -155,6 +215,36 @@ tribool is_nonpositive(const Basic &b, const Assumptions *assumptions)
     return visitor.apply(b);
 }
 
+void NegativeVisitor::error()
+{
+    throw SymEngineException("Only numeric types allowed for is_negative");
+}
+
+void NegativeVisitor::bvisit(const Basic &x)
+{
+    is_negative_ = tribool::indeterminate;
+}
+
+void NegativeVisitor::bvisit(const Set &x)
+{
+    error();
+}
+
+void NegativeVisitor::bvisit(const Relational &x)
+{
+    error();
+}
+
+void NegativeVisitor::bvisit(const Boolean &x)
+{
+    error();
+}
+
+void NegativeVisitor::bvisit(const Constant &x)
+{
+    is_negative_ = tribool::trifalse;
+}
+
 void NegativeVisitor::bvisit(const Symbol &x)
 {
     if (assumptions_) {
@@ -185,6 +275,36 @@ tribool is_negative(const Basic &b, const Assumptions *assumptions)
 {
     NegativeVisitor visitor(assumptions);
     return visitor.apply(b);
+}
+
+void NonNegativeVisitor::error()
+{
+    throw SymEngineException("Only numeric types allowed for is_nonnegative");
+}
+
+void NonNegativeVisitor::bvisit(const Basic &x)
+{
+    is_nonnegative_ = tribool::indeterminate;
+}
+
+void NonNegativeVisitor::bvisit(const Set &x)
+{
+    error();
+}
+
+void NonNegativeVisitor::bvisit(const Relational &x)
+{
+    error();
+}
+
+void NonNegativeVisitor::bvisit(const Boolean &x)
+{
+    error();
+}
+
+void NonNegativeVisitor::bvisit(const Constant &x)
+{
+    is_nonnegative_ = tribool::tritrue;
 }
 
 void NonNegativeVisitor::bvisit(const Symbol &x)

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -38,36 +38,18 @@ private:
     tribool is_positive_;
     const Assumptions *assumptions_;
 
-    void error()
-    {
-        throw SymEngineException("Only numeric types allowed for is_positive");
-    };
+    void error();
 
 public:
     PositiveVisitor(const Assumptions *assumptions)
         : assumptions_(assumptions){};
     void bvisit(const Symbol &x);
     void bvisit(const Number &x);
-    void bvisit(const Constant &x)
-    {
-        is_positive_ = tribool::tritrue;
-    };
-    void bvisit(const Basic &x)
-    {
-        is_positive_ = tribool::indeterminate;
-    };
-    void bvisit(const Set &x)
-    {
-        error();
-    };
-    void bvisit(const Relational &x)
-    {
-        error();
-    };
-    void bvisit(const Boolean &x)
-    {
-        error();
-    };
+    void bvisit(const Constant &x);
+    void bvisit(const Basic &x);
+    void bvisit(const Set &x);
+    void bvisit(const Relational &x);
+    void bvisit(const Boolean &x);
 
     tribool apply(const Basic &b);
 };
@@ -78,36 +60,18 @@ private:
     tribool is_nonpositive_;
     const Assumptions *assumptions_;
 
-    void error()
-    {
-        throw SymEngineException("Only numeric types allowed for is_negative");
-    };
+    void error();
 
 public:
     NonPositiveVisitor(const Assumptions *assumptions)
         : assumptions_(assumptions){};
     void bvisit(const Symbol &x);
     void bvisit(const Number &x);
-    void bvisit(const Constant &x)
-    {
-        is_nonpositive_ = tribool::trifalse;
-    };
-    void bvisit(const Basic &x)
-    {
-        is_nonpositive_ = tribool::indeterminate;
-    };
-    void bvisit(const Set &x)
-    {
-        error();
-    };
-    void bvisit(const Relational &x)
-    {
-        error();
-    };
-    void bvisit(const Boolean &x)
-    {
-        error();
-    };
+    void bvisit(const Constant &x);
+    void bvisit(const Basic &x);
+    void bvisit(const Set &x);
+    void bvisit(const Relational &x);
+    void bvisit(const Boolean &x);
 
     tribool apply(const Basic &b);
 };
@@ -118,36 +82,18 @@ private:
     tribool is_negative_;
     const Assumptions *assumptions_;
 
-    void error()
-    {
-        throw SymEngineException("Only numeric types allowed for is_negative");
-    };
+    void error();
 
 public:
     NegativeVisitor(const Assumptions *assumptions)
         : assumptions_(assumptions){};
-    void bvisit(const Basic &x)
-    {
-        is_negative_ = tribool::indeterminate;
-    };
+    void bvisit(const Basic &x);
     void bvisit(const Symbol &x);
     void bvisit(const Number &x);
-    void bvisit(const Set &x)
-    {
-        error();
-    };
-    void bvisit(const Relational &x)
-    {
-        error();
-    };
-    void bvisit(const Boolean &x)
-    {
-        error();
-    };
-    void bvisit(const Constant &x)
-    {
-        is_negative_ = tribool::trifalse;
-    };
+    void bvisit(const Set &x);
+    void bvisit(const Relational &x);
+    void bvisit(const Boolean &x);
+    void bvisit(const Constant &x);
 
     tribool apply(const Basic &b);
 };
@@ -158,37 +104,18 @@ private:
     tribool is_nonnegative_;
     const Assumptions *assumptions_;
 
-    void error()
-    {
-        throw SymEngineException(
-            "Only numeric types allowed for is_nonnegative");
-    };
+    void error();
 
 public:
     NonNegativeVisitor(const Assumptions *assumptions)
         : assumptions_(assumptions){};
-    void bvisit(const Basic &x)
-    {
-        is_nonnegative_ = tribool::indeterminate;
-    };
+    void bvisit(const Basic &x);
     void bvisit(const Symbol &x);
     void bvisit(const Number &x);
-    void bvisit(const Set &x)
-    {
-        error();
-    };
-    void bvisit(const Relational &x)
-    {
-        error();
-    };
-    void bvisit(const Boolean &x)
-    {
-        error();
-    };
-    void bvisit(const Constant &x)
-    {
-        is_nonnegative_ = tribool::tritrue;
-    };
+    void bvisit(const Set &x);
+    void bvisit(const Relational &x);
+    void bvisit(const Boolean &x);
+    void bvisit(const Constant &x);
 
     tribool apply(const Basic &b);
 };

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -36,12 +36,17 @@ class PositiveVisitor : public BaseVisitor<PositiveVisitor>
 {
 private:
     tribool is_positive_;
+    const Assumptions *assumptions_;
+
+    void error()
+    {
+        throw SymEngineException("Only numeric types allowed for is_positive");
+    };
 
 public:
-    void bvisit(const Symbol &x)
-    {
-        is_positive_ = tribool::indeterminate;
-    };
+    PositiveVisitor(const Assumptions *assumptions)
+        : assumptions_(assumptions){};
+    void bvisit(const Symbol &x);
     void bvisit(const Number &x);
     void bvisit(const Constant &x)
     {
@@ -53,15 +58,15 @@ public:
     };
     void bvisit(const Set &x)
     {
-        is_positive_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Relational &x)
     {
-        is_positive_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Boolean &x)
     {
-        is_positive_ = tribool::trifalse;
+        error();
     };
 
     tribool apply(const Basic &b);
@@ -71,12 +76,17 @@ class NonPositiveVisitor : public BaseVisitor<NonPositiveVisitor>
 {
 private:
     tribool is_nonpositive_;
+    const Assumptions *assumptions_;
+
+    void error()
+    {
+        throw SymEngineException("Only numeric types allowed for is_negative");
+    };
 
 public:
-    void bvisit(const Symbol &x)
-    {
-        is_nonpositive_ = tribool::indeterminate;
-    };
+    NonPositiveVisitor(const Assumptions *assumptions)
+        : assumptions_(assumptions){};
+    void bvisit(const Symbol &x);
     void bvisit(const Number &x);
     void bvisit(const Constant &x)
     {
@@ -88,15 +98,15 @@ public:
     };
     void bvisit(const Set &x)
     {
-        is_nonpositive_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Relational &x)
     {
-        is_nonpositive_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Boolean &x)
     {
-        is_nonpositive_ = tribool::trifalse;
+        error();
     };
 
     tribool apply(const Basic &b);
@@ -106,28 +116,33 @@ class NegativeVisitor : public BaseVisitor<NegativeVisitor>
 {
 private:
     tribool is_negative_;
+    const Assumptions *assumptions_;
+
+    void error()
+    {
+        throw SymEngineException("Only numeric types allowed for is_negative");
+    };
 
 public:
+    NegativeVisitor(const Assumptions *assumptions)
+        : assumptions_(assumptions){};
     void bvisit(const Basic &x)
     {
         is_negative_ = tribool::indeterminate;
     };
-    void bvisit(const Symbol &x)
-    {
-        is_negative_ = tribool::indeterminate;
-    };
+    void bvisit(const Symbol &x);
     void bvisit(const Number &x);
     void bvisit(const Set &x)
     {
-        is_negative_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Relational &x)
     {
-        is_negative_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Boolean &x)
     {
-        is_negative_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Constant &x)
     {
@@ -141,28 +156,34 @@ class NonNegativeVisitor : public BaseVisitor<NonNegativeVisitor>
 {
 private:
     tribool is_nonnegative_;
+    const Assumptions *assumptions_;
+
+    void error()
+    {
+        throw SymEngineException(
+            "Only numeric types allowed for is_nonnegative");
+    };
 
 public:
+    NonNegativeVisitor(const Assumptions *assumptions)
+        : assumptions_(assumptions){};
     void bvisit(const Basic &x)
     {
         is_nonnegative_ = tribool::indeterminate;
     };
-    void bvisit(const Symbol &x)
-    {
-        is_nonnegative_ = tribool::indeterminate;
-    };
+    void bvisit(const Symbol &x);
     void bvisit(const Number &x);
     void bvisit(const Set &x)
     {
-        is_nonnegative_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Relational &x)
     {
-        is_nonnegative_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Boolean &x)
     {
-        is_nonnegative_ = tribool::trifalse;
+        error();
     };
     void bvisit(const Constant &x)
     {

--- a/symengine/tests/basic/test_test_visitors.cpp
+++ b/symengine/tests/basic/test_test_visitors.cpp
@@ -110,7 +110,6 @@ TEST_CASE("Test is positive", "[is_positive]")
     RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
     RCP<const Number> c2 = Complex::from_two_nums(*i3, *i3);
     RCP<const Basic> rel1 = Eq(x, i1);
-    RCP<const Basic> rel2 = Lt(x, i1);
     RCP<const Symbol> t = symbol("t");
     RCP<const Basic> f = function_symbol("f", t);
     RCP<const Basic> d1 = f->diff(t);
@@ -122,14 +121,22 @@ TEST_CASE("Test is positive", "[is_positive]")
     REQUIRE(is_true(is_positive(*rat1)));
     REQUIRE(is_false(is_positive(*rat2)));
     REQUIRE(is_false(is_positive(*rat3)));
-    REQUIRE(is_false(is_positive(*s1)));
+    REQUIRE_THROWS_AS(is_positive(*s1), SymEngineException &);
     REQUIRE(is_false(is_positive(*c1)));
     REQUIRE(is_false(is_positive(*c2)));
-    REQUIRE(is_false(is_positive(*rel1)));
-    REQUIRE(is_false(is_positive(*rel2)));
+    REQUIRE_THROWS_AS(is_positive(*rel1), SymEngineException &);
     REQUIRE(is_true(is_positive(*pi)));
     REQUIRE(is_indeterminate(is_positive(*d1)));
-    REQUIRE(is_false(is_positive(*boolTrue)));
+    REQUIRE_THROWS_AS(is_positive(*boolTrue), SymEngineException &);
+
+    const auto a1 = Assumptions({Lt(x, integer(0))});
+    REQUIRE(is_false(is_positive(*x, &a1)));
+
+    const auto a2 = Assumptions({Lt(x, integer(1))});
+    REQUIRE(is_indeterminate(is_positive(*x, &a2)));
+
+    const auto a3 = Assumptions({Gt(x, integer(1))});
+    REQUIRE(is_true(is_positive(*x, &a3)));
 }
 
 TEST_CASE("Test is non positive", "[is_nonpositive]")
@@ -145,7 +152,6 @@ TEST_CASE("Test is non positive", "[is_nonpositive]")
     RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
     RCP<const Number> c2 = Complex::from_two_nums(*i3, *i3);
     RCP<const Basic> rel1 = Eq(x, i1);
-    RCP<const Basic> rel2 = Lt(x, i1);
     RCP<const Symbol> t = symbol("t");
     RCP<const Basic> f = function_symbol("f", t);
     RCP<const Basic> d1 = f->diff(t);
@@ -157,14 +163,22 @@ TEST_CASE("Test is non positive", "[is_nonpositive]")
     REQUIRE(is_false(is_nonpositive(*rat1)));
     REQUIRE(is_true(is_nonpositive(*rat2)));
     REQUIRE(is_true(is_nonpositive(*rat3)));
-    REQUIRE(is_false(is_nonpositive(*s1)));
+    REQUIRE_THROWS_AS(is_nonpositive(*s1), SymEngineException &);
     REQUIRE(is_false(is_nonpositive(*c1)));
     REQUIRE(is_false(is_nonpositive(*c2)));
-    REQUIRE(is_false(is_nonpositive(*rel1)));
-    REQUIRE(is_false(is_nonpositive(*rel2)));
+    REQUIRE_THROWS_AS(is_nonpositive(*rel1), SymEngineException &);
     REQUIRE(is_false(is_nonpositive(*pi)));
     REQUIRE(is_indeterminate(is_nonpositive(*d1)));
-    REQUIRE(is_false(is_nonpositive(*boolTrue)));
+    REQUIRE_THROWS_AS(is_nonpositive(*boolTrue), SymEngineException &);
+
+    const auto a1 = Assumptions({Lt(x, integer(0))});
+    REQUIRE(is_true(is_nonpositive(*x, &a1)));
+
+    const auto a2 = Assumptions({Lt(x, integer(1))});
+    REQUIRE(is_indeterminate(is_nonpositive(*x, &a2)));
+
+    const auto a3 = Assumptions({Gt(x, integer(1))});
+    REQUIRE(is_false(is_nonpositive(*x, &a3)));
 }
 
 TEST_CASE("Test is negative", "[is_negative]")
@@ -180,7 +194,6 @@ TEST_CASE("Test is negative", "[is_negative]")
     RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
     RCP<const Number> c2 = Complex::from_two_nums(*i3, *i3);
     RCP<const Basic> rel1 = Eq(x, i1);
-    RCP<const Basic> rel2 = Lt(x, i1);
     RCP<const Symbol> t = symbol("t");
     RCP<const Basic> f = function_symbol("f", t);
     RCP<const Basic> d1 = f->diff(t);
@@ -192,14 +205,22 @@ TEST_CASE("Test is negative", "[is_negative]")
     REQUIRE(is_false(is_negative(*rat1)));
     REQUIRE(is_false(is_negative(*rat2)));
     REQUIRE(is_true(is_negative(*rat3)));
-    REQUIRE(is_false(is_negative(*s1)));
+    REQUIRE_THROWS_AS(is_negative(*s1), SymEngineException &);
     REQUIRE(is_false(is_negative(*c1)));
     REQUIRE(is_false(is_negative(*c2)));
-    REQUIRE(is_false(is_negative(*rel1)));
-    REQUIRE(is_false(is_negative(*rel2)));
+    REQUIRE_THROWS_AS(is_negative(*rel1), SymEngineException &);
     REQUIRE(is_false(is_negative(*pi)));
     REQUIRE(is_indeterminate(is_negative(*d1)));
-    REQUIRE(is_false(is_negative(*boolTrue)));
+    REQUIRE_THROWS_AS(is_negative(*boolTrue), SymEngineException &);
+
+    const auto a1 = Assumptions({Lt(x, integer(0))});
+    REQUIRE(is_true(is_negative(*x, &a1)));
+
+    const auto a2 = Assumptions({Lt(x, integer(1))});
+    REQUIRE(is_indeterminate(is_negative(*x, &a2)));
+
+    const auto a3 = Assumptions({Gt(x, integer(1))});
+    REQUIRE(is_false(is_negative(*x, &a3)));
 }
 
 TEST_CASE("Test is nonnegative", "[is_nonnegative]")
@@ -215,7 +236,6 @@ TEST_CASE("Test is nonnegative", "[is_nonnegative]")
     RCP<const Number> c1 = Complex::from_two_nums(*i1, *i2);
     RCP<const Number> c2 = Complex::from_two_nums(*i3, *i3);
     RCP<const Basic> rel1 = Eq(x, i1);
-    RCP<const Basic> rel2 = Lt(x, i1);
     RCP<const Symbol> t = symbol("t");
     RCP<const Basic> f = function_symbol("f", t);
     RCP<const Basic> d1 = f->diff(t);
@@ -227,14 +247,22 @@ TEST_CASE("Test is nonnegative", "[is_nonnegative]")
     REQUIRE(is_true(is_nonnegative(*rat1)));
     REQUIRE(is_true(is_nonnegative(*rat2)));
     REQUIRE(is_false(is_nonnegative(*rat3)));
-    REQUIRE(is_false(is_nonnegative(*s1)));
+    REQUIRE_THROWS_AS(is_nonnegative(*s1), SymEngineException &);
     REQUIRE(is_false(is_nonnegative(*c1)));
     REQUIRE(is_false(is_nonnegative(*c2)));
-    REQUIRE(is_false(is_nonnegative(*rel1)));
-    REQUIRE(is_false(is_nonnegative(*rel2)));
+    REQUIRE_THROWS_AS(is_nonnegative(*rel1), SymEngineException &);
     REQUIRE(is_true(is_nonnegative(*pi)));
     REQUIRE(is_indeterminate(is_nonnegative(*d1)));
-    REQUIRE(is_false(is_nonnegative(*boolTrue)));
+    REQUIRE_THROWS_AS(is_nonnegative(*boolTrue), SymEngineException &);
+
+    const auto a1 = Assumptions({Lt(x, integer(0))});
+    REQUIRE(is_false(is_nonnegative(*x, &a1)));
+
+    const auto a2 = Assumptions({Lt(x, integer(1))});
+    REQUIRE(is_indeterminate(is_nonnegative(*x, &a2)));
+
+    const auto a3 = Assumptions({Gt(x, integer(1))});
+    REQUIRE(is_true(is_nonnegative(*x, &a3)));
 }
 
 TEST_CASE("Test is_integer", "[is_integer]")


### PR DESCRIPTION
* Allow assumptions in `is_positive`, `is_negative`, `is_nonpositve` and `is_nonnegative`.
* Throw for non-numeric elements in expressions for these tests