### PR TITLE
First version of simplify

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SRC
     test_visitors.cpp
     assumptions.cpp
     refine.cpp
+    simplify.cpp
 )
 
 if ("${SYMENGINE_INTEGER_CLASS}" STREQUAL "BOOSTMP")
@@ -220,6 +221,7 @@ set(HEADERS
     test_visitors.h
     assumptions.h
     refine.h
+    simplify.h
 )
 
 include(GNUInstallDirs)

--- a/symengine/simplify.cpp
+++ b/symengine/simplify.cpp
@@ -1,0 +1,62 @@
+#include <symengine/simplify.h>
+#include <symengine/refine.h>
+
+namespace SymEngine
+{
+
+void SimplifyVisitor::bvisit(const OneArgFunction &x)
+{
+    auto farg = x.get_arg();
+    auto newarg = apply(farg);
+    result_ = x.create(newarg);
+}
+
+void SimplifyVisitor::bvisit(const Pow &x)
+{
+    auto e = apply(x.get_exp());
+    auto base = apply(x.get_base());
+    auto pair = simplify_pow(e, base);
+    result_ = pow(pair.second, pair.first);
+}
+
+std::pair<RCP<const Basic>, RCP<const Basic>>
+SimplifyVisitor::simplify_pow(const RCP<const Basic> &e,
+                              const RCP<const Basic> &b)
+{
+    if (is_a<Csc>(*b) and eq(*e, *minus_one)) {
+        // csc(expr) ** -1 = sin(expr)
+        return std::make_pair(
+            one, sin(down_cast<const OneArgFunction &>(*b).get_arg()));
+    } else if (is_a<Sec>(*b) and eq(*e, *minus_one)) {
+        // sec(expr) ** -1 = cos(expr)
+        return std::make_pair(
+            one, cos(down_cast<const OneArgFunction &>(*b).get_arg()));
+    } else if (is_a<Cot>(*b) and eq(*e, *minus_one)) {
+        // cot(expr) ** -1 = tan(expr)
+        return std::make_pair(
+            one, tan(down_cast<const OneArgFunction &>(*b).get_arg()));
+    } else {
+        return std::make_pair(e, b);
+    }
+}
+
+void SimplifyVisitor::bvisit(const Mul &x)
+{
+    map_basic_basic map;
+    for (const auto &p : x.get_dict()) {
+        auto base = apply(p.first);
+        auto newpair = simplify_pow(p.second, base);
+        Mul::dict_add_term(map, newpair.first, newpair.second);
+    }
+    result_ = Mul::from_dict(x.get_coef(), std::move(map));
+}
+
+RCP<const Basic> simplify(const RCP<const Basic> &x,
+                          const Assumptions *assumptions)
+{
+    auto expr = refine(x, assumptions);
+    SimplifyVisitor b(assumptions);
+    return b.apply(expr);
+}
+
+} // namespace SymEngine

--- a/symengine/simplify.h
+++ b/symengine/simplify.h
@@ -1,0 +1,38 @@
+#ifndef SYMENGINE_SIMPLIFY_H
+#define SYMENGINE_SIMPLIFY_H
+
+#include <symengine/visitor.h>
+#include <symengine/basic.h>
+#include <symengine/assumptions.h>
+
+namespace SymEngine
+{
+
+class SimplifyVisitor : public BaseVisitor<SimplifyVisitor, TransformVisitor>
+{
+private:
+    const Assumptions *assumptions_;
+
+    std::pair<RCP<const Basic>, RCP<const Basic>>
+    simplify_pow(const RCP<const Basic> &e, const RCP<const Basic> &b);
+
+public:
+    using TransformVisitor::bvisit;
+
+    SimplifyVisitor(const Assumptions *assumptions)
+        : BaseVisitor<SimplifyVisitor, TransformVisitor>(),
+          assumptions_(assumptions)
+    {
+    }
+
+    void bvisit(const Mul &x);
+    void bvisit(const Pow &x);
+    void bvisit(const OneArgFunction &x);
+};
+
+RCP<const Basic> simplify(const RCP<const Basic> &x,
+                          const Assumptions *assumptions = nullptr);
+
+} // namespace SymEngine
+
+#endif

--- a/symengine/tests/basic/CMakeLists.txt
+++ b/symengine/tests/basic/CMakeLists.txt
@@ -122,3 +122,7 @@ add_test(test_assumptions ${PROJECT_BINARY_DIR}/test_assumptions)
 add_executable(test_refine test_refine.cpp)
 target_link_libraries(test_refine symengine catch)
 add_test(test_refine ${PROJECT_BINARY_DIR}/test_refine)
+
+add_executable(test_simplify test_simplify.cpp)
+target_link_libraries(test_simplify symengine catch)
+add_test(test_simplify ${PROJECT_BINARY_DIR}/test_simplify)

--- a/symengine/tests/basic/test_simplify.cpp
+++ b/symengine/tests/basic/test_simplify.cpp
@@ -1,0 +1,48 @@
+#include "catch.hpp"
+#include <symengine/simplify.h>
+
+using SymEngine::Assumptions;
+using SymEngine::integer;
+using SymEngine::integers;
+using SymEngine::pi;
+using SymEngine::reals;
+using SymEngine::symbol;
+using SymEngine::unevaluated_expr;
+
+TEST_CASE("Test simplify", "[simplify]")
+{
+    auto x = symbol("x");
+
+    // The following tests visits Mul
+    auto expr = div(integer(2), csc(x));
+    REQUIRE(eq(*simplify(expr), *mul(integer(2), sin(x))));
+    expr = div(integer(2), sec(x));
+    REQUIRE(eq(*simplify(expr), *mul(integer(2), cos(x))));
+    expr = div(integer(2), cot(x));
+    REQUIRE(eq(*simplify(expr), *mul(integer(2), tan(x))));
+    expr = div(integer(2), csc(div(integer(2), csc(x))));
+    REQUIRE(
+        eq(*simplify(expr), *mul(integer(2), sin(mul(integer(2), sin(x))))));
+
+    expr = div(integer(2), csc(abs(x)));
+    Assumptions a1 = Assumptions({Gt(x, integer(0))});
+    REQUIRE(eq(*simplify(expr, &a1), *mul(integer(2), sin(x))));
+
+    // The following tests visits Pow
+    expr = div(integer(1), csc(x));
+    REQUIRE(eq(*simplify(expr), *sin(x)));
+    expr = div(integer(1), sec(x));
+    REQUIRE(eq(*simplify(expr), *cos(x)));
+    expr = div(integer(1), cot(x));
+    REQUIRE(eq(*simplify(expr), *tan(x)));
+
+    // No simplifications
+    expr = x;
+    REQUIRE(eq(*simplify(expr), *expr));
+    expr = sin(x);
+    REQUIRE(eq(*simplify(expr), *expr));
+    expr = div(integer(1), sin(x));
+    REQUIRE(eq(*simplify(expr), *expr));
+    expr = div(integer(2), sin(x));
+    REQUIRE(eq(*simplify(expr), *expr));
+}


### PR DESCRIPTION
Will first do `refine` and then try more advanced simplifications. Started out with supporting `y/csc(x) = y*sin(x)` and similar.

I encountered the issue of having to support both `Pow` and `Mul` for very similar situations. For example `1 / x` will be a `Pow` but `2 / x` will be a `Mul`. Perhaps this would break too much and be a bad idea for other reasons, but in this scenario it would simplify things if also `1 / x`  would be `Mul` with coeff = 1. Then `Mul` would cover all cases with numeric exponents and Pow wouldn't have to cater for these.