### PR TITLE
Fixes for "static initialization order fiasco"

### DIFF
--- a/symengine/constants.cpp
+++ b/symengine/constants.cpp
@@ -90,41 +90,4 @@ RCP<const Basic> mC4 = mul(minus_one, C4);
 RCP<const Basic> mC5 = mul(minus_one, C5);
 RCP<const Basic> mC6 = mul(minus_one, C6);
 
-// sin_table[n] represents the value of sin(pi*n/12) for n = 0..23
-RCP<const Basic> sin_table[]
-    = {zero, C0,  C1,  C2,  C3,  C4,  one,       C4,  C3,  C2,  C1,  C0,
-       zero, mC0, mC1, mC2, mC3, mC4, minus_one, mC4, mC3, mC2, mC1, mC0};
-
-umap_basic_basic inverse_cst = {
-    {C3, i3},
-    {mC3, im3},
-    {C2, mul(i2, i2)},
-    {mC2, mul(im2, i2)},
-    {C4, integer(12)},
-    {mC4, integer(-12)},
-    {C5, i5},
-    {mC5, im5},
-    {C6, integer(10)},
-    {mC6, integer(-10)},
-    {div(one, i2), integer(6)},
-    {div(minus_one, i2), integer(-6)},
-};
-
-umap_basic_basic inverse_tct = {
-    {div(one, sq3), mul(i2, i3)},
-    {div(minus_one, sq3), mul(im2, i3)},
-    {sq3, i3},
-    {mul(minus_one, sq3), im3},
-    {add(one, sq2), div(pow(i2, i3), i3)},
-    {mul(minus_one, add(one, sq2)), div(pow(i2, i3), im3)},
-    {sub(sq2, one), pow(i2, i3)},
-    {sub(one, sq2), pow(im2, i3)},
-    {sub(i2, sq3), mul(mul(i2, i2), i3)},
-    {sub(sq3, i2), mul(mul(im2, i2), i3)},
-    {sqrt(add(i5, mul(i2, sqrt(i5)))), div(i5, i2)},
-    {mul(minus_one, sqrt(add(i5, mul(i2, sqrt(i5))))), div(im5, i2)},
-    {one, pow(i2, i2)},
-    {minus_one, mul(minus_one, pow(i2, i2))},
-};
-
 } // namespace SymEngine

--- a/symengine/constants.cpp
+++ b/symengine/constants.cpp
@@ -33,28 +33,35 @@ int Constant::compare(const Basic &o) const
     return name_ < s.name_ ? -1 : 1;
 }
 
-RCP<const Integer> zero = integer(0);
-RCP<const Integer> one = integer(1);
-RCP<const Integer> minus_one = integer(-1);
-RCP<const Integer> two = integer(2);
-RCP<const Number> I = Complex::from_two_nums(*zero, *one);
+#define DEFINE_CONSTANT(t, n, d)                                               \
+    RCP<const t> n = []() {                                                    \
+        static const RCP<const t> c = d;                                       \
+        return c;                                                              \
+    }()
 
-RCP<const Constant> pi = constant("pi");
-RCP<const Constant> E = constant("E");
-RCP<const Constant> EulerGamma = constant("EulerGamma");
-RCP<const Constant> Catalan = constant("Catalan");
-RCP<const Constant> GoldenRatio = constant("GoldenRatio");
+DEFINE_CONSTANT(Integer, zero, integer(0));
+DEFINE_CONSTANT(Integer, one, integer(1));
+DEFINE_CONSTANT(Integer, minus_one, integer(-1));
+DEFINE_CONSTANT(Integer, two, integer(2));
 
-RCP<const Infty> Inf = Infty::from_int(1);
-RCP<const Infty> NegInf = Infty::from_int(-1);
-RCP<const Infty> ComplexInf = Infty::from_int(0);
+DEFINE_CONSTANT(Number, I, Complex::from_two_nums(*zero, *one));
 
