### PR TITLE
Set version of benchmark package to 1.6.1

### DIFF
--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -72,7 +72,7 @@ else
 fi
 
 if [[ "${WITH_BENCHMARKS_GOOGLE}" == "yes" ]]; then
-    conda_pkgs="${conda_pkgs} benchmark"
+    conda_pkgs="${conda_pkgs} benchmark=1.6.1"
 fi
 
 if [[ "${WITH_PIRANHA}" == "yes" ]]; then


### PR DESCRIPTION
This might fix the failing CI for the benchmark build. Version 1.7 of benchmark on conda have some issues with the libc++ being used.