### PR TITLE
Remove unused assumptions from simplify class

### DIFF
--- a/symengine/simplify.cpp
+++ b/symengine/simplify.cpp
@@ -55,7 +55,7 @@ RCP<const Basic> simplify(const RCP<const Basic> &x,
                           const Assumptions *assumptions)
 {
     auto expr = refine(x, assumptions);
-    SimplifyVisitor b(assumptions);
+    SimplifyVisitor b;
     return b.apply(expr);
 }
 

--- a/symengine/simplify.h
+++ b/symengine/simplify.h
@@ -11,19 +11,13 @@ namespace SymEngine
 class SimplifyVisitor : public BaseVisitor<SimplifyVisitor, TransformVisitor>
 {
 private:
-    const Assumptions *assumptions_;
-
     std::pair<RCP<const Basic>, RCP<const Basic>>
     simplify_pow(const RCP<const Basic> &e, const RCP<const Basic> &b);
 
 public:
     using TransformVisitor::bvisit;
 
-    SimplifyVisitor(const Assumptions *assumptions)
-        : BaseVisitor<SimplifyVisitor, TransformVisitor>(),
-          assumptions_(assumptions)
-    {
-    }
+    SimplifyVisitor() : BaseVisitor<SimplifyVisitor, TransformVisitor>() {}
 
     void bvisit(const Mul &x);
     void bvisit(const Pow &x);


### PR DESCRIPTION
This will be needed in the future, but triggers a warning when compiling with clang.