### PR TITLE
Deconst to remove warning in tests compilation

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -493,7 +493,7 @@ dcomplex complex_double_get(const basic s)
     return d;
 }
 
-const char *basic_dumps(const basic s, unsigned long *size)
+char *basic_dumps(const basic s, unsigned long *size)
 {
     std::string str = s->m->dumps();
     *size = str.length();

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -365,7 +365,7 @@ CWRAPPER_OUTPUT_TYPE basic_beta(basic s, const basic a, const basic b);
 CWRAPPER_OUTPUT_TYPE basic_polygamma(basic s, const basic a, const basic b);
 
 //! Serialize an expression
-const char *basic_dumps(const basic s, unsigned long *size);
+char *basic_dumps(const basic s, unsigned long *size);
 //! Deserialize an expression
 CWRAPPER_OUTPUT_TYPE basic_loads(basic s, const char *c, unsigned long size);
 

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -103,7 +103,7 @@ void test_cwrapper()
     unsigned long size = 0;
     basic deserialized;
 
-    const char *serialized = basic_dumps(e, &size);
+    char *serialized = basic_dumps(e, &size);
     basic_new_stack(deserialized);
     basic_loads(deserialized, serialized, size);
     SYMENGINE_C_ASSERT(basic_eq(deserialized, e) == 1);


### PR DESCRIPTION
When freeing serialization string in C we get a const mismatch. I can see the point of having the serialized string as const, but it will require a cast for every free to avoid const-warnings. I remove a warning in the tests with this PR, but we should think about changing to non-const in the dump function to be able to free it with the free string function. Alternatively to have a separate free function for dumps.