### PR TITLE
Tribool refactor

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -219,6 +219,7 @@ set(HEADERS
     symengine_casts.h
     symengine_exception.h
     symengine_rcp.h
+    tribool.h
     type_codes.inc
     visitor.h
     test_visitors.h

--- a/symengine/basic-inl.h
+++ b/symengine/basic-inl.h
@@ -49,57 +49,6 @@ inline bool is_same_type(const Basic &a, const Basic &b)
     return a.get_type_code() == b.get_type_code();
 }
 
-inline bool is_true(tribool x)
-{
-    return x == tribool::tritrue;
-}
-
-inline bool is_false(tribool x)
-{
-    return x == tribool::trifalse;
-}
-
-inline bool is_indeterminate(tribool x)
-{
-    return x == tribool::indeterminate;
-}
-
-inline tribool tribool_from_bool(bool x)
-{
-    if (x) {
-        return tribool::tritrue;
-    } else {
-        return tribool::trifalse;
-    }
-}
-
-inline tribool and_tribool(tribool a, tribool b)
-{
-    if (!(a & b)) {
-        return tribool::trifalse;
-    } else {
-        return (tribool)(a | b);
-    }
-}
-
-inline tribool not_tribool(tribool a)
-{
-    if (is_indeterminate(a))
-        return a;
-    else
-        return (tribool)!a;
-}
-
-// The weak kleene conjunction
-// Indeterminate if any indeterminate otherwise like regular and
-inline tribool andwk_tribool(tribool a, tribool b)
-{
-    if (is_indeterminate(a) or is_indeterminate(b))
-        return tribool::indeterminate;
-    else
-        return (tribool)(a && b);
-}
-
 //! `<<` Operator
 inline std::ostream &operator<<(std::ostream &out, const SymEngine::Basic &p)
 {

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -238,16 +238,6 @@ struct RCPBasicKeyLess {
     }
 };
 
-enum tribool { indeterminate = -1, trifalse = 0, tritrue = 1 };
-
-inline bool is_true(tribool x);
-inline bool is_false(tribool x);
-inline bool is_indeterminate(tribool x);
-inline tribool tribool_from_bool(bool x);
-inline tribool and_tribool(tribool a, tribool b);
-inline tribool not_tribool(tribool a);
-inline tribool andwk_tribool(tribool a, tribool b);
-
 // Convenience functions
 //! Checks equality for `a` and `b`
 bool eq(const Basic &a, const Basic &b);
@@ -333,6 +323,7 @@ struct hash<SymEngine::Basic>;
 
 //! Inline members and functions
 #include "basic-inl.h"
+#include <symengine/tribool.h>
 
 // Macro to define the type_code_id variable and its getter method
 #ifdef WITH_SYMENGINE_VIRTUAL_TYPEID

