### PR TITLE
Add sup and inf for sets

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -92,6 +92,7 @@ set(SRC
     series.cpp
     series_generic.cpp
     sets.cpp
+    set_funcs.cpp
     solve.cpp
     sparse_matrix.cpp
     symbol.cpp

--- a/symengine/set_funcs.cpp
+++ b/symengine/set_funcs.cpp
@@ -1,0 +1,164 @@
+#ifndef SYMENGINE_SET_FUNCS_H
+#define SYMENGINE_SET_FUNCS_H
+
+#include <symengine/visitor.h>
+#include <symengine/functions.h>
+
+namespace SymEngine
+{
+
+class SupVisitor : public BaseVisitor<SupVisitor>
+{
+private:
+    RCP<const Basic> sup_;
+
+public:
+    SupVisitor() {}
+
+    void bvisit(const Basic &x){};
+
+    void bvisit(const Set &x)
+    {
+        throw SymEngineException(
+            "Set not partially ordered: supremum undefined");
+    };
+
+    void bvisit(const Reals &x)
+    {
+        sup_ = infty(1);
+    };
+
+    void bvisit(const Rationals &x)
+    {
+        sup_ = infty(1);
+    };
+
+    void bvisit(const Integers &x)
+    {
+        sup_ = infty(1);
+    };
+
+    void bvisit(const Interval &x)
+    {
+        sup_ = x.get_end();
+    };
+
+    void bvisit(const FiniteSet &x)
+    {
+        const set_basic &container = x.get_container();
+        vec_basic v(container.begin(), container.end());
+        sup_ = max(v);
+    };
+
+    void bvisit(const Union &x)
+    {
+        vec_basic suprema;
+        for (auto &a : x.get_container()) {
+            a->accept(*this);
+            suprema.push_back(sup_);
+        }
+        sup_ = max(suprema);
+    };
+
+    void bvisit(const Complement &x)
+    {
+        throw NotImplementedError("sup for Complement not implemented");
+    };
+
+    void bvisit(const ImageSet &x)
+    {
+        throw NotImplementedError("sup for ImageSet not implemented");
+    };
+
+    RCP<const Basic> apply(const Set &s)
+    {
+        s.accept(*this);
+        return sup_;
+    };
+};
+
+class InfVisitor : public BaseVisitor<InfVisitor>
+{
+private:
+    RCP<const Basic> inf_;
+
+public:
+    InfVisitor() {}
+
+    void bvisit(const Basic &x){};
+
+    void bvisit(const Set &x)
+    {
+        throw SymEngineException(
+            "Set not partially ordered: infimum undefined");
+    };
+
+    void bvisit(const Reals &x)
+    {
+        inf_ = infty(-1);
+    };
+
+    void bvisit(const Rationals &x)
+    {
+        inf_ = infty(-1);
+    };
+
+    void bvisit(const Integers &x)
+    {
+        inf_ = infty(-1);
+    };
+
+    void bvisit(const Interval &x)
+    {
+        inf_ = x.get_start();
+    };
+
+    void bvisit(const FiniteSet &x)
+    {
+        const set_basic &container = x.get_container();
+        vec_basic v(container.begin(), container.end());
+        inf_ = min(v);
+    };
+
+    void bvisit(const Union &x)
+    {
+        vec_basic infima;
+        for (auto &a : x.get_container()) {
+            a->accept(*this);
+            infima.push_back(inf_);
+        }
+        inf_ = min(infima);
+    };
+
+    void bvisit(const Complement &x)
+    {
+        throw NotImplementedError("inf for Complement not implemented");
+    };
+
+    void bvisit(const ImageSet &x)
+    {
+        throw NotImplementedError("inf for ImageSet not implemented");
+    };
+
+    RCP<const Basic> apply(const Set &s)
+    {
+        s.accept(*this);
+        return inf_;
+    };
+};
+
+RCP<const Basic> sup(const Set &s)
+{
+    SupVisitor visitor;
+    return visitor.apply(s);
+}
+
+RCP<const Basic> inf(const Set &s)
+{
+    InfVisitor visitor;
+    return visitor.apply(s);
+}
+
+} // namespace SymEngine
+
+#endif // SYMENGINE_SET_FUNCS_H

--- a/symengine/sets.h
+++ b/symengine/sets.h
@@ -546,5 +546,9 @@ RCP<const Set> set_complement(const RCP<const Set> &universe,
 //! \return RCP<const Set>
 RCP<const Set> conditionset(const RCP<const Basic> &sym,
                             const RCP<const Boolean> &condition);
+
+RCP<const Basic> sup(const Set &s);
+RCP<const Basic> inf(const Set &s);
+
 } // namespace SymEngine
 #endif

--- a/symengine/tests/basic/test_sets.cpp
+++ b/symengine/tests/basic/test_sets.cpp
@@ -30,6 +30,7 @@ using SymEngine::Gt;
 using SymEngine::ImageSet;
 using SymEngine::imageset;
 using SymEngine::Inf;
+using SymEngine::infty;
 using SymEngine::Integer;
 using SymEngine::integer;
 using SymEngine::Integers;
@@ -40,6 +41,8 @@ using SymEngine::is_a;
 using SymEngine::Le;
 using SymEngine::logical_and;
 using SymEngine::make_rcp;
+using SymEngine::max;
+using SymEngine::min;
 using SymEngine::mul;
 using SymEngine::NegInf;
 using SymEngine::Not;
@@ -62,6 +65,7 @@ using SymEngine::set_intersection;
 using SymEngine::set_set;
 using SymEngine::set_union;
 using SymEngine::sin;
+using SymEngine::sup;
 using SymEngine::symbol;
 using SymEngine::Symbol;
 using SymEngine::SymEngineException;
@@ -1074,4 +1078,66 @@ TEST_CASE("ImageSet : Basic", "[basic]")
 
     auto xD = dummy("x");
     REQUIRE(is_a<ImageSet>(*imageset(xD, mul(xD, xD), i1)));
+}
+
+TEST_CASE("sup : Basic", "[basic]")
+{
+    REQUIRE(eq(*sup(*reals()), *infty(1)));
+    REQUIRE(eq(*sup(*rationals()), *infty(1)));
+    REQUIRE(eq(*sup(*integers()), *infty(1)));
+    REQUIRE(eq(*sup(*interval(one, integer(2), true, true)), *integer(2)));
+    REQUIRE(eq(*sup(*interval(one, integer(2), false, false)), *integer(2)));
+
+    RCP<const Set> r1 = finiteset({zero, one, symbol("x")});
+    RCP<const Set> r2 = finiteset({zero, one, integer(2)});
+    REQUIRE(eq(*sup(*r1), *max({one, symbol("x")})));
+    REQUIRE(eq(*sup(*r2), *integer(2)));
+
+    RCP<const Set> r3 = set_union(
+        {interval(integer(-1), integer(1)), finiteset({integer(-23)})});
+    REQUIRE(eq(*sup(*r3), *integer(1)));
+
+    RCP<const Number> rat1 = Rational::from_two_ints(*integer(5), *integer(6));
+    RCP<const Set> r4 = set_union({integers(), finiteset({rat1})});
+    REQUIRE(eq(*sup(*r4), *infty(1)));
+
+    CHECK_THROWS_AS(sup(*emptyset()), SymEngineException &);
+    CHECK_THROWS_AS(sup(*rationals()->set_complement(reals())),
+                    NotImplementedError &);
+
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Set> i1 = interval(zero, one);
+    r1 = imageset(x, mul(x, x), i1);
+    CHECK_THROWS_AS(sup(*r1), NotImplementedError &);
+}
+
+TEST_CASE("inf : Basic", "[basic]")
+{
+    REQUIRE(eq(*inf(*reals()), *infty(-1)));
+    REQUIRE(eq(*inf(*rationals()), *infty(-1)));
+    REQUIRE(eq(*inf(*integers()), *infty(-1)));
+    REQUIRE(eq(*inf(*interval(one, integer(2), true, true)), *integer(1)));
+    REQUIRE(eq(*inf(*interval(one, integer(2), false, false)), *integer(1)));
+
+    RCP<const Set> r1 = finiteset({zero, one, symbol("x")});
+    RCP<const Set> r2 = finiteset({zero, one, integer(2)});
+    REQUIRE(eq(*inf(*r1), *min({zero, symbol("x")})));
+    REQUIRE(eq(*inf(*r2), *integer(0)));
+
+    RCP<const Set> r3 = set_union(
+        {interval(integer(-1), integer(1)), finiteset({integer(-23)})});
+    REQUIRE(eq(*inf(*r3), *integer(-23)));
+
+    RCP<const Number> rat1 = Rational::from_two_ints(*integer(5), *integer(6));
+    RCP<const Set> r4 = set_union({integers(), finiteset({rat1})});
+    REQUIRE(eq(*inf(*r4), *infty(-1)));
+
+    CHECK_THROWS_AS(inf(*emptyset()), SymEngineException &);
+    CHECK_THROWS_AS(inf(*rationals()->set_complement(reals())),
+                    NotImplementedError &);
+
+    RCP<const Symbol> x = symbol("x");
+    RCP<const Set> i1 = interval(zero, one);
+    r1 = imageset(x, mul(x, x), i1);
+    CHECK_THROWS_AS(inf(*r1), NotImplementedError &);
 }


### PR DESCRIPTION
Add functions `sup` and `inf` to calculate supremum and infimum for sets.

Implemented as plain functions and not member functions to keep the operations decoupled from the classes. This also allows using double dispatch.