### PR TITLE
Support NaN in LLVM- and Lambda visitors

### DIFF
--- a/symengine/lambda_double.h
+++ b/symengine/lambda_double.h
@@ -560,7 +560,13 @@ public:
                 "LambdaDouble can only represent real valued infinity");
         }
     }
-
+    void bvisit(const NaN &nan)
+    {
+        assert(&nan == &(*Nan) /* singleton, or do we support NaN quiet/singaling nan with payload? */);
+        result_ = [](const double * /* x  */) {
+            return std::numeric_limits<double>::signaling_NaN();
+        };
+    }
     void bvisit(const Contains &cts)
     {
         const auto fn_expr = apply(*cts.get_expr());

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -699,8 +699,8 @@ void LLVMVisitor::bvisit(const Infty &x)
 
 void LLVMVisitor::bvisit(const NaN &x)
 {
-    result_ = llvm::ConstantFP::getSNaN(get_float_type(&mod->getContext()),
-                                        /*negative=*/false, /*payload=*/0);
+    result_ = llvm::ConstantFP::getNaN(get_float_type(&mod->getContext()),
+                                       /*negative=*/false, /*payload=*/0);
 }
 
 void LLVMVisitor::bvisit(const BooleanAtom &x)

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -697,6 +697,12 @@ void LLVMVisitor::bvisit(const Infty &x)
     }
 }
 
+void LLVMVisitor::bvisit(const NaN &x)
+{
+    result_ = llvm::ConstantFP::getSNaN(get_float_type(&mod->getContext()),
+                                        /*negative=*/false, /*payload=*/0);
+}
+
 void LLVMVisitor::bvisit(const BooleanAtom &x)
 {
     const bool val = x.get_val();

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -99,6 +99,7 @@ public:
     void bvisit(const Min &x);
     void bvisit(const Contains &x);
     void bvisit(const Infty &x);
+    void bvisit(const NaN &x);
     void bvisit(const Floor &x);
     void bvisit(const Ceiling &x);
     void bvisit(const Truncate &x);

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -1,4 +1,6 @@
 #include "catch.hpp"
+#include "symengine/constants.h"
+#include "symengine/nan.h"
 #include <chrono>
 #include <array>
 
@@ -49,6 +51,7 @@ using SymEngine::Eq;
 using SymEngine::evalf;
 using SymEngine::floor;
 using SymEngine::gamma;
+using SymEngine::Inf;
 using SymEngine::integer;
 using SymEngine::LambdaComplexDoubleVisitor;
 using SymEngine::LambdaRealDoubleVisitor;
@@ -61,6 +64,7 @@ using SymEngine::map_basic_basic;
 using SymEngine::max;
 using SymEngine::min;
 using SymEngine::mul;
+using SymEngine::Nan;
 using SymEngine::Ne;
 using SymEngine::NegInf;
 using SymEngine::NotImplementedError;
@@ -274,6 +278,12 @@ TEST_CASE("Evaluate functions", "[lambda_gamma]")
             REQUIRE(::fabs(d - ref) < 1e-12);
         }
     }
+    v.init({}, *Nan);
+    REQUIRE(std::isnan(v.call({})));
+    v.init({}, *Inf);
+    std::isinf(v.call({}));
+    v.init({}, *NegInf);
+    REQUIRE(std::isinf(v.call({})));
 }
 
 #ifdef HAVE_SYMENGINE_LLVM
@@ -333,6 +343,13 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
         d3 = v3.call({1.4, 3.0, -1.0});
         REQUIRE(::fabs((d - d2)) < 1e-12);
         REQUIRE(::fabs((d - d3)) < 1e-12);
+    }
+    {
+        double out[2];
+        LLVMDoubleVisitor v;
+        v.init({}, {*Nan, *Inf});
+        v.call(out, {}) REQUIRE(std::isnan(out[0]));
+        REQUIRE(std::isinf(out[1]));
     }
 }
 

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -348,7 +348,8 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
         double out[2];
         LLVMDoubleVisitor v;
         v.init({}, {*Nan, *Inf});
-        v.call(out, {}) REQUIRE(std::isnan(out[0]));
+        v.call(out, {});
+        REQUIRE(std::isnan(out[0]));
         REQUIRE(std::isinf(out[1]));
     }
 }

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -347,7 +347,9 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
     {
         double out[2];
         LLVMDoubleVisitor v;
-        v.init({}, {*Nan, *Inf});
+        bool symbolic_cse = false;
+        int opt_level = 0;
+        v.init({}, {Nan, Inf}, symbolic_cse, opt_level);
         v.call(out, {});
         REQUIRE(std::isnan(out[0]));
         REQUIRE(std::isinf(out[1]));


### PR DESCRIPTION
Not sure if we should prefer constructing signaling or quiet NaNs.

If someone has an application where the payload is used, I guess we could support that too at some later point.