--- a/symengine/test_visitors.cpp
+++ b/symengine/test_visitors.cpp
@@ -1037,7 +1037,7 @@ void AlgebraicVisitor::trans_nonzero_and_algebraic(const Basic &b)
 {
     // transcendental if b is algebraic and nonzero
     b.accept(*this);
-    if (is_true(is_algebraic_) and is_nonzero(b)) {
+    if (is_true(is_algebraic_) and is_true(is_nonzero(b))) {
         is_algebraic_ = tribool::trifalse;
     } else {
         is_algebraic_ = tribool::indeterminate;

--- a/symengine/tests/basic/CMakeLists.txt
+++ b/symengine/tests/basic/CMakeLists.txt
@@ -134,3 +134,7 @@ add_test(test_simplify ${PROJECT_BINARY_DIR}/test_simplify)
 add_executable(test_tuple test_tuple.cpp)
 target_link_libraries(test_tuple symengine catch)
 add_test(test_tuple ${PROJECT_BINARY_DIR}/test_tuple)
+
+add_executable(test_tribool test_tribool.cpp)
+target_link_libraries(test_tribool symengine catch)
+add_test(test_tribool ${PROJECT_BINARY_DIR}/test_tribool)

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -47,7 +47,6 @@ using SymEngine::sdiff;
 using SymEngine::set_basic;
 using SymEngine::Symbol;
 using SymEngine::symbol;
-using SymEngine::tribool;
 using SymEngine::umap_basic_basic;
 using SymEngine::umap_basic_num;
 using SymEngine::unified_compare;
@@ -1127,51 +1126,4 @@ TEST_CASE("args: Basic", "[basic]")
 
     r1 = log(pi);
     REQUIRE(vec_basic_eq_perm(r1->get_args(), {pi}));
-}
-
-TEST_CASE("tribool", "[basic]")
-{
-    REQUIRE(!is_true(tribool::indeterminate));
-    REQUIRE(!is_true(tribool::trifalse));
-    REQUIRE(is_true(tribool::tritrue));
-
-    REQUIRE(!is_false(tribool::indeterminate));
-    REQUIRE(is_false(tribool::trifalse));
-    REQUIRE(!is_false(tribool::tritrue));
-
-    REQUIRE(is_indeterminate(tribool::indeterminate));
-    REQUIRE(!is_indeterminate(tribool::trifalse));
-    REQUIRE(!is_indeterminate(tribool::tritrue));
-
-    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::trifalse)));
-    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::indeterminate)));
-    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::tritrue)));
-    REQUIRE(is_false(and_tribool(tribool::indeterminate, tribool::trifalse)));
-    REQUIRE(is_false(and_tribool(tribool::tritrue, tribool::trifalse)));
-    REQUIRE(is_indeterminate(
-        and_tribool(tribool::indeterminate, tribool::indeterminate)));
-    REQUIRE(is_indeterminate(
-        and_tribool(tribool::tritrue, tribool::indeterminate)));
-    REQUIRE(is_indeterminate(
-        and_tribool(tribool::indeterminate, tribool::tritrue)));
-    REQUIRE(is_true(and_tribool(tribool::tritrue, tribool::tritrue)));
-
-    REQUIRE(is_true(not_tribool(tribool::trifalse)));
-    REQUIRE(is_false(not_tribool(tribool::tritrue)));
-    REQUIRE(is_indeterminate(not_tribool(tribool::indeterminate)));
-
-    REQUIRE(is_false(andwk_tribool(tribool::trifalse, tribool::trifalse)));
-    REQUIRE(is_indeterminate(
-        andwk_tribool(tribool::trifalse, tribool::indeterminate)));
-    REQUIRE(is_false(andwk_tribool(tribool::trifalse, tribool::tritrue)));
-    REQUIRE(is_indeterminate(
-        andwk_tribool(tribool::indeterminate, tribool::trifalse)));
-    REQUIRE(is_false(andwk_tribool(tribool::tritrue, tribool::trifalse)));
-    REQUIRE(is_indeterminate(
-        andwk_tribool(tribool::indeterminate, tribool::indeterminate)));
-    REQUIRE(is_indeterminate(
-        andwk_tribool(tribool::tritrue, tribool::indeterminate)));
-    REQUIRE(is_indeterminate(
-        andwk_tribool(tribool::indeterminate, tribool::tritrue)));
-    REQUIRE(is_true(andwk_tribool(tribool::tritrue, tribool::tritrue)));
 }

--- a/symengine/tests/basic/test_tribool.cpp
+++ b/symengine/tests/basic/test_tribool.cpp
@@ -1,0 +1,83 @@
+#include "catch.hpp"
+#include <symengine/tribool.h>
+
+using SymEngine::tribool;
+using SymEngine::tribool_from_bool;
+
+TEST_CASE("tribool", "[basic]")
+{
+    REQUIRE(!is_true(tribool::indeterminate));
+    REQUIRE(!is_true(tribool::trifalse));
+    REQUIRE(is_true(tribool::tritrue));
+
+    REQUIRE(!is_false(tribool::indeterminate));
+    REQUIRE(is_false(tribool::trifalse));
+    REQUIRE(!is_false(tribool::tritrue));
+
+    REQUIRE(is_indeterminate(tribool::indeterminate));
+    REQUIRE(!is_indeterminate(tribool::trifalse));
+    REQUIRE(!is_indeterminate(tribool::tritrue));
+
+    REQUIRE(is_true(tribool_from_bool(true)));
+    REQUIRE(is_false(tribool_from_bool(false)));
+
+    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::trifalse)));
+    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::indeterminate)));
+    REQUIRE(is_false(and_tribool(tribool::trifalse, tribool::tritrue)));
+    REQUIRE(is_false(and_tribool(tribool::indeterminate, tribool::trifalse)));
+    REQUIRE(is_false(and_tribool(tribool::tritrue, tribool::trifalse)));
+    REQUIRE(is_indeterminate(
+        and_tribool(tribool::indeterminate, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        and_tribool(tribool::tritrue, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        and_tribool(tribool::indeterminate, tribool::tritrue)));
+    REQUIRE(is_true(and_tribool(tribool::tritrue, tribool::tritrue)));
+
+    REQUIRE(is_false(or_tribool(tribool::trifalse, tribool::trifalse)));
+    REQUIRE(is_indeterminate(
+        or_tribool(tribool::trifalse, tribool::indeterminate)));
+    REQUIRE(is_true(or_tribool(tribool::trifalse, tribool::tritrue)));
+    REQUIRE(is_indeterminate(
+        or_tribool(tribool::indeterminate, tribool::trifalse)));
+    REQUIRE(is_true(or_tribool(tribool::tritrue, tribool::trifalse)));
+    REQUIRE(is_indeterminate(
+        or_tribool(tribool::indeterminate, tribool::indeterminate)));
+    REQUIRE(is_true(or_tribool(tribool::tritrue, tribool::indeterminate)));
+    REQUIRE(is_true(or_tribool(tribool::indeterminate, tribool::tritrue)));
+    REQUIRE(is_true(or_tribool(tribool::tritrue, tribool::tritrue)));
+
+    REQUIRE(is_true(not_tribool(tribool::trifalse)));
+    REQUIRE(is_false(not_tribool(tribool::tritrue)));
+    REQUIRE(is_indeterminate(not_tribool(tribool::indeterminate)));
+
+    REQUIRE(is_false(andwk_tribool(tribool::trifalse, tribool::trifalse)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::trifalse, tribool::indeterminate)));
+    REQUIRE(is_false(andwk_tribool(tribool::trifalse, tribool::tritrue)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::indeterminate, tribool::trifalse)));
+    REQUIRE(is_false(andwk_tribool(tribool::tritrue, tribool::trifalse)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::indeterminate, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::tritrue, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        andwk_tribool(tribool::indeterminate, tribool::tritrue)));
+    REQUIRE(is_true(andwk_tribool(tribool::tritrue, tribool::tritrue)));
+
+    REQUIRE(is_false(orwk_tribool(tribool::trifalse, tribool::trifalse)));
+    REQUIRE(is_indeterminate(
+        orwk_tribool(tribool::trifalse, tribool::indeterminate)));
+    REQUIRE(is_true(orwk_tribool(tribool::trifalse, tribool::tritrue)));
+    REQUIRE(is_indeterminate(
+        orwk_tribool(tribool::indeterminate, tribool::trifalse)));
+    REQUIRE(is_true(orwk_tribool(tribool::tritrue, tribool::trifalse)));
+    REQUIRE(is_indeterminate(
+        orwk_tribool(tribool::indeterminate, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        orwk_tribool(tribool::tritrue, tribool::indeterminate)));
+    REQUIRE(is_indeterminate(
+        orwk_tribool(tribool::indeterminate, tribool::tritrue)));
+    REQUIRE(is_true(orwk_tribool(tribool::tritrue, tribool::tritrue)));
+}

