### PR TITLE
Specify u8 for string literals in unicode printer

### DIFF
--- a/symengine/printers/stringbox.cpp
+++ b/symengine/printers/stringbox.cpp
@@ -3,6 +3,10 @@
 #include <algorithm>
 #include <symengine/printers/stringbox.h>
 
+// Macro to let string literals be unicode const char in all C++ standards
+// Otherwise u8"" would be char8_t in C++20
+#define U8(x) reinterpret_cast<const char *>(u8##x)
+
 namespace SymEngine
 {
 
@@ -36,7 +40,7 @@ void StringBox::add_below_unicode_line(StringBox &other)
     auto new_width = std::max(width_, other.width_);
     std::string bar;
     for (unsigned i = 0; i < new_width; i++) {
-        bar.append("\u2015");
+        bar.append(U8("\u2015"));
     }
     StringBox barbox(bar, new_width);
     add_below(barbox);
@@ -85,8 +89,8 @@ void StringBox::add_power(StringBox &other)
 void StringBox::enclose_abs()
 {
     for (std::string &line : lines_) {
-        line.insert(0, "\u2502");
-        line.append("\u2502");
+        line.insert(0, U8("\u2502"));
+        line.append(U8("\u2502"));
     }
     width_ += 2;
 }
@@ -114,10 +118,10 @@ void StringBox::add_left_parens()
     if (lines_.size() == 1) {
         lines_[0].insert(0, "(");
     } else {
-        lines_[0].insert(0, "\u239B");
-        lines_.back().insert(0, "\u239D");
+        lines_[0].insert(0, U8("\u239B"));
+        lines_.back().insert(0, U8("\u239D"));
         for (unsigned i = 1; i < lines_.size() - 1; i++) {
-            lines_[i].insert(0, "\u239C");
+            lines_[i].insert(0, U8("\u239C"));
         }
     }
     width_ += 1;
@@ -128,10 +132,10 @@ void StringBox::add_right_parens()
     if (lines_.size() == 1) {
         lines_[0].append(")");
     } else {
-        lines_[0].append("\u239E");
-        lines_.back().append("\u23A0");
+        lines_[0].append(U8("\u239E"));
+        lines_.back().append(U8("\u23A0"));
         for (unsigned i = 1; i < lines_.size() - 1; i++) {
-            lines_[i].append("\u239F");
+            lines_[i].append(U8("\u239F"));
         }
     }
     width_ += 1;
@@ -142,10 +146,10 @@ void StringBox::add_left_sqbracket()
     if (lines_.size() == 1) {
         lines_[0].insert(0, "[");
     } else {
-        lines_[0].insert(0, "\u23A1");
-        lines_.back().insert(0, "\u23A3");
+        lines_[0].insert(0, U8("\u23A1"));
+        lines_.back().insert(0, U8("\u23A3"));
         for (unsigned i = 1; i < lines_.size() - 1; i++) {
-            lines_[i].insert(0, "\u23A2");
+            lines_[i].insert(0, U8("\u23A2"));
         }
     }
     width_ += 1;
@@ -156,18 +160,19 @@ void StringBox::add_left_curly()
     if (lines_.size() == 1) {
         lines_[0].insert(0, "{");
     } else if (lines_.size() == 2) {
-        lines_[0].insert(0, "\u23A7");
-        lines_[1].insert(0, "\u23A9");
-        lines_.insert(lines_.begin() + 1, "\u23A8" + std::string(width_, ' '));
+        lines_[0].insert(0, U8("\u23A7"));
+        lines_[1].insert(0, U8("\u23A9"));
+        lines_.insert(lines_.begin() + 1,
+                      U8("\u23A8") + std::string(width_, ' '));
     } else {
-        lines_[0].insert(0, "\u23A7");
-        lines_.back().insert(0, "\u23A9");
+        lines_[0].insert(0, U8("\u23A7"));
+        lines_.back().insert(0, U8("\u23A9"));
         std::size_t mid = lines_.size() / 2;
         for (std::size_t i = 1; i < lines_.size() - 1; i++) {
             if (i == mid) {
-                lines_[i].insert(0, "\u23A8");
+                lines_[i].insert(0, U8("\u23A8"));
             } else {
-                lines_[i].insert(0, "\u23AA");
+                lines_[i].insert(0, U8("\u23AA"));
             }
         }
     }
@@ -179,18 +184,19 @@ void StringBox::add_right_curly()
     if (lines_.size() == 1) {
         lines_[0].append("}");
     } else if (lines_.size() == 2) {
-        lines_[0].append("\u23AB");
-        lines_[1].append("\u23AD");
-        lines_.insert(lines_.begin() + 1, std::string(width_, ' ') + "\u23AC");
+        lines_[0].append(U8("\u23AB"));
+        lines_[1].append(U8("\u23AD"));
+        lines_.insert(lines_.begin() + 1,
+                      std::string(width_, ' ') + U8("\u23AC"));
     } else {
-        lines_[0].append("\u23AB");
-        lines_.back().append("\u23AD");
+        lines_[0].append(U8("\u23AB"));
+        lines_.back().append(U8("\u23AD"));
         std::size_t mid = lines_.size() / 2;
         for (std::size_t i = 1; i < lines_.size() - 1; i++) {
             if (i == mid) {
-                lines_[i].append("\u23AC");
+                lines_[i].append(U8("\u23AC"));
             } else {
-                lines_[i].append("\u23AA");
+                lines_[i].append(U8("\u23AA"));
             }
         }
     }
@@ -202,10 +208,10 @@ void StringBox::add_right_sqbracket()
     if (lines_.size() == 1) {
         lines_[0].append("]");
     } else {
-        lines_[0].append("\u23A4");
-        lines_.back().append("\u23A5");
+        lines_[0].append(U8("\u23A4"));
+        lines_.back().append(U8("\u23A5"));
         for (unsigned i = 1; i < lines_.size() - 1; i++) {
-            lines_[i].append("\u23A6");
+            lines_[i].append(U8("\u23A6"));
         }
     }
     width_ += 1;
@@ -213,22 +219,22 @@ void StringBox::add_right_sqbracket()
 
 void StringBox::enclose_floor()
 {
-    lines_.back().insert(0, "\u230A");
-    lines_.back().append("\u230B");
+    lines_.back().insert(0, U8("\u230A"));
+    lines_.back().append(U8("\u230B"));
     for (unsigned i = 0; i < lines_.size() - 1; i++) {
-        lines_[i].insert(0, "\u2502");
-        lines_[i].append("\u2502");
+        lines_[i].insert(0, U8("\u2502"));
+        lines_[i].append(U8("\u2502"));
     }
     width_ += 2;
 }
 
 void StringBox::enclose_ceiling()
 {
-    lines_[0].insert(0, "\u2308");
-    lines_[0].append("\u2309");
+    lines_[0].insert(0, U8("\u2308"));
+    lines_[0].append(U8("\u2309"));
     for (unsigned i = 1; i < lines_.size(); i++) {
-        lines_[i].insert(0, "\u2502");
-        lines_[i].append("\u2502");
+        lines_[i].insert(0, U8("\u2502"));
+        lines_[i].append(U8("\u2502"));
     }
     width_ += 2;
 }
@@ -239,9 +245,9 @@ void StringBox::enclose_sqrt()
     std::size_t i = len;
     for (std::string &line : lines_) {
         if (i == 1) {
-            line.insert(0, "\u2572\u2571" + std::string(len - i, ' '));
+            line.insert(0, U8("\u2572\u2571") + std::string(len - i, ' '));
         } else {
-            line.insert(0, std::string(i, ' ') + "\u2571"
+            line.insert(0, std::string(i, ' ') + U8("\u2571")
                                + std::string(len - i, ' '));
         }
         i--;

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -84,6 +84,10 @@ using SymEngine::zeta;
 
 using namespace SymEngine::literals;
 
+// Macro to let string literals be unicode const char in all C++ standards
+// Otherwise u8"" would be char8_t in C++20
+#define U8(x) reinterpret_cast<const char *>(u8##x)
+
 namespace SymEngine
 {
 class MyStrPrinter : public BaseVisitor<MyStrPrinter, StrPrinter>
@@ -782,252 +786,255 @@ TEST_CASE("test_unicode()", "[unicode]")
     std::string s;
 
     s = unicode(*complexes());
-    CHECK(s == "\u2102");
+    CHECK(s == U8("\u2102"));
 
     s = unicode(*reals());
-    CHECK(s == "\u211D");
+    CHECK(s == U8("\u211D"));
 
     s = unicode(*rationals());
-    CHECK(s == "\u211A");
+    CHECK(s == U8("\u211A"));
 
     s = unicode(*integers());
-    CHECK(s == "\u2124");
+    CHECK(s == U8("\u2124"));
 
     s = unicode(*emptyset());
-    CHECK(s == "\u2205");
+    CHECK(s == U8("\u2205"));
 
     s = unicode(*universalset());
-    CHECK(s == "\U0001D54C");
+    CHECK(s == U8("\U0001D54C"));
 
     s = unicode(*finiteset({integer(1), integer(2)}));
-    CHECK(s == "{1, 2}");
+    CHECK(s == U8("{1, 2}"));
 
     s = unicode(*finiteset(
         {Rational::from_two_ints(*integer(1), *integer(2)), integer(-1)}));
-    CHECK(s == "\u23A71    \u23AB\n\u23A8\u2015, -1\u23AC\n\u23A92    \u23AD");
+    CHECK(
+        s
+        == U8("\u23A71    \u23AB\n\u23A8\u2015, -1\u23AC\n\u23A92    \u23AD"));
 
     s = unicode(*reals()->contains(x));
-    CHECK(s == "x \u220A \u211D");
+    CHECK(s == U8("x \u220A \u211D"));
 
     s = unicode(*interval(integer(0), integer(1)));
-    CHECK(s == "[0, 1]");
+    CHECK(s == U8("[0, 1]"));
 
     s = unicode(*interval(integer(-1), integer(1), true, false));
-    CHECK(s == "(-1, 1]");
+    CHECK(s == U8("(-1, 1]"));
 
     auto rat = Rational::from_two_ints(*integer(2), *integer(21));
     s = unicode(*interval(rat, integer(23), false, true));
     CHECK(s
-          == "\u23A1 2    \u239E\n\u23A2\u2015\u2015, 23\u239F\n\u23A321    "
-             "\u23A0");
+          == U8("\u23A1 2    \u239E\n\u23A2\u2015\u2015, 23\u239F\n\u23A321    "
+                u8"\u23A0"));
 
     s = unicode(*set_union({integers(), finiteset({Rational::from_two_ints(
                                             *integer(1), *integer(3))})}));
     CHECK(s
-          == "    \u23A71\u23AB\n\u2124 \u222A \u23A8\u2015\u23AC\n    "
-             "\u23A93\u23AD");
+          == U8("    \u23A71\u23AB\n\u2124 \u222A \u23A8\u2015\u23AC\n    "
+                u8"\u23A93\u23AD"));
 
     s = unicode(*set_complement(reals(), rationals()));
-    CHECK(s == "\u211D \\ \u211A");
+    CHECK(s == U8("\u211D \\ \u211A"));
 
     s = unicode(*imageset(x, add(x, integer(1)), interval(zero, one)));
-    CHECK(s == "{1 + x | x \u220A [0, 1]}");
+    CHECK(s == U8("{1 + x | x \u220A [0, 1]}"));
 
     s = unicode(*conditionset(
         {x}, logical_and({reals()->contains(x), Ge(x, integer(9))})));
-    CHECK(s == "{x | 9 \u2264 x \u2227 x \u220A \u211D}");
+    CHECK(s == U8("{x | 9 \u2264 x \u2227 x \u220A \u211D}"));
 
     s = unicode(NaN());
-    CHECK(s == "NaN");
+    CHECK(s == U8("NaN"));
 
     s = unicode(*pi);
-    CHECK(s == "\U0001D70B");
+    CHECK(s == U8("\U0001D70B"));
 
     s = unicode(*parse("e"));
-    CHECK(s == "\U0001D452");
+    CHECK(s == U8("\U0001D452"));
 
     s = unicode(*parse("EulerGamma"));
-    CHECK(s == "\U0001D6FE");
+    CHECK(s == U8("\U0001D6FE"));
 
     s = unicode(*parse("Catalan"));
-    CHECK(s == "\U0001D43A");
+    CHECK(s == U8("\U0001D43A"));
 
     s = unicode(*parse("GoldenRatio"));
-    CHECK(s == "\U0001D719");
+    CHECK(s == U8("\U0001D719"));
 
     s = unicode(*lambertw(x));
-    CHECK(s == "W(x)");
+    CHECK(s == U8("W(x)"));
 
     s = unicode(*zeta(x));
-    CHECK(s == "\U0001D701(x, 1)");
+    CHECK(s == U8("\U0001D701(x, 1)"));
 
     s = unicode(*gamma(x));
-    CHECK(s == "\u0393(x)");
+    CHECK(s == U8("\u0393(x)"));
 
     s = unicode(*lowergamma(x, y));
-    CHECK(s == "\U0001D6FE(x, y)");
+    CHECK(s == U8("\U0001D6FE(x, y)"));
 
     s = unicode(*uppergamma(x, y));
-    CHECK(s == "\u0393(x, y)");
+    CHECK(s == U8("\u0393(x, y)"));
 
     s = unicode(*beta(x, y));
-    CHECK(s == "B(y, x)");
+    CHECK(s == U8("B(y, x)"));
 
     s = unicode(*dirichlet_eta(x));
-    CHECK(s == "\U0001D702(x)");
+    CHECK(s == U8("\U0001D702(x)"));
 
     s = unicode(*loggamma(x));
-    CHECK(s == "log \u0393(x)");
+    CHECK(s == U8("log \u0393(x)"));
 
     s = unicode(*primepi(x));
-    CHECK(s == "\U0001D70B(x)");
+    CHECK(s == U8("\U0001D70B(x)"));
 
     s = unicode(*abs(x));
-    CHECK(s == "\u2502x\u2502");
+    CHECK(s == U8("\u2502x\u2502"));
 
     s = unicode(*floor(x));
-    CHECK(s == "\u230Ax\u230B");
+    CHECK(s == U8("\u230Ax\u230B"));
 
     s = unicode(*ceiling(x));
-    CHECK(s == "\u2308x\u2309");
+    CHECK(s == U8("\u2308x\u2309"));
 
     auto c1 = Complex::from_two_nums(*integer(1), *integer(2));
     s = unicode(*c1);
-    CHECK(s == "1 + 2\u22C5\U0001D456");
+    CHECK(s == U8("1 + 2\u22C5\U0001D456"));
 
     auto c2 = Complex::from_two_nums(*integer(-5), *integer(6));
     s = unicode(*c2);
-    CHECK(s == "-5 + 6\u22C5\U0001D456");
+    CHECK(s == U8("-5 + 6\u22C5\U0001D456"));
 
     auto c3 = Complex::from_two_nums(*integer(5), *integer(-6));
     s = unicode(*c3);
-    CHECK(s == "5 - 6\u22C5\U0001D456");
+    CHECK(s == U8("5 - 6\u22C5\U0001D456"));
 
     auto c4 = Complex::from_two_nums(*integer(5), *integer(-1));
     s = unicode(*c4);
-    CHECK(s == "5 - \U0001D456");
+    CHECK(s == U8("5 - \U0001D456"));
 
     auto c5 = Complex::from_two_nums(*integer(0), *integer(-1));
     s = unicode(*c5);
-    CHECK(s == "-\U0001D456");
+    CHECK(s == U8("-\U0001D456"));
 
     auto c6 = Complex::from_two_nums(*integer(0), *integer(-2));
     s = unicode(*c6);
-    CHECK(s == "-2\u22C5\U0001D456");
+    CHECK(s == U8("-2\u22C5\U0001D456"));
 
     s = unicode(*infty());
-    CHECK(s == "\u221E");
+    CHECK(s == U8("\u221E"));
 
     s = unicode(*mul(integer(-1), infty()));
-    CHECK(s == "-\u221E");
+    CHECK(s == U8("-\u221E"));
 
     s = unicode(*ComplexInf);
-    CHECK(s == "\U0001D467\u221E");
+    CHECK(s == U8("\U0001D467\u221E"));
 
     s = unicode(*Le(x, integer(0)));
-    CHECK(s == "x \u2264 0");
+    CHECK(s == U8("x \u2264 0"));
 
     s = unicode(*Lt(x, integer(0)));
-    CHECK(s == "x < 0");
+    CHECK(s == U8("x < 0"));
 
     s = unicode(*Ne(x, integer(0)));
-    CHECK(s == "0 \u2260 x");
+    CHECK(s == U8("0 \u2260 x"));
 
     s = unicode(*Eq(x, integer(0)));
-    CHECK(s == "0 = x");
+    CHECK(s == U8("0 = x"));
 
     s = unicode(*parse("5 == 5"));
-    CHECK(s == "true");
+    CHECK(s == U8("true"));
 
     s = unicode(*parse("5 != 5"));
-    CHECK(s == "false");
+    CHECK(s == U8("false"));
 
     s = unicode(*logical_and(
         {Lt(x, integer(0)), Ne(integer(-1), x), Lt(x, integer(2))}));
-    CHECK(s == "-1 \u2260 x \u2227 x < 2 \u2227 x < 0");
+    CHECK(s == U8("-1 \u2260 x \u2227 x < 2 \u2227 x < 0"));
 
     s = unicode(*logical_or(
         {Lt(x, integer(0)), Ne(integer(-1), x), Lt(x, integer(2))}));
-    CHECK(s == "-1 \u2260 x \u2228 x < 2 \u2228 x < 0");
+    CHECK(s == U8("-1 \u2260 x \u2228 x < 2 \u2228 x < 0"));
 
     s = unicode(*logical_xor(
         {Lt(x, integer(0)), Ne(integer(-1), x), Lt(x, integer(2))}));
-    CHECK(s == "-1 \u2260 x \u22BB x < 2 \u22BB x < 0");
+    CHECK(s == U8("-1 \u2260 x \u22BB x < 2 \u22BB x < 0"));
 
     s = unicode(*logical_not(logical_xor({Ne(x, y), Lt(x, y)})));
-    CHECK(s == "\u00AC(x \u2260 y \u22BB x < y)");
+    CHECK(s == U8("\u00AC(x \u2260 y \u22BB x < y)"));
 
     s = unicode(*integer(2));
-    CHECK(s == "2");
+    CHECK(s == U8("2"));
 
     s = unicode(*real_double(2.25));
-    CHECK(s == "2.25");
+    CHECK(s == U8("2.25"));
 
     s = unicode(*complex_double(std::complex<double>(2.25, -23)));
-    CHECK(s == "2.25 - 23.0\u22C5\U0001D456");
+    CHECK(s == U8("2.25 - 23.0\u22C5\U0001D456"));
 
     s = unicode(*Rational::from_two_ints(*integer(1), *integer(3)));
-    CHECK(s == "1\n\u2015\n3");
+    CHECK(s == U8("1\n\u2015\n3"));
 
     s = unicode(*Rational::from_two_ints(*integer(3), *integer(187)));
-    CHECK(s == " 3 \n\u2015\u2015\u2015\n187");
+    CHECK(s == U8(" 3 \n\u2015\u2015\u2015\n187"));
 
     s = unicode(*Rational::from_two_ints(*integer(3), *integer(17)));
-    CHECK(s == " 3\n\u2015\u2015\n17");
+    CHECK(s == U8(" 3\n\u2015\u2015\n17"));
 
     s = unicode(*x);
-    CHECK(s == "x");
+    CHECK(s == U8("x"));
 
     s = unicode(*add(integer(2), x));
-    CHECK(s == "2 + x");
+    CHECK(s == U8("2 + x"));
 
     s = unicode(*add(integer(-1), x));
-    CHECK(s == "-1 + x");
+    CHECK(s == U8("-1 + x"));
 
     s = unicode(*add(Rational::from_two_ints(*integer(1), *integer(3)), x));
-    CHECK(s == "1    \n\u2015 + x\n3    ");
+    CHECK(s == U8("1    \n\u2015 + x\n3    "));
 
     s = unicode(*mul(integer(2), x));
-    CHECK(s == "2\u22C5x");
+    CHECK(s == U8("2\u22C5x"));
 
     s = unicode(*mul(integer(2), x));
-    CHECK(s == "2\u22C5x");
+    CHECK(s == U8("2\u22C5x"));
 
     s = unicode(*mul(mul(integer(2), x), pow(y, integer(2))));
-    CHECK(s == "     2\n2\u22C5x\u22C5y ");
+    CHECK(s == U8("     2\n2\u22C5x\u22C5y "));
 
     s = unicode(*mul(Rational::from_two_ints(*integer(2), *integer(5)), x));
-    CHECK(s == "2\u22C5x\n\u2015\u2015\u2015\n 5 ");
+    CHECK(s == U8("2\u22C5x\n\u2015\u2015\u2015\n 5 "));
 
     s = unicode(*div(y, x));
-    CHECK(s == "y\n\u2015\nx");
+    CHECK(s == U8("y\n\u2015\nx"));
 
     s = unicode(*sqrt(x));
-    CHECK(s == "  _\n\u2572\u2571x");
+    CHECK(s == U8("  _\n\u2572\u2571x"));
 
     s = unicode(*pow(x, y));
-    CHECK(s == " y\nx ");
+    CHECK(s == U8(" y\nx "));
 
     auto p = piecewise({{x, contains(x, reals())}});
     s = unicode(*p);
-    CHECK(s == "{x if x \u220A \u211D");
+    CHECK(s == U8("{x if x \u220A \u211D"));
 
     p = piecewise(
         {{integer(1), Lt(x, integer(0))}, {integer(0), Eq(x, integer(0))}});
     s = unicode(*p);
-    CHECK(s == "\u23A71 if x < 0\n\u23A8          \n\u23A90 if 0 = x");
+    CHECK(s == U8("\u23A71 if x < 0\n\u23A8          \n\u23A90 if 0 = x"));
 
     p = piecewise({{Rational::from_two_ints(*integer(1), *integer(123)),
                     Lt(x, integer(0))},
                    {integer(0), Eq(x, integer(0))}});
     s = unicode(*p);
     CHECK(s
-          == "\u23A7 1          \n\u23AA\u2015\u2015\u2015 if x < 0\n\u23A8123 "
-             "        \n\u23A9 0 if 0 = x ");
+          == U8("\u23A7 1          \n\u23AA\u2015\u2015\u2015 if x "
+                u8"< 0\n\u23A8123 "
+                u8"        \n\u23A9 0 if 0 = x "));
     // FIXME: Test default
 
     s = unicode(*function_symbol("f", x));
-    CHECK(s == "f(x)");
+    CHECK(s == U8("f(x)"));
 }
 
 TEST_CASE("test_stringbox()", "[stringbox]")


### PR DESCRIPTION
Compiling on Windows assumed regular string literals were 1252 encoded.