### PR TITLE
Add refine

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SRC
     visitor.cpp
     test_visitors.cpp
     assumptions.cpp
+    refine.cpp
 )
 
 if ("${SYMENGINE_INTEGER_CLASS}" STREQUAL "BOOSTMP")
@@ -198,6 +199,7 @@ set(HEADERS
     visitor.h
     test_visitors.h
     assumptions.h
+    refine.h
 )
 
 include(GNUInstallDirs)

--- a/symengine/refine.cpp
+++ b/symengine/refine.cpp
@@ -26,8 +26,8 @@ void RefineVisitor::bvisit(const Sign &x)
         result_ = integer(1);
     } else if (is_true(is_negative(*newarg, assumptions_))) {
         result_ = integer(-1);
-        //    } else if (is_true(is_zero(*newarg, assumptions_))) {
-        //        result_ = integer(0);
+    } else if (is_true(is_zero(*newarg, assumptions_))) {
+        result_ = integer(0);
     } else {
         result_ = sign(newarg);
     }

--- a/symengine/refine.cpp
+++ b/symengine/refine.cpp
@@ -1,0 +1,80 @@
+#include <symengine/refine.h>
+
+namespace SymEngine
+{
+
+void RefineVisitor::bvisit(const Abs &x)
+{
+    auto farg = x.get_arg();
+    auto newarg = apply(farg);
+    if (is_true(is_nonnegative(*newarg, assumptions_))) {
+        result_ = newarg;
+    } else if (is_true(is_nonpositive(*newarg, assumptions_))) {
+        result_ = neg(newarg);
+    } else if (is_a<Conjugate>(*newarg)) {
+        result_ = abs(down_cast<const Conjugate &>(*newarg).get_arg());
+    } else {
+        result_ = abs(newarg);
+    }
+}
+
+void RefineVisitor::bvisit(const Sign &x)
+{
+    auto farg = x.get_arg();
+    auto newarg = apply(farg);
+    if (is_true(is_positive(*newarg, assumptions_))) {
+        result_ = integer(1);
+    } else if (is_true(is_negative(*newarg, assumptions_))) {
+        result_ = integer(-1);
+        //    } else if (is_true(is_zero(*newarg, assumptions_))) {
+        //        result_ = integer(0);
+    } else {
+        result_ = sign(newarg);
+    }
+}
+
+void RefineVisitor::bvisit(const Floor &x)
+{
+    auto farg = x.get_arg();
+    auto newarg = apply(farg);
+    if (is_true(is_integer(*newarg, assumptions_))) {
+        result_ = newarg;
+    } else if (could_extract_minus(*newarg)) {
+        result_ = neg(ceiling(neg(newarg)));
+    } else {
+        result_ = floor(newarg);
+    }
+}
+
+void RefineVisitor::bvisit(const Ceiling &x)
+{
+    auto farg = x.get_arg();
+    auto newarg = apply(farg);
+    if (is_true(is_integer(*newarg, assumptions_))) {
+        result_ = newarg;
+    } else if (could_extract_minus(*newarg)) {
+        result_ = neg(floor(neg(newarg)));
+    } else {
+        result_ = ceiling(newarg);
+    }
+}
+
+void RefineVisitor::bvisit(const Conjugate &x)
+{
+    auto farg = x.get_arg();
+    auto newarg = apply(farg);
+    if (is_true(is_real(*newarg, assumptions_))) {
+        result_ = newarg;
+    } else {
+        result_ = conjugate(newarg);
+    }
+}
+
+RCP<const Basic> refine(const RCP<const Basic> &x,
+                        const Assumptions *assumptions)
+{
+    RefineVisitor b(assumptions);
+    return b.apply(x);
+}
+
+} // namespace SymEngine