--- a/symengine/tribool.h
+++ b/symengine/tribool.h
@@ -1,0 +1,85 @@
+#ifndef SYMENGINE_TRIBOOL_H
+#define SYMENGINE_TRIBOOL_H
+
+namespace SymEngine
+{
+
+enum class tribool { indeterminate = -1, trifalse = 0, tritrue = 1 };
+
+inline bool is_true(tribool x)
+{
+    return x == tribool::tritrue;
+}
+
+inline bool is_false(tribool x)
+{
+    return x == tribool::trifalse;
+}
+
+inline bool is_indeterminate(tribool x)
+{
+    return x == tribool::indeterminate;
+}
+
+inline tribool tribool_from_bool(bool x)
+{
+    return static_cast<tribool>(x);
+}
+
+inline tribool and_tribool(tribool a, tribool b)
+{
+    if (!(static_cast<unsigned>(a) & static_cast<unsigned>(b))) {
+        return tribool::trifalse;
+    } else {
+        return static_cast<tribool>(static_cast<unsigned>(a)
+                                    | static_cast<unsigned>(b));
+    }
+}
+
+inline tribool or_tribool(tribool a, tribool b)
+{
+    if (is_true(a) || is_true(b)) {
+        return tribool::tritrue;
+    } else if (is_indeterminate(a) || is_indeterminate(b)) {
+        return tribool::indeterminate;
+    } else {
+        return tribool::trifalse;
+    }
+}
+
+inline tribool not_tribool(tribool a)
+{
+    if (is_indeterminate(a)) {
+        return a;
+    } else {
+        return static_cast<tribool>(!static_cast<unsigned>(a));
+    }
+}
+
+// The weak kleene conjunction
+// Indeterminate if any indeterminate otherwise like regular and
+inline tribool andwk_tribool(tribool a, tribool b)
+{
+    if (is_indeterminate(a) || is_indeterminate(b)) {
+        return tribool::indeterminate;
+    } else {
+        return static_cast<tribool>(static_cast<unsigned>(a)
+                                    && static_cast<unsigned>(b));
+    }
+}
+
+// The weak kleene disjunction
+// Indeterminate if any indeterminate otherwise like regular or
+inline tribool orwk_tribool(tribool a, tribool b)
+{
+    if (is_indeterminate(a) || is_indeterminate(b)) {
+        return tribool::indeterminate;
+    } else {
+        return static_cast<tribool>(static_cast<unsigned>(a)
+                                    || static_cast<unsigned>(b));
+    }
+}
+
+} // namespace SymEngine
+
+#endif


### PR DESCRIPTION
* Change `tribool` from plain `enum` to safer `enum class`
* Move `tribool` to its own header `tribool.h`
* Add `or_tribool` and `orwk_tribool` for completeness
* Add tests for `tribool_from_bool`
* Fix bug that was found when moving to `enum class` for tribool