### PR TITLE
only specify integer type of llvm powi 2nd argument for llvm version > 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
             OS: ubuntu-16.04
             CC: gcc
 
+          # Release build (recent LLVM+clang)
+          - BUILD_TYPE: Release
+            OS: ubuntu-20.04
+            CC: clang
+            WITH_LLVM: 13
+            WITH_COTIRE: no
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+            EXTRA_APT_PACKAGES: clang-13 llvm-13
+
           ## In-tree builds (we just check a few configurations to make sure they work):
           # Debug build
           - BUILD_TYPE: Debug

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -127,6 +127,10 @@ elif [[ "${WITH_LLVM}" == "8.0" ]]; then
     export LLVM_DIR=/usr/lib/llvm-8/share/llvm/
 elif [[ "${WITH_LLVM}" == "6.0" ]]; then
     export LLVM_DIR=/usr/lib/llvm-6.0/share/llvm/
+elif [[ "${WITH_LLVM}" == "13" ]]; then
+    export LLVM_DIR=/usr/lib/llvm-13/share/llvm/
+    export CC=clang-13
+    export CXX=clang++-13
 elif [[ ! -z "${WITH_LLVM}" ]]; then
     conda_pkgs="$conda_pkgs llvmdev=${WITH_LLVM} cmake=3.10.0"
     export LLVM_DIR=$our_install_dir/share/llvm/

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -495,7 +495,9 @@ llvm::Function *LLVMVisitor::get_powi()
 {
     std::vector<llvm::Type *> arg_type;
     arg_type.push_back(get_float_type(&mod->getContext()));
+#if (LLVM_VERSION_MAJOR > 12)
     arg_type.push_back(llvm::Type::getInt32Ty(mod->getContext()));
+#endif
     return llvm::Intrinsic::getDeclaration(mod, llvm::Intrinsic::powi,
                                            arg_type);
 }


### PR DESCRIPTION
fix for these warnings when running `./symengine/tests/eval/test_lambda_double` with llvm <= 12:

```
Intrinsic name not mangled correctly for type arguments! Should be: llvm.powi.f32
float (float, i32)* @llvm.powi.f32.i32﻿
```

(#1810 re-introduced this warning which was previously fixed in #1751)