--- a/symengine/refine.h
+++ b/symengine/refine.h
@@ -1,0 +1,37 @@
+#ifndef SYMENGINE_REFINE_H
+#define SYMENGINE_REFINE_H
+
+#include <symengine/visitor.h>
+#include <symengine/basic.h>
+#include <symengine/assumptions.h>
+
+namespace SymEngine
+{
+
+class RefineVisitor : public BaseVisitor<RefineVisitor, TransformVisitor>
+{
+private:
+    const Assumptions *assumptions_;
+
+public:
+    using TransformVisitor::bvisit;
+
+    RefineVisitor(const Assumptions *assumptions)
+        : BaseVisitor<RefineVisitor, TransformVisitor>(),
+          assumptions_(assumptions)
+    {
+    }
+
+    void bvisit(const Abs &x);
+    void bvisit(const Sign &x);
+    void bvisit(const Floor &x);
+    void bvisit(const Ceiling &x);
+    void bvisit(const Conjugate &x);
+};
+
+RCP<const Basic> refine(const RCP<const Basic> &x,
+                        const Assumptions *assumptions);
+
+} // namespace SymEngine
+
+#endif

--- a/symengine/tests/basic/CMakeLists.txt
+++ b/symengine/tests/basic/CMakeLists.txt
@@ -114,3 +114,7 @@ add_test(test_test_visitors ${PROJECT_BINARY_DIR}/test_test_visitors)
 add_executable(test_assumptions test_assumptions.cpp)
 target_link_libraries(test_assumptions symengine catch)
 add_test(test_assumptions ${PROJECT_BINARY_DIR}/test_assumptions)
+
+add_executable(test_refine test_refine.cpp)
+target_link_libraries(test_refine symengine catch)
+add_test(test_refine ${PROJECT_BINARY_DIR}/test_refine)

--- a/symengine/tests/basic/test_refine.cpp
+++ b/symengine/tests/basic/test_refine.cpp
@@ -1,0 +1,77 @@
+#include "catch.hpp"
+#include <symengine/refine.h>
+
+using SymEngine::Assumptions;
+using SymEngine::integer;
+using SymEngine::integers;
+using SymEngine::reals;
+using SymEngine::symbol;
+
+TEST_CASE("Test refine", "[refine]")
+{
+    auto x = symbol("x");
+
+    auto expr = abs(x);
+    auto a1 = Assumptions({Gt(x, integer(0))});
+    REQUIRE(eq(*refine(expr, &a1), *x));
+
+    expr = abs(x);
+    auto a2 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a2), *expr));
+
+    expr = abs(x);
+    auto a3 = Assumptions({Le(x, integer(0))});
+    REQUIRE(eq(*refine(expr, &a3), *neg(x)));
+
+    expr = abs(conjugate(x));
+    auto a3b = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a3b), *abs(x)));
+
+    expr = sign(x);
+    auto a4 = Assumptions({Lt(x, integer(0))});
+    REQUIRE(eq(*refine(expr, &a4), *integer(-1)));
+
+    expr = sign(x);
+    auto a5 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a5), *expr));
+
+    expr = sign(x);
+    auto a6 = Assumptions({Gt(x, integer(0))});
+    REQUIRE(eq(*refine(expr, &a6), *integer(1)));
+
+    expr = sign(abs(x));
+    auto a7 = Assumptions({Gt(x, integer(0))});
+    REQUIRE(eq(*refine(expr, &a7), *integer(1)));
+
+    expr = floor(x);
+    auto a8 = Assumptions({integers()->contains(x)});
+    REQUIRE(eq(*refine(expr, &a8), *x));
+
+    expr = floor(x);
+    auto a9 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a9), *expr));
+
+    expr = ceiling(x);
+    auto a10 = Assumptions({integers()->contains(x)});
+    REQUIRE(eq(*refine(expr, &a10), *x));
+
+    expr = ceiling(x);
+    auto a11 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a11), *expr));
+
+    expr = ceiling(neg(x));
+    auto a12 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a12), *neg(floor(x))));
+
+    expr = floor(neg(x));
+    auto a13 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a13), *neg(ceiling(x))));
+
+    expr = conjugate(x);
+    auto a14 = Assumptions({reals()->contains(x)});
+    REQUIRE(eq(*refine(expr, &a14), *x));
+
+    expr = conjugate(x);
+    auto a15 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a15), *expr));
+}