-RCP<const NaN> Nan = make_rcp<NaN>();
+DEFINE_CONSTANT(Constant, pi, constant("pi"));
+DEFINE_CONSTANT(Constant, E, constant("E"));
+DEFINE_CONSTANT(Constant, EulerGamma, constant("EulerGamma"));
+DEFINE_CONSTANT(Constant, Catalan, constant("Catalan"));
+DEFINE_CONSTANT(Constant, GoldenRatio, constant("GoldenRatio"));
+
+DEFINE_CONSTANT(Infty, Inf, Infty::from_int(1));
+DEFINE_CONSTANT(Infty, NegInf, Infty::from_int(-1));
+DEFINE_CONSTANT(Infty, ComplexInf, Infty::from_int(0));
+
+DEFINE_CONSTANT(NaN, Nan, make_rcp<NaN>());
 
 // Global variables declared in functions.cpp
 // Look over https://github.com/sympy/symengine/issues/272
 // for further details
-RCP<const Basic> i2 = integer(2);
+DEFINE_CONSTANT(Basic, i2, integer(2));
 
 namespace
 {
@@ -64,30 +71,32 @@ RCP<const Basic> sqrt_(const RCP<const Basic> &arg)
 }
 } // namespace
 
-RCP<const Basic> i3 = integer(3);
-RCP<const Basic> i5 = integer(5);
-RCP<const Basic> im2 = integer(-2);
-RCP<const Basic> im3 = integer(-3);
-RCP<const Basic> im5 = integer(-5);
+DEFINE_CONSTANT(Basic, i3, integer(3));
+DEFINE_CONSTANT(Basic, i5, integer(5));
+DEFINE_CONSTANT(Basic, im2, integer(-2));
+DEFINE_CONSTANT(Basic, im3, integer(-3));
+DEFINE_CONSTANT(Basic, im5, integer(-5));
 
-RCP<const Basic> sq3 = sqrt_(i3);
-RCP<const Basic> sq2 = sqrt_(i2);
-RCP<const Basic> sq5 = sqrt_(i5);
+DEFINE_CONSTANT(Basic, sq3, sqrt_(i3));
+DEFINE_CONSTANT(Basic, sq2, sqrt_(i2));
+DEFINE_CONSTANT(Basic, sq5, sqrt_(i5));
 
-RCP<const Basic> C0 = div(sub(sq3, one), mul(i2, sq2));
-RCP<const Basic> C1 = div(one, i2);
-RCP<const Basic> C2 = div(sq2, i2);
-RCP<const Basic> C3 = div(sq3, i2);
-RCP<const Basic> C4 = div(add(sq3, one), mul(i2, sq2));
-RCP<const Basic> C5 = div(sqrt_(sub(i5, sqrt_(i5))), integer(8));
-RCP<const Basic> C6 = div(sub(sqrt_(i5), one), integer(4));
+DEFINE_CONSTANT(Basic, C0, div(sub(sq3, one), mul(i2, sq2)));
+DEFINE_CONSTANT(Basic, C1, div(one, i2));
+DEFINE_CONSTANT(Basic, C2, div(sq2, i2));
+DEFINE_CONSTANT(Basic, C3, div(sq3, i2));
+DEFINE_CONSTANT(Basic, C4, div(add(sq3, one), mul(i2, sq2)));
+DEFINE_CONSTANT(Basic, C5, div(sqrt_(sub(i5, sqrt_(i5))), integer(8)));
+DEFINE_CONSTANT(Basic, C6, div(sub(sqrt_(i5), one), integer(4)));
 
-RCP<const Basic> mC0 = mul(minus_one, C0);
-RCP<const Basic> mC1 = mul(minus_one, C1);
-RCP<const Basic> mC2 = mul(minus_one, C2);
-RCP<const Basic> mC3 = mul(minus_one, C3);
-RCP<const Basic> mC4 = mul(minus_one, C4);
-RCP<const Basic> mC5 = mul(minus_one, C5);
-RCP<const Basic> mC6 = mul(minus_one, C6);
+DEFINE_CONSTANT(Basic, mC0, mul(minus_one, C0));
+DEFINE_CONSTANT(Basic, mC1, mul(minus_one, C1));
+DEFINE_CONSTANT(Basic, mC2, mul(minus_one, C2));
+DEFINE_CONSTANT(Basic, mC3, mul(minus_one, C3));
+DEFINE_CONSTANT(Basic, mC4, mul(minus_one, C4));
+DEFINE_CONSTANT(Basic, mC5, mul(minus_one, C5));
+DEFINE_CONSTANT(Basic, mC6, mul(minus_one, C6));
+
+#undef DEFINE_CONSTANT
 
 } // namespace SymEngine

--- a/symengine/eval_double.cpp
+++ b/symengine/eval_double.cpp
@@ -722,8 +722,6 @@ std::vector<fn> init_eval_double()
     return table;
 }
 
