### PR TITLE
specify integer type of llvm powi 2nd argument

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -495,6 +495,7 @@ llvm::Function *LLVMVisitor::get_powi()
 {
     std::vector<llvm::Type *> arg_type;
     arg_type.push_back(get_float_type(&mod->getContext()));
+    arg_type.push_back(llvm::Type::getInt32Ty(mod->getContext()));
     return llvm::Intrinsic::getDeclaration(mod, llvm::Intrinsic::powi,
                                            arg_type);
 }


### PR DESCRIPTION
- this was implicitly assumed to be int32 in llvm <= 12
- appears to no longer be the case in llvm 13 (https://reviews.llvm.org/D99439)

Fixes the following segfault that occurs when running `test_lambda_double` compiled with llvm trunk:

```
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.cpp", line 24, in main()
    int result = Catch::Session().run( argc, argv );
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 7185, in Catch::Session::run(int, char const* const*)
    returnCode = run();
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 7220, in Catch::Session::run()
    int exitCode = runInternal();
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 7261, in Catch::Session::runInternal()
    return static_cast<int>( runTests( m_config ).assertions.failed );
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 7089, in Catch::runTests(Catch::Ptr<Catch::Config> const&)
    totals += context.runTest( *it );
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 6709, in Catch::RunContext::runTest(Catch::TestCase const&)
    runCurrentTest( redirectedCout, redirectedCerr );
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 6917, in Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)
    invokeActiveTestCase();
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 6944, in Catch::RunContext::invokeActiveTestCase()
    m_activeTestCase->invoke();
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 8416, in Catch::TestCase::invoke() const
    test->invoke();
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/catch/catch.hpp", line 7418, in Catch::FreeFunctionTestCase::invoke() const
    m_fun();
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/tests/eval/test_lambda_double.cpp", line 314, in ____C_A_T_C_H____T_E_S_T____10()
    v2.init({x, y, z}, *expr);
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 76, in SymEngine::LLVMVisitor::init(std::vector<Teuchos::RCP<SymEngine::Basic const>, std::allocator<Teuchos::RCP<SymEngine::Basic const> > > const&, SymEngine::Basic const&, bool, unsigned int)
    init(x, b, symbolic_cse, LLVMVisitor::create_default_passes(opt_level),
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 84, in SymEngine::LLVMVisitor::init(std::vector<Teuchos::RCP<SymEngine::Basic const>, std::allocator<Teuchos::RCP<SymEngine::Basic const> > > const&, SymEngine::Basic const&, bool, std::vector<llvm::Pass*, std::allocator<llvm::Pass*> > const&, unsigned int)
    init(x, {b.rcp_from_this()}, symbolic_cse, passes, opt_level);
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 266, in SymEngine::LLVMVisitor::init(std::vector<Teuchos::RCP<SymEngine::Basic const>, std::allocator<Teuchos::RCP<SymEngine::Basic const> > > const&, std::vector<Teuchos::RCP<SymEngine::Basic const>, std::allocator<Teuchos::RCP<SymEngine::Basic const> > > const&, bool, std::vector<llvm::Pass*, std::allocator<llvm::Pass*> > const&, unsigned int)
    output_vals.push_back(apply(*outputs[i]));
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 69, in SymEngine::LLVMVisitor::apply(SymEngine::Basic const&)
    b.accept(*this);
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/type_codes.inc", line 28, in SymEngine::Add::accept(SymEngine::Visitor&) const
    SYMENGINE_ENUM(SYMENGINE_ADD, Add)
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/type_codes.inc", line 28, in SymEngine::BaseVisitor<SymEngine::LLVMVisitor, SymEngine::Visitor>::visit(SymEngine::Add const&)
    SYMENGINE_ENUM(SYMENGINE_ADD, Add)
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 471, in SymEngine::LLVMVisitor::bvisit(SymEngine::Add const&)
    tmp1 = apply(*(it->first));
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 69, in SymEngine::LLVMVisitor::apply(SymEngine::Basic const&)
    b.accept(*this);
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/type_codes.inc", line 27, in SymEngine::Mul::accept(SymEngine::Visitor&) const
    SYMENGINE_ENUM(SYMENGINE_MUL, Mul)
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/type_codes.inc", line 27, in SymEngine::BaseVisitor<SymEngine::LLVMVisitor, SymEngine::Visitor>::visit(SymEngine::Mul const&)
    SYMENGINE_ENUM(SYMENGINE_MUL, Mul)
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 485, in SymEngine::LLVMVisitor::bvisit(SymEngine::Mul const&)
    tmp = apply(*p);
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 69, in SymEngine::LLVMVisitor::apply(SymEngine::Basic const&)
    b.accept(*this);
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/type_codes.inc", line 29, in SymEngine::Pow::accept(SymEngine::Visitor&) const
    SYMENGINE_ENUM(SYMENGINE_POW, Pow)
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/type_codes.inc", line 29, in SymEngine::BaseVisitor<SymEngine::LLVMVisitor, SymEngine::Visitor>::visit(SymEngine::Pow const&)
    SYMENGINE_ENUM(SYMENGINE_POW, Pow)
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 537, in SymEngine::LLVMVisitor::bvisit(SymEngine::Pow const&)
    fun = get_powi();
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/llvm_double.cpp", line 498, in SymEngine::LLVMVisitor::get_powi()
    return llvm::Intrinsic::getDeclaration(mod, llvm::Intrinsic::powi,
  File unknown, in llvm::Intrinsic::getDeclaration(llvm::Module*, unsigned int, llvm::ArrayRef<llvm::Type*>)
  File unknown, in llvm::Intrinsic::getType(llvm::LLVMContext&, unsigned int, llvm::ArrayRef<llvm::Type*>)
  File unknown, in __funlockfile()
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/teuchos/Teuchos_stacktrace.cpp", line 454, in (anonymous namespace)::loc_segfault_callback_print_stack(int)
    Teuchos::show_stacktrace();
  File "/home/lkeegan/BIOQUANT/symengine/build/../symengine/utilities/teuchos/Teuchos_stacktrace.cpp", line 522, in Teuchos::show_stacktrace()
    std::cout << Teuchos::get_stacktrace(impl_stacktrace_depth);
```