### PR TITLE
Canonicalize Piecewise to remove redundant conditions

### DIFF
--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -123,6 +123,27 @@ RCP<const Boolean> contains(const RCP<const Basic> &expr,
     }
 }
 
+RCP<const Basic> piecewise(const PiecewiseVec &vec)
+{
+    PiecewiseVec new_vec;
+    for (auto &p: vec) {
+        if (eq(*p.second, *boolFalse)) {
+            continue;
+        } else if (eq(*p.second, *boolTrue)) {
+            new_vec.push_back(p);
+            break;
+        } else {
+            new_vec.push_back(p);
+        }
+    }
+    if (new_vec.size() == 0) {
+        return Nan;
+    } else if (new_vec.size() == 0 and eq(*new_vec[0].second, *boolTrue)) {
+        return new_vec[0].first;
+    }
+    return make_rcp<Piecewise>(std::move(new_vec));
+}
+
 Piecewise::Piecewise(PiecewiseVec &&vec)
     : vec_(vec){SYMENGINE_ASSIGN_TYPEID()}
 

--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -127,7 +127,7 @@ RCP<const Basic> piecewise(const PiecewiseVec &vec)
 {
     PiecewiseVec new_vec;
     set_boolean conditions;
-    for (auto &p: vec) {
+    for (auto &p : vec) {
         if (eq(*p.second, *boolFalse)) {
             continue;
         } else if (eq(*p.second, *boolTrue)) {
@@ -147,8 +147,7 @@ RCP<const Basic> piecewise(const PiecewiseVec &vec)
     return make_rcp<Piecewise>(std::move(new_vec));
 }
 
-Piecewise::Piecewise(PiecewiseVec &&vec)
-    : vec_(vec)
+Piecewise::Piecewise(PiecewiseVec &&vec) : vec_(vec)
 {
     SYMENGINE_ASSIGN_TYPEID()
     SYMENGINE_ASSERT(is_canonical(vec_));
@@ -158,7 +157,7 @@ bool Piecewise::is_canonical(const PiecewiseVec &vec)
 {
     set_boolean conditions;
     bool found_true = false;
-    for (auto &p: vec) {
+    for (auto &p : vec) {
         if (found_true) {
             return false;
         }

--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -126,28 +126,61 @@ RCP<const Boolean> contains(const RCP<const Basic> &expr,
 RCP<const Basic> piecewise(const PiecewiseVec &vec)
 {
     PiecewiseVec new_vec;
+    set_boolean conditions;
     for (auto &p: vec) {
         if (eq(*p.second, *boolFalse)) {
             continue;
         } else if (eq(*p.second, *boolTrue)) {
             new_vec.push_back(p);
+            conditions.insert(p.second);
             break;
-        } else {
+        } else if (conditions.find(p.second) == conditions.end()) {
             new_vec.push_back(p);
+            conditions.insert(p.second);
         }
     }
     if (new_vec.size() == 0) {
-        return Nan;
-    } else if (new_vec.size() == 0 and eq(*new_vec[0].second, *boolTrue)) {
+        throw DomainError("piecewise undefined for this domain.");
+    } else if (new_vec.size() == 1 and eq(*new_vec[0].second, *boolTrue)) {
         return new_vec[0].first;
     }
     return make_rcp<Piecewise>(std::move(new_vec));
 }
 
 Piecewise::Piecewise(PiecewiseVec &&vec)
-    : vec_(vec){SYMENGINE_ASSIGN_TYPEID()}
+    : vec_(vec)
+{
+    SYMENGINE_ASSIGN_TYPEID()
+    SYMENGINE_ASSERT(is_canonical(vec_));
+}
 
-      hash_t Piecewise::__hash__() const
+bool Piecewise::is_canonical(const PiecewiseVec &vec)
+{
+    set_boolean conditions;
+    bool found_true = false;
+    for (auto &p: vec) {
+        if (found_true) {
+            return false;
+        }
+        if (eq(*p.second, *boolFalse)) {
+            return false;
+        } else if (eq(*p.second, *boolTrue)) {
+            found_true = true;
+        } else if (conditions.find(p.second) == conditions.end()) {
+            conditions.insert(p.second);
+        } else {
+            return false
+        }
+    }
+    if (vec.size() == 0) {
+        return false;
+    } else if (vec.size() == 1 and eq(*vec[0].second, *boolTrue)) {
+        return false;
+    }
+    return true;
+}
+
+hash_t Piecewise::__hash__() const
 {
     hash_t seed = this->get_type_code();
     for (auto &p : vec_) {

--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -168,7 +168,7 @@ bool Piecewise::is_canonical(const PiecewiseVec &vec)
         } else if (conditions.find(p.second) == conditions.end()) {
             conditions.insert(p.second);
         } else {
-            return false
+            return false;
         }
     }
     if (vec.size() == 0) {

--- a/symengine/logic.h
+++ b/symengine/logic.h
@@ -88,6 +88,7 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_PIECEWISE)
     //! Constructor
     Piecewise(PiecewiseVec &&vec);
+    bool is_canonical(const PiecewiseVec &vec);
     hash_t __hash__() const;
     const PiecewiseVec &get_vec() const;
     virtual vec_basic get_args() const;

--- a/symengine/logic.h
+++ b/symengine/logic.h
@@ -98,10 +98,7 @@ public:
 
 // Vec is vector of pairs of RCP<const Basic> and RCP<const Boolean> to
 // represent (Expr, Condition) pairs
-inline RCP<const Basic> piecewise(PiecewiseVec &&vec)
-{
-    return make_rcp<Piecewise>(std::move(vec));
-}
+RCP<const Basic> piecewise(const PiecewiseVec &vec);
 
 class And : public Boolean
 {

--- a/symengine/tests/logic/test_logic.cpp
+++ b/symengine/tests/logic/test_logic.cpp
@@ -155,7 +155,9 @@ TEST_CASE("Piecewise", "[logic]")
 
     REQUIRE(eq(*q, *p));
 
-    q = piecewise({{one, boolTrue}}) REQUIRE(eq(*q, *one));
+    q = piecewise({{one, boolTrue}});
+
+    REQUIRE(eq(*q, *one));
 
     CHECK_THROWS_AS(piecewise({{one, boolFalse}}), DomainError);
 }

--- a/symengine/tests/logic/test_logic.cpp
+++ b/symengine/tests/logic/test_logic.cpp
@@ -12,6 +12,7 @@ using SymEngine::boolFalse;
 using SymEngine::boolTrue;
 using SymEngine::contains;
 using SymEngine::Contains;
+using SymEngine::DomainError;
 using SymEngine::eq;
 using SymEngine::Integer;
 using SymEngine::integer;
@@ -98,6 +99,7 @@ TEST_CASE("Piecewise", "[logic]")
     auto int1 = interval(integer(1), integer(2), true, false);
     auto int2 = interval(integer(2), integer(5), true, false);
     auto int3 = interval(integer(5), integer(10), true, false);
+    auto int4 = interval(integer(10), integer(12), true, false);
     auto p = piecewise({{x, contains(x, int1)},
                         {y, contains(x, int2)},
                         {add(x, y), contains(x, int3)}});
@@ -117,6 +119,45 @@ TEST_CASE("Piecewise", "[logic]")
 
     REQUIRE((p->diff(x))->__hash__() == q->__hash__());
     REQUIRE(eq(*p->diff(x), *q));
+
+    auto q2 = piecewise({
+        {one, contains(x, int1)},
+        {zero, contains(x, int2)},
+        {one, contains(x, int3)},
+        {one, contains(x, int2)},
+    });
+
+    REQUIRE(eq(*q2, *q));
+
+    q2 = piecewise({
+        {one, contains(x, int1)},
+        {zero, contains(x, int2)},
+        {one, boolFalse},
+        {one, contains(x, int3)},
+    });
+
+    REQUIRE(eq(*q2, *q));
+
+    p = piecewise({
+        {one, contains(x, int1)},
+        {zero, contains(x, int2)},
+        {one, contains(x, int3)},
+        {one, boolTrue},
+    });
+
+    q = piecewise({
+        {one, contains(x, int1)},
+        {zero, contains(x, int2)},
+        {one, contains(x, int3)},
+        {one, boolTrue},
+        {one, contains(x, int4)},
+    });
+
+    REQUIRE(eq(*q, *p));
+
+    q = piecewise({{one, boolTrue}}) REQUIRE(eq(*q, *one));
+
+    CHECK_THROWS_AS(piecewise({{one, boolFalse}}), DomainError);
 }
 
 TEST_CASE("And, Or : Basic", "[basic]")


### PR DESCRIPTION
1. If there's a True condition, all conditions after are dropped.
2. False conditions are dropped.
3. If there's only one condition and it's True, the expression is returned
4. If the same condition is repeated, only the first one is kept.
5. If there are no conditions, a DomainError is thrown. This can happen if we evaluate a condition to False and it is dropped.

Fixes https://github.com/symengine/symengine.py/issues/393