--- a/symengine/tests/basic/test_refine.cpp
+++ b/symengine/tests/basic/test_refine.cpp
@@ -4,8 +4,10 @@
 using SymEngine::Assumptions;
 using SymEngine::integer;
 using SymEngine::integers;
+using SymEngine::pi;
 using SymEngine::reals;
 using SymEngine::symbol;
+using SymEngine::unevaluated_expr;
 
 TEST_CASE("Test refine", "[refine]")
 {
@@ -39,39 +41,43 @@ TEST_CASE("Test refine", "[refine]")
     auto a6 = Assumptions({Gt(x, integer(0))});
     REQUIRE(eq(*refine(expr, &a6), *integer(1)));
 
+    expr = sign(x);
+    auto a7 = Assumptions({Eq(x, integer(0))});
+    REQUIRE(eq(*refine(expr, &a7), *integer(0)));
+
     expr = sign(abs(x));
-    auto a7 = Assumptions({Gt(x, integer(0))});
-    REQUIRE(eq(*refine(expr, &a7), *integer(1)));
+    auto a8 = Assumptions({Gt(x, integer(0))});
+    REQUIRE(eq(*refine(expr, &a8), *integer(1)));
 
     expr = floor(x);
-    auto a8 = Assumptions({integers()->contains(x)});
-    REQUIRE(eq(*refine(expr, &a8), *x));
+    auto a9 = Assumptions({integers()->contains(x)});
+    REQUIRE(eq(*refine(expr, &a9), *x));
 
     expr = floor(x);
-    auto a9 = Assumptions({});
-    REQUIRE(eq(*refine(expr, &a9), *expr));
+    auto a10 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a10), *expr));
 
     expr = ceiling(x);
-    auto a10 = Assumptions({integers()->contains(x)});
-    REQUIRE(eq(*refine(expr, &a10), *x));
+    auto a11 = Assumptions({integers()->contains(x)});
+    REQUIRE(eq(*refine(expr, &a11), *x));
 
     expr = ceiling(x);
-    auto a11 = Assumptions({});
-    REQUIRE(eq(*refine(expr, &a11), *expr));
+    auto a12 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a12), *expr));
 
     expr = ceiling(neg(x));
-    auto a12 = Assumptions({});
-    REQUIRE(eq(*refine(expr, &a12), *neg(floor(x))));
+    auto a13 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a13), *neg(floor(x))));
 
     expr = floor(neg(x));
-    auto a13 = Assumptions({});
-    REQUIRE(eq(*refine(expr, &a13), *neg(ceiling(x))));
+    auto a14 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a14), *neg(ceiling(x))));
 
     expr = conjugate(x);
-    auto a14 = Assumptions({reals()->contains(x)});
-    REQUIRE(eq(*refine(expr, &a14), *x));
+    auto a15 = Assumptions({reals()->contains(x)});
+    REQUIRE(eq(*refine(expr, &a15), *x));
 
     expr = conjugate(x);
-    auto a15 = Assumptions({});
-    REQUIRE(eq(*refine(expr, &a15), *expr));
+    auto a16 = Assumptions({});
+    REQUIRE(eq(*refine(expr, &a16), *expr));
 }


### PR DESCRIPTION
As promised: A refine function that simplifies expressions given assumptions (like refine in mathematica https://reference.wolfram.com/language/ref/Refine.html and sympy https://docs.sympy.org/latest/modules/assumptions/refine.html). A modest start supporting `Abs`, `Sign`, `Floor`, `Ceiling` and `Conjugate`.