### PR TITLE
Fix cotire missing flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
             OS: ubuntu-20.04
             CC: clang
             WITH_LLVM: 13
-            WITH_COTIRE: no
             EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
             EXTRA_APT_PACKAGES: clang-13 llvm-13
 
@@ -159,7 +158,6 @@ jobs:
             EXTRA_APT_PACKAGES: "clang-7 llvm-7-dev"
     
           - BUILD_TYPE: Debug
-            WITH_COTIRE: no
             WITH_SANITIZE: undefined
             WITH_LLVM: 12
             CC: clang

--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -237,13 +237,6 @@ include_directories(BEFORE ${symengine_SOURCE_DIR})
 
 add_library(symengine ${SRC})
 
-
-if (WITH_COTIRE)
-    # throws if CMAKE_VERSION < 2.8.12
-    include(cotire)
-    cotire(symengine)
-endif()
-
 include(GenerateExportHeader)
 generate_export_header(symengine)
 set_target_properties(symengine PROPERTIES COMPILE_DEFINITIONS "symengine_EXPORTS")
@@ -317,4 +310,10 @@ if (BUILD_TESTS)
     add_subdirectory(tests)
     add_subdirectory(utilities/matchpycpp/tests)
     add_subdirectory(utilities/matchpycpp/autogen_tests)
+endif()
+
+if (WITH_COTIRE)
+    # throws if CMAKE_VERSION < 2.8.12
+    include(cotire)
+    cotire(symengine)
 endif()


### PR DESCRIPTION
- move cotire to end of CMakeLists.txt after all target properties (e.g. c++14) have been set
- re-enable cotire in ci jobs where it was disabled due to using c++ std > 11
- left it disabled for msan build as it causes other problems there