### PR TITLE
16.04 (xenial) -> 20.04 (focal) & bump respective llvm versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
           # Debug build (with BFD)
           - BUILD_TYPE: Debug
             WITH_BFD: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           # Debug build (with BFD and SYMENGINE_THREAD_SAFE)
           - BUILD_TYPE: Debug
             WITH_BFD: yes
             WITH_SYMENGINE_THREAD_SAFE: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           # Debug build (with BFD, ECM, PRIMESIEVE and MPC)
@@ -28,7 +28,7 @@ jobs:
             WITH_ECM: yes
             WITH_PRIMESIEVE: yes
             WITH_MPC: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           # Debug build (with BFD, Flint and Arb and INTEGER_CLASS from flint)
@@ -38,7 +38,7 @@ jobs:
             INTEGER_CLASS: flint
             WITH_MPC: yes
             TEST_IN_TREE: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           # Debug build (with BFD, MPFR and INTEGER_CLASS from gmpxx)
@@ -46,14 +46,14 @@ jobs:
             WITH_SYMENGINE_RCP: yes
             WITH_MPFR: yes
             INTEGER_CLASS: gmpxx
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           # Debug build (with BFD and INTEGER_CLASS from boostmp)
           - BUILD_TYPE: Debug
             WITH_BFD: yes
             INTEGER_CLASS: boostmp
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             WITH_LATEST_GCC: yes
             CC: gcc
 
@@ -61,18 +61,18 @@ jobs:
           - BUILD_TYPE: Debug
             WITH_BFD: yes
             BUILD_SHARED_LIBS: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           # Release build (with BFD)
           - WITH_BFD: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           # Release shared build (with BFD)
           - WITH_BFD: yes
             BUILD_SHARED_LIBS: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           ## In-tree builds (we just check a few configurations to make sure they work):
@@ -80,13 +80,13 @@ jobs:
           - BUILD_TYPE: Debug
             WITH_BFD: yes
             TEST_IN_TREE: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
 
           - TEST_CLANG_FORMAT: yes
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             CC: gcc
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-11 main'
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
             EXTRA_APT_PACKAGES: clang-format-11
 
           - BUILD_TYPE: Debug
@@ -95,7 +95,7 @@ jobs:
             MAKEFLAGS: -j2
             BUILD_SHARED_LIBS: yes
             CC: gcc
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             EXTRA_APT_PACKAGES: "binutils-dev g++-4.8"
             # This is not used, but was in travis config
             # WITH_GCC_6: yes
@@ -106,7 +106,7 @@ jobs:
             INTEGER_CLASS: piranha
             MAKEFLAGS: -j2
             CC: gcc
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
             EXTRA_APT_PACKAGES: "g++-4.8"
 
           - BUILD_TYPE: Debug
@@ -114,14 +114,14 @@ jobs:
             WITH_LLVM: 6.0
             WITH_BENCHMARKS_NONIUS: yes
             CC: clang
-            OS: ubuntu-16.04
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main'
+            OS: ubuntu-20.04
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main'
             EXTRA_APT_PACKAGES: "clang-6.0 libstdc++-4.8-dev libgmp-dev llvm-6.0-dev"
 
           - BUILD_TYPE: Release
             CC: clang
-            OS: ubuntu-16.04
-            EXTRA_APT_PACKAGES: "clang libstdc++-4.8-dev libgmp-dev"
+            OS: ubuntu-20.04
+            EXTRA_APT_PACKAGES: "clang libstdc++-9-dev libgmp-dev"
 
           - BUILD_TYPE: Debug
             WITH_LLVM: 3.8
@@ -143,19 +143,19 @@ jobs:
 
           - BUILD_TYPE: Debug
             WITH_SANITIZE: address
-            WITH_LLVM: 7.0
+            WITH_LLVM: 13
             CC: clang
-            OS: ubuntu-16.04
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
-            EXTRA_APT_PACKAGES: "clang-7 llvm-7-dev"
+            OS: ubuntu-20.04
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+            EXTRA_APT_PACKAGES: "clang-13 llvm-13-dev"
     
           - BUILD_TYPE: Debug
             WITH_SANITIZE: undefined
-            WITH_LLVM: 7.0
+            WITH_LLVM: 13
             CC: clang