-const static std::vector<fn> table_eval_double = init_eval_double();
-
 double eval_double(const Basic &b)
 {
     EvalRealDoubleVisitorFinal v;
@@ -738,6 +736,7 @@ std::complex<double> eval_complex_double(const Basic &b)
 
 double eval_double_single_dispatch(const Basic &b)
 {
+    static const std::vector<fn> table_eval_double = init_eval_double();
     return table_eval_double[b.get_type_code()](b);
 }
 

--- a/symengine/eval_double.cpp
+++ b/symengine/eval_double.cpp
@@ -450,7 +450,7 @@ public:
 // typedef double (*fn)(const Basic &);
 typedef std::function<double(const Basic &)> fn;
 
-std::vector<fn> init_eval_double()
+static inline std::vector<fn> init_eval_double()
 {
     std::vector<fn> table;
     table.assign(TypeID_Count, [](const Basic &x) -> double {

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -295,7 +295,7 @@ bool handle_minus(const RCP<const Basic> &arg,
 /*! returns `true` if the given argument `t` is found in the
  *   lookup table `d`. It also returns the value in `index`
  **/
-bool inverse_lookup(umap_basic_basic &d, const RCP<const Basic> &t,
+bool inverse_lookup(const umap_basic_basic &d, const RCP<const Basic> &t,
                     const Ptr<RCP<const Basic>> &index);
 
 // \return true of conjugate has to be returned finally else false

--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -50,8 +50,16 @@ RCP<const Boolean> BooleanAtom::logical_not() const
     return boolean(not this->get_val());
 }
 
-RCP<const BooleanAtom> boolTrue = make_rcp<BooleanAtom>(true);
-RCP<const BooleanAtom> boolFalse = make_rcp<BooleanAtom>(false);
+#define DEFINE_CONST_BOOL(n, v)                                                \
+    RCP<const BooleanAtom> n = []() {                                          \
+        static const RCP<const BooleanAtom> c = make_rcp<BooleanAtom>(v);      \
+        return c;                                                              \
+    }()
+
+DEFINE_CONST_BOOL(boolTrue, true);
+DEFINE_CONST_BOOL(boolFalse, false);
+
+#undef DEFINE_CONST_BOOL
 
 Contains::Contains(const RCP<const Basic> &expr, const RCP<const Set> &set)
     : expr_{expr}, set_{set} {SYMENGINE_ASSIGN_TYPEID()}

--- a/symengine/parser/parser.cpp
+++ b/symengine/parser/parser.cpp
@@ -41,8 +41,8 @@ typedef RCP<const Boolean> (*single_arg_boolean_func)(const RCP<const Basic> &);
 typedef RCP<const Boolean> (*double_arg_boolean_func)(const RCP<const Basic> &,
                                                       const RCP<const Basic> &);
 
-static std::map<const std::string,
-                const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
+static const std::map<const std::string, const std::function<RCP<const Basic>(
+                                             const RCP<const Basic> &)>> &
 init_parser_single_arg_functions()
 {
     static const std::map<
@@ -180,7 +180,7 @@ RCP<const Basic> Parser::functionify(const std::string &name, vec_basic &params)
         };
 
     if (params.size() == 1) {
-        auto single_arg_functions_ = init_parser_single_arg_functions();
+        const auto &single_arg_functions_ = init_parser_single_arg_functions();
         auto it1 = single_arg_functions_.find(name);
         if (it1 != single_arg_functions_.end()) {
             return it1->second(params[0]);

--- a/symengine/parser/parser.cpp
+++ b/symengine/parser/parser.cpp
@@ -41,84 +41,73 @@ typedef RCP<const Boolean> (*single_arg_boolean_func)(const RCP<const Basic> &);
 typedef RCP<const Boolean> (*double_arg_boolean_func)(const RCP<const Basic> &,
                                                       const RCP<const Basic> &);
 
-// cast overloaded functions below to single_arg, double_arg before they can
-// be used in the map
-single_arg_func single_casted_log = log;
-single_arg_func single_casted_zeta = zeta;
-
-double_arg_func double_casted_log = log;
-double_arg_func double_casted_zeta = zeta;
-
-single_arg_boolean_func single_casted_Eq = Eq;
-double_arg_boolean_func double_casted_Eq = Eq;
-
-std::map<const std::string,
-         const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
+static std::map<const std::string,
+                const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
 init_parser_single_arg_functions()
 {
-    return {
-        {"sin", sin},
-        {"cos", cos},
-        {"tan", tan},
-        {"cot", cot},
-        {"csc", csc},
-        {"sec", sec},
+    static const std::map<
+        const std::string,
+        const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
+        functions = {
+            {"sin", sin},
+            {"cos", cos},
+            {"tan", tan},
+            {"cot", cot},
+            {"csc", csc},
+            {"sec", sec},
 
-        {"asin", asin},
-        {"arcsin", asin},
-        {"acos", acos},
-        {"arccos", acos},
-        {"atan", atan},
-        {"arctan", atan},
-        {"asec", asec},
-        {"arcsec", asec},
-        {"acsc", acsc},
-        {"arccsc", acsc},
-        {"acot", acot},
-        {"arccot", acot},
+            {"asin", asin},
+            {"arcsin", asin},
+            {"acos", acos},
+            {"arccos", acos},
+            {"atan", atan},
+            {"arctan", atan},
+            {"asec", asec},
+            {"arcsec", asec},
+            {"acsc", acsc},
+            {"arccsc", acsc},
+            {"acot", acot},
+            {"arccot", acot},
 
-        {"sinh", sinh},
-        {"cosh", cosh},
-        {"tanh", tanh},
-        {"coth", coth},
-        {"sech", sech},
-        {"csch", csch},
+            {"sinh", sinh},
+            {"cosh", cosh},
+            {"tanh", tanh},
+            {"coth", coth},
+            {"sech", sech},
+            {"csch", csch},
 
-        {"asinh", asinh},
-        {"arcsinh", asinh},
-        {"acosh", acosh},
-        {"arccosh", acosh},
-        {"atanh", atanh},
-        {"arctanh", atanh},
-        {"asech", asech},
-        {"arcsech", asech},
-        {"acoth", acoth},
-        {"arccoth", acoth},
-        {"acsch", acsch},
-        {"arccsch", acsch},
+            {"asinh", asinh},
+            {"arcsinh", asinh},
+            {"acosh", acosh},
+            {"arccosh", acosh},
+            {"atanh", atanh},
+            {"arctanh", atanh},
+            {"asech", asech},
+            {"arcsech", asech},
+            {"acoth", acoth},
+            {"arccoth", acoth},
+            {"acsch", acsch},
+            {"arccsch", acsch},
 
-        {"gamma", gamma},
-        {"sqrt", sqrt},
-        {"abs", abs},
-        {"exp", exp},
-        {"erf", erf},
-        {"erfc", erfc},
-        {"loggamma", loggamma},
-        {"lambertw", lambertw},
-        {"dirichlet_eta", dirichlet_eta},
-        {"floor", floor},
-        {"ceiling", ceiling},
-        {"ln", single_casted_log},
-        {"log", single_casted_log},
-        {"zeta", single_casted_zeta},
-        {"primepi", primepi},
-        {"primorial", primorial},
-    };
+            {"gamma", gamma},
+            {"sqrt", sqrt},
+            {"abs", abs},
+            {"exp", exp},
+            {"erf", erf},
+            {"erfc", erfc},
+            {"loggamma", loggamma},
+            {"lambertw", lambertw},
+            {"dirichlet_eta", dirichlet_eta},
+            {"floor", floor},
+            {"ceiling", ceiling},
+            {"ln", (single_arg_func)log},
+            {"log", (single_arg_func)log},
+            {"zeta", (single_arg_func)zeta},
+            {"primepi", primepi},
+            {"primorial", primorial},
+        };
+    return functions;
 }
-
-const std::map<const std::string,
-               const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
-    Parser::single_arg_functions_ = init_parser_single_arg_functions();
 
 RCP<const Basic> Parser::functionify(const std::string &name, vec_basic &params)
 {
@@ -129,8 +118,8 @@ RCP<const Basic> Parser::functionify(const std::string &name, vec_basic &params)
         double_arg_functions = {
             {"pow", (double_arg_func)pow},
             {"beta", beta},
-            {"log", double_casted_log},
-            {"zeta", double_casted_zeta},
+            {"log", (double_arg_func)log},
+            {"zeta", (double_arg_func)zeta},
             {"lowergamma", lowergamma},
             {"uppergamma", uppergamma},
             {"polygamma", polygamma},
@@ -150,7 +139,7 @@ RCP<const Basic> Parser::functionify(const std::string &name, vec_basic &params)
         const std::string,
         const std::function<RCP<const Boolean>(const RCP<const Basic> &)>>
         single_arg_boolean_functions = {
-            {"Eq", single_casted_Eq},
+            {"Eq", (single_arg_boolean_func)Eq},
         };
     const static std::map<
         const std::string,
@@ -164,7 +153,7 @@ RCP<const Basic> Parser::functionify(const std::string &name, vec_basic &params)
         const std::function<RCP<const Boolean>(const RCP<const Basic> &,
                                                const RCP<const Basic> &)>>
         double_arg_boolean_functions = {
-            {"Eq", double_casted_Eq},
+            {"Eq", (double_arg_boolean_func)Eq},
             {"Ne", Ne},
             {"Ge", Ge},
             {"Gt", Gt},
@@ -191,6 +180,7 @@ RCP<const Basic> Parser::functionify(const std::string &name, vec_basic &params)
         };
 
     if (params.size() == 1) {
+        auto single_arg_functions_ = init_parser_single_arg_functions();
         auto it1 = single_arg_functions_.find(name);
         if (it1 != single_arg_functions_.end()) {
             return it1->second(params[0]);

--- a/symengine/parser/parser.h
+++ b/symengine/parser/parser.h
@@ -28,18 +28,8 @@ namespace SymEngine
 
 class Tokenizer;
 
-std::map<const std::string,
-         const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
-init_parser_single_arg_functions();
-
 class Parser
 {
-private:
-    static const std::map<
-        const std::string,
-        const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
-        single_arg_functions_;
-
 protected:
     std::string inp;
     std::map<const std::string, const RCP<const Basic>> local_parser_constants;

--- a/symengine/parser/sbml/sbml_parser.cpp
+++ b/symengine/parser/sbml/sbml_parser.cpp
@@ -79,8 +79,8 @@ static RCP<const Basic> fact(const RCP<const Basic> &x)
     return gamma(add(x, integer(1)));
 }
 
-static std::map<const std::string,
-                const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
+static const std::map<const std::string, const std::function<RCP<const Basic>(
+                                             const RCP<const Basic> &)>> &
 init_sbml_parser_single_arg_functions()
 {
     static const std::map<
@@ -256,7 +256,8 @@ RCP<const Basic> SbmlParser::functionify(const std::string &name,
 
     std::string lname = lowercase(name);
     if (params.size() == 1) {
-        auto single_arg_functions_ = init_sbml_parser_single_arg_functions();
+        const auto &single_arg_functions_
+            = init_sbml_parser_single_arg_functions();
         auto it1 = single_arg_functions_.find(lname);
         if (it1 != single_arg_functions_.end()) {
             return it1->second(params[0]);

--- a/symengine/parser/sbml/sbml_parser.h
+++ b/symengine/parser/sbml/sbml_parser.h
@@ -17,12 +17,6 @@ class SbmlTokenizer;
 
 class SbmlParser : public Parser
 {
-private:
-    static const std::map<
-        const std::string,
-        const std::function<RCP<const Basic>(const RCP<const Basic> &)>>
-        single_arg_functions_;
-
 public:
     std::unique_ptr<SbmlTokenizer> m_tokenizer;
     RCP<const Basic> parse(const std::string &input);

--- a/symengine/prime_sieve.cpp
+++ b/symengine/prime_sieve.cpp
@@ -3,11 +3,17 @@
 #include <cmath>
 #include <valarray>
 #include <algorithm>
+#include <vector>
 
 namespace SymEngine
 {
 
-std::vector<unsigned> Sieve::_primes = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29};
+static std::vector<unsigned> &sieve_primes()
+{
+    static std::vector<unsigned> primes = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29};
+    return primes;
+}
+
 bool Sieve::_clear = true;
 unsigned Sieve::_sieve_size = 32 * 1024 * 8; // 32K in bits
 
@@ -18,6 +24,7 @@ void Sieve::set_clear(bool clear)
 
 void Sieve::clear()
 {
+    std::vector<unsigned> &_primes = sieve_primes();
     _primes.erase(_primes.begin() + 10, _primes.end());
 }
 
@@ -32,6 +39,7 @@ void Sieve::set_sieve_size(unsigned size)
 
 void Sieve::_extend(unsigned limit)
 {
+    std::vector<unsigned> &_primes = sieve_primes();
 #ifdef HAVE_SYMENGINE_PRIMESIEVE
     if (_primes.back() < limit)
         primesieve::generate_primes(_primes.back() + 1, limit, &_primes);
@@ -79,6 +87,7 @@ void Sieve::_extend(unsigned limit)
 void Sieve::generate_primes(std::vector<unsigned> &primes, unsigned limit)
 {
     _extend(limit);
+    std::vector<unsigned> &_primes = sieve_primes();
     auto it = std::upper_bound(_primes.begin(), _primes.end(), limit);
     // find the first position greater than limit and reserve space for the
     // primes
@@ -108,6 +117,7 @@ Sieve::iterator::~iterator()
 
 unsigned Sieve::iterator::next_prime()
 {
+    std::vector<unsigned> &_primes = sieve_primes();
     if (_index >= _primes.size()) {
         unsigned extend_to = _primes[_index - 1] * 2;
         if (_limit > 0 and _limit < extend_to) {
@@ -118,7 +128,7 @@ unsigned Sieve::iterator::next_prime()
             return _limit + 1;
         }
     }
-    return SymEngine::Sieve::_primes[_index++];
+    return _primes[_index++];
 }
 
 }; // namespace SymEngine

--- a/symengine/prime_sieve.h
+++ b/symengine/prime_sieve.h
@@ -19,7 +19,6 @@ class Sieve
 {
 
 private:
-    static std::vector<unsigned> _primes;
     static void _extend(unsigned limit);
     static unsigned _sieve_size;
     static bool _clear;

--- a/symengine/printers/latex.cpp
+++ b/symengine/printers/latex.cpp
@@ -451,11 +451,9 @@ std::vector<std::string> init_latex_printer_names()
     return names;
 }
 
-const std::vector<std::string> LatexPrinter::names_
-    = init_latex_printer_names();
-
 void LatexPrinter::bvisit(const Function &x)
 {
+    static const std::vector<std::string> names_ = init_latex_printer_names();
     std::ostringstream o;
     o << names_[x.get_type_code()] << "{";
     vec_basic vec = x.get_args();

--- a/symengine/printers/mathml.cpp
+++ b/symengine/printers/mathml.cpp
@@ -23,8 +23,6 @@ std::vector<std::string> init_mathml_printer_names()
     names[SYMENGINE_ASECH] = "arcsech";
     return names;
 }
-const std::vector<std::string> MathMLPrinter::names_
-    = init_mathml_printer_names();
 
 void MathMLPrinter::bvisit(const Basic &x)
 {
@@ -278,6 +276,7 @@ void MathMLPrinter::bvisit(const Constant &x)
 
 void MathMLPrinter::bvisit(const Function &x)
 {
+    static const std::vector<std::string> names_ = init_mathml_printer_names();
     s << "<apply>";
     s << "<" << names_[x.get_type_code()] << "/>";
     const auto &args = x.get_args();

--- a/symengine/printers/sbml.cpp
+++ b/symengine/printers/sbml.cpp
@@ -23,8 +23,6 @@ static std::vector<std::string> init_sbml_printer_names()
     return names;
 }
 
-const std::vector<std::string> SbmlPrinter::names_ = init_sbml_printer_names();
-
 void SbmlPrinter::_print_pow(std::ostringstream &o, const RCP<const Basic> &a,
                              const RCP<const Basic> &b)
 {
@@ -130,6 +128,7 @@ void SbmlPrinter::bvisit(const Constant &x)
 
 void SbmlPrinter::bvisit(const Function &x)
 {
+    static const std::vector<std::string> names_ = init_sbml_printer_names();
     std::ostringstream o;
     vec_basic vec = x.get_args();
     if (x.get_type_code() == SYMENGINE_GAMMA) {

--- a/symengine/printers/strprinter.cpp
+++ b/symengine/printers/strprinter.cpp
@@ -855,6 +855,7 @@ std::string StrPrinter::apply(const vec_basic &d)
 
 void StrPrinter::bvisit(const Function &x)
 {
+    static const std::vector<std::string> names_ = init_str_printer_names();
     std::ostringstream o;
     o << names_[x.get_type_code()];
     vec_basic vec = x.get_args();
@@ -1097,8 +1098,6 @@ std::vector<std::string> init_str_printer_names()
     names[SYMENGINE_UNEVALUATED_EXPR] = "";
     return names;
 }
-
-const std::vector<std::string> StrPrinter::names_ = init_str_printer_names();
 
 std::string StrPrinter::print_mul()
 {

--- a/symengine/printers/strprinter.h
+++ b/symengine/printers/strprinter.h
@@ -103,8 +103,6 @@ public:
     PrecedenceEnum getPrecedence(const RCP<const Basic> &x);
 };
 
-std::vector<std::string> init_str_printer_names();
-
 class StrPrinter : public BaseVisitor<StrPrinter>
 {
 private:

--- a/symengine/printers/unicode.cpp
+++ b/symengine/printers/unicode.cpp
@@ -564,8 +564,45 @@ void UnicodePrinter::bvisit(const Ceiling &x)
     box_ = box;
 }
 
+static std::vector<std::string> init_unicode_printer_names()
+{
+    std::vector<std::string> names = init_str_printer_names();
+    names[SYMENGINE_LAMBERTW] = "W";
+    names[SYMENGINE_ZETA] = "\U0001D701";
+    names[SYMENGINE_DIRICHLET_ETA] = "\U0001D702";
+    names[SYMENGINE_LOWERGAMMA] = "\U0001D6FE";
+    names[SYMENGINE_UPPERGAMMA] = "\u0393";
+    names[SYMENGINE_BETA] = "B";
+    names[SYMENGINE_LOGGAMMA] = "log \u0393";
+    names[SYMENGINE_GAMMA] = "\u0393";
+    names[SYMENGINE_PRIMEPI] = "\U0001D70B";
+    return names;
+}
+
+static std::vector<size_t>
+init_unicode_printer_lengths(const std::vector<std::string> &names)
+{
+    std::vector<size_t> lengths;
+    for (auto &name : names) {
+        lengths.push_back(name.length());
+    }
+    lengths[SYMENGINE_LAMBERTW] = 1;
+    lengths[SYMENGINE_ZETA] = 1;
+    lengths[SYMENGINE_DIRICHLET_ETA] = 1;
+    lengths[SYMENGINE_LOWERGAMMA] = 1;
+    lengths[SYMENGINE_UPPERGAMMA] = 1;
+    lengths[SYMENGINE_BETA] = 1;
+    lengths[SYMENGINE_LOGGAMMA] = 5;
+    lengths[SYMENGINE_GAMMA] = 1;
+    lengths[SYMENGINE_PRIMEPI] = 1;
+    return lengths;
+}
+
 void UnicodePrinter::bvisit(const Function &x)
 {
+    static const std::vector<std::string> names_ = init_unicode_printer_names();
+    static const std::vector<size_t> lengths_
+        = init_unicode_printer_lengths(names_);
     StringBox box(names_[x.get_type_code()], lengths_[x.get_type_code()]);
     vec_basic vec = x.get_args();
     StringBox args = apply(vec);
@@ -631,46 +668,6 @@ StringBox UnicodePrinter::apply(const Basic &b)
     b.accept(*this);
     return box_;
 }
-
-static std::vector<std::string> init_unicode_printer_names()
-{
-    std::vector<std::string> names = init_str_printer_names();
-    names[SYMENGINE_LAMBERTW] = "W";
-    names[SYMENGINE_ZETA] = "\U0001D701";
-    names[SYMENGINE_DIRICHLET_ETA] = "\U0001D702";
-    names[SYMENGINE_LOWERGAMMA] = "\U0001D6FE";
-    names[SYMENGINE_UPPERGAMMA] = "\u0393";
-    names[SYMENGINE_BETA] = "B";
-    names[SYMENGINE_LOGGAMMA] = "log \u0393";
-    names[SYMENGINE_GAMMA] = "\u0393";
-    names[SYMENGINE_PRIMEPI] = "\U0001D70B";
-    return names;
-}
-
-const std::vector<std::string> UnicodePrinter::names_
-    = init_unicode_printer_names();
-
-std::vector<size_t>
-init_unicode_printer_lengths(const std::vector<std::string> &names)
-{
-    std::vector<size_t> lengths;
-    for (auto &name : names) {
-        lengths.push_back(name.length());
-    }
-    lengths[SYMENGINE_LAMBERTW] = 1;
-    lengths[SYMENGINE_ZETA] = 1;
-    lengths[SYMENGINE_DIRICHLET_ETA] = 1;
-    lengths[SYMENGINE_LOWERGAMMA] = 1;
-    lengths[SYMENGINE_UPPERGAMMA] = 1;
-    lengths[SYMENGINE_BETA] = 1;
-    lengths[SYMENGINE_LOGGAMMA] = 5;
-    lengths[SYMENGINE_GAMMA] = 1;
-    lengths[SYMENGINE_PRIMEPI] = 1;
-    return lengths;
-}
-
-const std::vector<size_t> UnicodePrinter::lengths_
-    = init_unicode_printer_lengths(UnicodePrinter::names_);
 
 StringBox UnicodePrinter::print_mul()
 {

--- a/symengine/tests/ntheory/test_ntheory.cpp
+++ b/symengine/tests/ntheory/test_ntheory.cpp
@@ -625,6 +625,7 @@ TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
     RCP<const Integer> i93 = integer(93);
     RCP<const Integer> i100 = integer(100);
     RCP<const Integer> i105 = integer(105);
+    RCP<const Integer> i5001 = integer(5001);
     RCP<const Integer> i5008 = integer(5008);
     RCP<const Integer> i7519 = integer(7519);
     RCP<const Integer> i10009 = integer(10009);
@@ -645,7 +646,10 @@ TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
     REQUIRE(eq(*nthroot, *i5));
 
     REQUIRE(nthroot_mod(outArg(nthroot), i7519, i2, i10009) == true);
-    REQUIRE(eq(*nthroot, *i5008));
+    // The square root is +/- 5001 mod 10009.
+    if (!eq(*nthroot, *i5001)) {
+        REQUIRE(eq(*nthroot, *i5008));
+    }
 
     REQUIRE(nthroot_mod(outArg(nthroot), im1, i2, i41) == true);
     rem = integer(nthroot->as_integer_class() * nthroot->as_integer_class()

--- a/symengine/tests/ntheory/test_ntheory.cpp
+++ b/symengine/tests/ntheory/test_ntheory.cpp
@@ -625,6 +625,9 @@ TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
     RCP<const Integer> i93 = integer(93);
     RCP<const Integer> i100 = integer(100);
     RCP<const Integer> i105 = integer(105);
+    RCP<const Integer> i5008 = integer(5008);
+    RCP<const Integer> i7519 = integer(7519);
+    RCP<const Integer> i10009 = integer(10009);
     RCP<const Integer> nthroot, rem;
     std::vector<RCP<const Integer>> roots, v;
 
@@ -640,6 +643,9 @@ TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
 
     REQUIRE(nthroot_mod(outArg(nthroot), i5, i1, i100) == true);
     REQUIRE(eq(*nthroot, *i5));
+
+    REQUIRE(nthroot_mod(outArg(nthroot), i7519, i2, i10009) == true);
+    REQUIRE(eq(*nthroot, *i5008));
 
     REQUIRE(nthroot_mod(outArg(nthroot), im1, i2, i41) == true);
     rem = integer(nthroot->as_integer_class() * nthroot->as_integer_class()

--- a/symengine/tests/ntheory/test_ntheory.cpp
+++ b/symengine/tests/ntheory/test_ntheory.cpp
@@ -647,9 +647,8 @@ TEST_CASE("test_nthroot_mod(): ntheory", "[ntheory]")
 
     REQUIRE(nthroot_mod(outArg(nthroot), i7519, i2, i10009) == true);
     // The square root is +/- 5001 mod 10009.
-    if (!eq(*nthroot, *i5001)) {
-        REQUIRE(eq(*nthroot, *i5008));
-    }
+    bool sqrt_ok = eq(*nthroot, *i5001) || eq(*nthroot, *i5008);
+    REQUIRE(sqrt_ok);
 
     REQUIRE(nthroot_mod(outArg(nthroot), im1, i2, i41) == true);
     rem = integer(nthroot->as_integer_class() * nthroot->as_integer_class()


### PR DESCRIPTION
When symengine is statically linked to a library, especially with link-time optimization, it can result in segfaults due to this issue: https://en.cppreference.com/w/cpp/language/siof

This PR tries to fix the instances I have found. It's possible I've missed some, but at least this is enough to avoid the issue in my use case involving pybind11 (527 valgrind errors from importing the python module reduced to 0).

Typically the fix is some form of the initialize-on-first-use idiom. For the constants, I introduced lambdas for this purpose to avoid having to add `()` to every reference to them in the code base.