### PR TITLE
sbml parser: add support for zero arg function symbols

### DIFF
--- a/symengine/parser/sbml/sbml_parser.cpp
+++ b/symengine/parser/sbml/sbml_parser.cpp
@@ -206,8 +206,7 @@ RCP<const Basic> SbmlParser::functionify(const std::string &name)
     if (l != zero_arg_functions.end()) {
         return l->second;
     }
-    throw ParseError("Parsing Unsuccessful: Function '" + name
-                     + "' has no arguments");
+    return function_symbol(name, vec_basic{});
 }
 
 RCP<const Basic> SbmlParser::functionify(const std::string &name,

--- a/symengine/tests/basic/test_sbml_parser.cpp
+++ b/symengine/tests/basic/test_sbml_parser.cpp
@@ -57,6 +57,7 @@ using SymEngine::RealDouble;
 using SymEngine::sbml;
 using SymEngine::Symbol;
 using SymEngine::symbol;
+using SymEngine::vec_basic;
 using SymEngine::zero;
 
 using namespace SymEngine::literals;
@@ -606,8 +607,10 @@ TEST_CASE("Parsing: functions", "[sbml_parser]")
     REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
 
     s = "geq()";
-    REQUIRE_THROWS_WITH(
-        parse_sbml(s), "Parsing Unsuccessful: Function 'geq' has no arguments");
+    res = parse_sbml(s);
+    // parsed as user-defined zero-arg function
+    REQUIRE(eq(*res, *function_symbol("geq", vec_basic{})));
+    REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
 
     s = "geq(x)";
     REQUIRE_THROWS_WITH(
@@ -943,6 +946,11 @@ TEST_CASE("Parsing: function_symbols", "[sbml_parser]")
     RCP<const Basic> y = symbol("y");
     RCP<const Basic> z = symbol("wt");
 
+    s = "f()";
+    res = parse_sbml(s);
+    REQUIRE(eq(*res, *function_symbol("f", vec_basic{})));
+    REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
+
     s = "f(x)";
     res = parse_sbml(s);
     REQUIRE(eq(*res, *function_symbol("f", x)));
@@ -1046,9 +1054,6 @@ TEST_CASE("Parsing: errors", "[sbml_parser]")
     CHECK_THROWS_AS(parse_sbml(s), ParseError &);
 
     s = "x+y+";
-    CHECK_THROWS_AS(parse_sbml(s), ParseError &);
-
-    s = "what()";
     CHECK_THROWS_AS(parse_sbml(s), ParseError &);
 
     s = "x + (y))";


### PR DESCRIPTION
- parse unknown zero-argument functions as function symbols instead of raising exception
- this is now consistent with what is done for functions with arguments