### PR TITLE
Add conan installation method to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ SymEngine mailinglist: http://groups.google.com/group/symengine
 
     conda install symengine -c conda-forge
 
+### Conan package manager
+
+    conan install symengine/<version>@
+
 ### Building from source
 
 Install prerequisites.


### PR DESCRIPTION
My PR to add a `symengine` recipe to the central conan repository was accepted: https://github.com/conan-io/conan-center-index/pull/7241.

It only includes the latest version (0.8.1), but I will try to update it with new versions as they are released.