-            OS: ubuntu-16.04
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
-            EXTRA_APT_PACKAGES: "clang-7 llvm-7-dev"
+            OS: ubuntu-20.04
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+            EXTRA_APT_PACKAGES: "clang-13 llvm-13-dev"
 
           - BUILD_TYPE: Debug
             WITH_SYMENGINE_RCP: yes
@@ -163,13 +163,13 @@ jobs:
             WITH_SANITIZE: memory
             INTEGER_CLASS: boostmp
             CC: clang
-            OS: ubuntu-18.04
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main'
-            EXTRA_APT_PACKAGES: "clang-7 llvm-7-dev"
+            OS: ubuntu-20.04
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-13 main'
+            EXTRA_APT_PACKAGES: "clang-13 llvm-13-dev"
 
           - CONDA_ENV_FILE: symengine/utilities/matchpycpp/environment.yml
             CC: gcc
-            OS: ubuntu-16.04
+            OS: ubuntu-20.04
     
           - MSYSTEM: MINGW64
             ARCH: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
             BUILD_SHARED_LIBS: yes
             CC: gcc
             OS: ubuntu-20.04
-            EXTRA_APT_PACKAGES: "binutils-dev g++-4.8"
+            EXTRA_APT_PACKAGES: "binutils-dev g++-9"
             # This is not used, but was in travis config
             # WITH_GCC_6: yes
 
@@ -107,7 +107,7 @@ jobs:
             MAKEFLAGS: -j2
             CC: gcc
             OS: ubuntu-20.04
-            EXTRA_APT_PACKAGES: "g++-4.8"
+            EXTRA_APT_PACKAGES: "g++-9"
 
           - BUILD_TYPE: Debug
             WITH_BFD: yes
@@ -116,7 +116,7 @@ jobs:
             CC: clang
             OS: ubuntu-20.04
             EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main'
-            EXTRA_APT_PACKAGES: "clang-6.0 libstdc++-4.8-dev libgmp-dev llvm-6.0-dev"
+            EXTRA_APT_PACKAGES: "clang-6.0 libstdc++-9-dev libgmp-dev llvm-6.0-dev"
 
           - BUILD_TYPE: Release
             CC: clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
           - BUILD_TYPE: Debug
             WITH_SYMENGINE_RCP: yes
             WITH_BFD: no
+            WITH_COTIRE: no
             WITH_SANITIZE: memory
             INTEGER_CLASS: boostmp
             CC: clang

--- a/.github/workflows/coverage1.yml
+++ b/.github/workflows/coverage1.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   coverage1:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
         WITH_MPC: yes
         WITH_LLVM: 8.0
         USE_GLIBCXX_DEBUG: yes
-        OS: ubuntu-16.04
+        OS: ubuntu-20.04
         CC: gcc
-        EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+        EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
         EXTRA_APT_PACKAGES: "clang-8 llvm-8-dev binutils-dev g++-8"

--- a/.github/workflows/coverage2.yml
+++ b/.github/workflows/coverage2.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   coverage2:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -24,4 +24,4 @@ jobs:
         BUILD_BENCHMARKS: no
         MAKEFLAGS: -j2
         CC: gcc
-        OS: ubuntu-16.04
+        OS: ubuntu-20.04

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -37,21 +37,21 @@ export GCOV_EXECUTABLE=gcov
 
 if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ "${CC}" == "gcc" ]]; then
     if [[ "${WITH_PIRANHA}" == "yes" ]]; then
-        export CC=gcc-4.8
-        export CXX=g++-4.8
-        export GCOV_EXECUTABLE=gcov-4.8
-    elif [[ "${WITH_LATEST_GCC}" == "yes" ]]; then
         export CC=gcc-9
         export CXX=g++-9
         export GCOV_EXECUTABLE=gcov-9
+    elif [[ "${WITH_LATEST_GCC}" == "yes" ]]; then
+        export CC=gcc-11
+        export CXX=g++-11
+        export GCOV_EXECUTABLE=gcov-11
     elif [[ "${WITH_GCC_6}" == "yes" ]]; then
-        export CC=gcc-6
-        export CXX=g++-6
-        export GCOV_EXECUTABLE=gcov-6
+        export CC=gcc-10
+        export CXX=g++-10
+        export GCOV_EXECUTABLE=gcov-10
     else
-        export CC=gcc-4.7
-        export CXX=g++-4.7
-        export GCOV_EXECUTABLE=gcov-4.7
+        export CC=gcc-9
+        export CXX=g++-9
+        export GCOV_EXECUTABLE=gcov-9
     fi
 fi
 

