### PR TITLE
Add is_finite and is_infinite

### DIFF
--- a/symengine/number.h
+++ b/symengine/number.h
@@ -170,6 +170,8 @@ tribool is_real(const Basic &b, const Assumptions *assumptions = nullptr);
 tribool is_complex(const Basic &b, const Assumptions *assumptions = nullptr);
 tribool is_rational(const Basic &b);
 tribool is_irrational(const Basic &b);
+tribool is_finite(const Basic &b, const Assumptions *assumptions = nullptr);
+tribool is_infinite(const Basic &b, const Assumptions *assumptions = nullptr);
 
 class NumberWrapper : public Number
 {

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -754,4 +754,78 @@ tribool is_irrational(const Basic &b)
     RationalVisitor visitor(false);
     return visitor.apply(b);
 }
+
+void FiniteVisitor::error()
+{
+    throw SymEngineException(
+        "Only numeric types allowed for is_finite/is_infinite");
+}
+
+void FiniteVisitor::bvisit(const Basic &x)
+{
+    is_finite_ = tribool::indeterminate;
+}
+
+void FiniteVisitor::bvisit(const Symbol &x)
+{
+    if (assumptions_) {
+        is_finite_ = assumptions_->is_complex(x.rcp_from_this());
+    } else {
+        is_finite_ = tribool::indeterminate;
+    }
+}
+
+void FiniteVisitor::bvisit(const Number &x)
+{
+    is_finite_ = tribool::tritrue;
+}
+
+void FiniteVisitor::bvisit(const Infty &x)
+{
+    is_finite_ = tribool::trifalse;
+}
+
+void FiniteVisitor::bvisit(const NaN &x)
+{
+    error();
+}
+
+void FiniteVisitor::bvisit(const Set &x)
+{
+    error();
+}
+
+void FiniteVisitor::bvisit(const Relational &x)
+{
+    error();
+}
+
+void FiniteVisitor::bvisit(const Boolean &x)
+{
+    error();
+}
+
+void FiniteVisitor::bvisit(const Constant &x)
+{
+    is_finite_ = tribool::tritrue;
+}
+
+tribool FiniteVisitor::apply(const Basic &b)
+{
+    b.accept(*this);
+    return is_finite_;
+}
+
+tribool is_finite(const Basic &b, const Assumptions *assumptions)
+{
+    FiniteVisitor visitor(assumptions);
+    return visitor.apply(b);
+}
+
+tribool is_infinite(const Basic &b, const Assumptions *assumptions)
+{
+    FiniteVisitor visitor(assumptions);
+    return not_tribool(visitor.apply(b));
+}
+
 } // namespace SymEngine

--- a/symengine/test_visitors.h
+++ b/symengine/test_visitors.h
@@ -400,6 +400,31 @@ public:
 
     tribool apply(const Basic &b);
 };
+
+class FiniteVisitor : public BaseVisitor<FiniteVisitor>
+{
+private:
+    tribool is_finite_;
+    const Assumptions *assumptions_;
+
+    void error();
+
+public:
+    FiniteVisitor(const Assumptions *assumptions) : assumptions_(assumptions){};
+
+    void bvisit(const Basic &x);
+    void bvisit(const Symbol &x);
+    void bvisit(const Infty &x);
+    void bvisit(const NaN &x);
+    void bvisit(const Number &x);
+    void bvisit(const Set &x);
+    void bvisit(const Relational &x);
+    void bvisit(const Boolean &x);
+    void bvisit(const Constant &x);
+
+    tribool apply(const Basic &b);
+};
+
 } // namespace SymEngine
 
 #endif // SYMENGINE_TEST_VISITORS_H

--- a/symengine/tests/basic/test_test_visitors.cpp
+++ b/symengine/tests/basic/test_test_visitors.cpp
@@ -639,3 +639,38 @@ TEST_CASE("Test is_irrational", "[is_irrational]")
     REQUIRE(is_true(is_irrational(*irr1)));
     REQUIRE(is_indeterminate(is_irrational(*constant("catalan"))));
 }
+
+TEST_CASE("Test is_finite", "[is_finite]")
+{
+    auto x = symbol("x");
+
+    REQUIRE(is_false(is_finite(*Inf)));
+    REQUIRE(is_true(is_infinite(*Inf)));
+
+    REQUIRE_THROWS_AS(is_finite(*boolTrue), SymEngineException &);
+    REQUIRE_THROWS_AS(is_infinite(*boolTrue), SymEngineException &);
+    REQUIRE_THROWS_AS(is_finite(*Eq(symbol("x"), integer(1))),
+                      SymEngineException &);
+    REQUIRE_THROWS_AS(is_infinite(*Eq(symbol("x"), integer(1))),
+                      SymEngineException &);
+    REQUIRE_THROWS_AS(is_finite(*integers()), SymEngineException &);
+    REQUIRE_THROWS_AS(is_infinite(*integers()), SymEngineException &);
+    REQUIRE_THROWS_AS(is_finite(*Nan), SymEngineException &);
+    REQUIRE_THROWS_AS(is_infinite(*Nan), SymEngineException &);
+
+    REQUIRE(is_true(is_finite(*pi)));
+    REQUIRE(is_false(is_infinite(*pi)));
+
+    REQUIRE(is_true(is_finite(*integer(23))));
+    REQUIRE(is_false(is_infinite(*integer(23))));
+
+    REQUIRE(is_indeterminate(is_finite(*x)));
+    REQUIRE(is_indeterminate(is_infinite(*x)));
+
+    const auto a1 = Assumptions({reals()->contains(x)});
+    REQUIRE(is_true(is_finite(*x, &a1)));
+    REQUIRE(is_false(is_infinite(*x, &a1)));
+
+    // Not yet supported
+    REQUIRE(is_indeterminate(is_finite(*add(x, x))));
+}


### PR DESCRIPTION
So far the basics is in. We could also consider using the `is_complex` as the same as `is_finite`.

Would be nice to at least have all the `is_` functions that sympy has to be more compatible