### PR TITLE
Fix exception handling for basic_diff

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -493,8 +493,9 @@ CWRAPPER_OUTPUT_TYPE basic_diff(basic s, const basic expr, basic const symbol)
 {
     if (not is_a_Symbol(symbol))
         return SYMENGINE_RUNTIME_ERROR;
+    CWRAPPER_BEGIN
     s->m = expr->m->diff(rcp_static_cast<const Symbol>(symbol->m));
-    return SYMENGINE_NO_EXCEPTION;
+    CWRAPPER_END
 }
 
 CWRAPPER_OUTPUT_TYPE basic_assign(basic a, const basic b)


### PR DESCRIPTION
Currently we can't test this, because it's not supposed to throw an exception.
The only way an exception is triggered is if there's some bug in symengine
like #1828.