### PR TITLE
bin/test_travis.sh is source'd by symengine.py test script

### DIFF
--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -56,7 +56,7 @@ if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ "${CC}" == "gcc" ]]; then
 fi
 
 if [[ "$WITH_LLVM" != "" && "${TRAVIS_OS_NAME}" == "linux" && "$GITHUB_ACTIONS" == "true" ]]; then
-    wget http://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.xz
+    wget -q http://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.xz
     tar -xf binutils-2.32.tar.xz
     pushd binutils-2.32
     ./configure --disable-static --enable-shared --prefix=/usr
@@ -71,9 +71,9 @@ export our_install_dir="$HOME/our_usr"
 if [[ ! -d $HOME/conda_root/pkgs ]]; then
     rm -rf $HOME/conda_root
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
     else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
     bash miniconda.sh -b -p $HOME/conda_root
 fi

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -162,7 +162,7 @@ echo "Running make install:"
 make install
 
 if [[ "${TEST_CPP}" == "no" ]]; then
-    exit 0;
+    return 0;
 fi
 
 echo "=== Running tests in build directory:"
@@ -173,12 +173,12 @@ if [[ "${WITH_COVERAGE}" == "yes" ]]; then
     echo "=== Collecting coverage data"
     curl --connect-timeout 10 --retry 5 -L https://codecov.io/bash -o codecov.sh
     bash codecov.sh -x $GCOV_EXECUTABLE 2>&1 | grep -v "has arcs to entry block" | grep -v "has arcs from exit block"
-    exit 0;
+    return 0;
 fi
 
 if [[ "${WITH_SANITIZE}" != "" ]]; then
     # currently compile_flags and link_flags below won't pick up -fsanitize=...
-    exit 0;
+    return 0;
 fi
 
 echo "=== Testing the installed SymEngine library simulating use by 3rd party lib"


### PR DESCRIPTION
I noticed that the CI in symengine.py [never reaches](https://github.com/bjodah/symengine.py/runs/2882747493#step:3:3038) the python tests due to sourcing of a bash script with "exit 0":
https://github.com/bjodah/symengine.py/blame/master/bin/test_symengine_unix.sh#L13
https://github.com/symengine/symengine/blob/master/bin/test_symengine_unix.sh#L33

Sourced scripts (and functions) in bash are allowed to "return", trying to use that in this PR.