--- a/bin/test_symengine_unix.sh
+++ b/bin/test_symengine_unix.sh
@@ -9,7 +9,7 @@ if [[ "$(uname)" == "Linux" ]]; then
       sudo add-apt-repository "$EXTRA_APT_REPOSITORY"
   fi
   sudo apt update
-  if [[ "$OS" == "ubuntu-16.04" ]]; then
+  if [[ "$OS" == "ubuntu-20.04" ]]; then
     sudo apt install binutils-dev g++-4.7 $EXTRA_APT_PACKAGES
   else
     sudo apt install binutils-dev g++ $EXTRA_APT_PACKAGES

--- a/bin/test_symengine_unix.sh
+++ b/bin/test_symengine_unix.sh
@@ -10,7 +10,7 @@ if [[ "$(uname)" == "Linux" ]]; then
   fi
   sudo apt update
   if [[ "$OS" == "ubuntu-20.04" ]]; then
-    sudo apt install binutils-dev g++-4.7 $EXTRA_APT_PACKAGES
+    sudo apt install binutils-dev g++-9 $EXTRA_APT_PACKAGES
   else
     sudo apt install binutils-dev g++ $EXTRA_APT_PACKAGES
   fi

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -142,6 +142,9 @@ fi
 if [[ "${WITH_COVERAGE}" != "" ]]; then
     cmake_line="$cmake_line -DWITH_COVERAGE=${WITH_COVERAGE}"
 fi
+if [[ "${WITH_COTIRE}" != "" ]]; then
+    cmake_line="$cmake_line -DWITH_COTIRE=${WITH_COTIRE}"
+fi
 if [[ "${WITH_LLVM}" != "" ]] ; then
     cmake_line="$cmake_line -DWITH_LLVM:BOOL=ON -DLLVM_DIR=${LLVM_DIR}"
 fi

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -8,23 +8,26 @@ set -x
 if [[ "${WITH_SANITIZE}" != "" ]]; then
 	export CXXFLAGS="-fsanitize=${WITH_SANITIZE}"
 	if [[ "${WITH_SANITIZE}" == "address" ]]; then
-	    export ASAN_OPTIONS=symbolize=1,detect_leaks=1,external_symbolizer_path=/usr/lib/llvm-7/bin/llvm-symbolizer
+	    export ASAN_OPTIONS=symbolize=1,detect_leaks=1,external_symbolizer_path=/usr/lib/llvm-13/bin/llvm-symbolizer
 	elif [[ "${WITH_SANITIZE}" == "undefined" ]]; then
-	    export UBSAN_OPTIONS=print_stacktrace=1,halt_on_error=1,external_symbolizer_path=/usr/lib/llvm-7/bin/llvm-symbolizer
+	    export UBSAN_OPTIONS=print_stacktrace=1,halt_on_error=1,external_symbolizer_path=/usr/lib/llvm-13/bin/llvm-symbolizer
 	elif [[ "${WITH_SANITIZE}" == "memory" ]]; then
-            # remove existing system libc++ to avoid conflicts with msan instrumented libc++
-            sudo apt-get remove -yy libc++abi-dev libc++-dev
             # for reference: https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo#instrumented-libc
             echo "=== Building libc++ instrumented with memory-sanitizer (msan) for detecting use of uninitialized variables"
-            LLVM_ORG_VER=7.1.0  # should match llvm-X-dev package.
-            export CC=clang-7
-            export CXX=clang++-7
+            LLVM_ORG_VER=13.0.0-rc1  # should match llvm-X-dev package.
+            export CC=clang-13
+            export CXX=clang++-13
             curl -Ls https://github.com/llvm/llvm-project/archive/llvmorg-${LLVM_ORG_VER}.tar.gz | tar xz -C /tmp
             ( \
               set -xe; \
               mkdir /tmp/build_libcxx; \
               cd /tmp/build_libcxx; \
-              cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER=Memory -DLLVM_CONFIG_PATH=/usr/bin/llvm-config-7 -DCMAKE_INSTALL_PREFIX=/opt/libcxx7_msan /tmp/llvm-project-llvmorg-${LLVM_ORG_VER}/libcxx; \
+              cmake \
+                  -DCMAKE_BUILD_TYPE=Debug \
+                  -DLLVM_USE_SANITIZER=MemoryWithOrigins \
+                  -DLLVM_CONFIG_PATH=/usr/bin/llvm-config-13 \
+                  -DCMAKE_INSTALL_PREFIX=/opt/libcxx-13-msan \
+                  /tmp/llvm-project-llvmorg-${LLVM_ORG_VER}/libcxx; \
               echo "Current dir:"; \
               pwd; \
               cmake --build . ;\
@@ -35,19 +38,24 @@ if [[ "${WITH_SANITIZE}" != "" ]]; then
               set -xe;
               mkdir /tmp/build_libcxxabi; \
               cd /tmp/build_libcxxabi; \
-              cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER=Memory  -DLLVM_CONFIG_PATH=/usr/bin/llvm-config-7 -DCMAKE_INSTALL_PREFIX=/opt/libcxx7_msan  -DLIBCXXABI_LIBCXX_INCLUDES=/opt/libcxx7_msan/include/c++/v1 -DLIBCXXABI_LIBCXX_PATH=/tmp/llvm-project-llvmorg-${LLVM_ORG_VER}/libcxx /tmp/llvm-project-llvmorg-${LLVM_ORG_VER}/libcxxabi; \
+              cmake \
+                  -DCMAKE_BUILD_TYPE=Debug \
+                  -DCMAKE_MODULE_PATH=/tmp/llvm-project-llvmorg-${LLVM_ORG_VER}/libcxx/cmake/Modules \
+                  -DLLVM_USE_SANITIZER=MemoryWithOrigins  \
+                  -DLLVM_CONFIG_PATH=/usr/bin/llvm-config-13 \
+                  -DCMAKE_INSTALL_PREFIX=/opt/libcxx-13-msan  \
+                  -DLIBCXXABI_LIBCXX_INCLUDES=/opt/libcxx-13-msan/include/c++/v1 \
+                  -DLIBCXXABI_LIBCXX_PATH=/tmp/llvm-project-llvmorg-${LLVM_ORG_VER}/libcxx \
+                  /tmp/llvm-project-llvmorg-${LLVM_ORG_VER}/libcxx; \
               echo "Current dir:"; \
               pwd; \
               cmake --build . ;\
               cmake --build . --target install
             )
-            if [ ! -e /opt/libcxx7_msan/lib/libc++abi.so ]; then >&2 echo "Failed to build libcxx++abi?"; exit 1; fi
-	    export MSAN_OPTIONS=print_stacktrace=1,halt_on_error=1,external_symbolizer_path=/usr/lib/llvm-7/bin/llvm-symbolizer
-            export CXXFLAGS="$CXXFLAGS -stdlib=libc++ -I/opt/libcxx7_msan/include -I/opt/libcxx7_msan/include/c++/v1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -O1 -glldb -DHAVE_GCC_ABI_DEMANGLE=no"
-            export LDFLAGS="-fsanitize=memory $LDFLAGS -Wl,-rpath,/opt/libcxx7_msan/lib -L/opt/libcxx7_msan/lib -lc++abi"
-            #export CMAKE_CXX_FLAGS_DEBUG="$CXXFLAGS"
-            #unset CXXFLAGS
-            #echo "CMAKE_CXX_FLAGS_DEBUG=$CMAKE_CXX_FLAGS_DEBUG"  # debug
+            if [ ! -e /opt/libcxx-13-msan/lib/libc++abi.so ]; then >&2 echo "Failed to build libcxx++abi?"; exit 1; fi
+	    export MSAN_OPTIONS=print_stacktrace=1,halt_on_error=1,external_symbolizer_path=/usr/lib/llvm-13/bin/llvm-symbolizer
+            export CXXFLAGS="$CXXFLAGS -fsanitize-memory-track-origins=2 -stdlib=libc++ -I/opt/libcxx-13-msan/include -I/opt/libcxx-13-msan/include/c++/v1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -O1 -glldb -DHAVE_GCC_ABI_DEMANGLE=no"
+            export LDFLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 $LDFLAGS -Wl,-rpath,/opt/libcxx-13-msan/lib -L/opt/libcxx-13-msan/lib -lc++abi"
 	else
 	    2>&1 echo "Unknown sanitize option: ${WITH_SANITIZE}"
 	    exit 1


### PR DESCRIPTION
As an alternative to #1820

Did a bunch of git sed and manually updated the recipe for building libc++ with memory sanitizer. Let's see how this goes.

Before merging, we probably want to revert some of these changes to keep testing the oldest supported compiler toolchain (whatever that version is).