### PR TITLE
Handle denominator of zero explicitly for boost

### DIFF
--- a/symengine/mp_class.h
+++ b/symengine/mp_class.h
@@ -990,6 +990,9 @@ inline rational_class mp_abs(const rational_class &i)
 
 inline bool mp_divisible_p(const integer_class &a, const integer_class &b)
 {
+    if (b == 0) {
+        return (a == 0);
+    }
     return a % b == 0;
 }
 

--- a/symengine/tests/ntheory/test_ntheory.cpp
+++ b/symengine/tests/ntheory/test_ntheory.cpp
@@ -231,6 +231,11 @@ TEST_CASE("test_factor(): ntheory", "[ntheory]")
     REQUIRE(not divides(*i1001, *i6));
     REQUIRE(factor(outArg(f), *i900) > 0);
     REQUIRE(divides(*i900, *f));
+
+    REQUIRE(divides(*one, *one));
+    REQUIRE(divides(*zero, *one));
+    REQUIRE(!divides(*one, *zero));
+    REQUIRE(divides(*zero, *zero));
 }
 
 TEST_CASE("test_factor_lehman_method(): ntheory", "[ntheory]")


### PR DESCRIPTION
see symengine/symengine.py#428 and https://github.com/symengine/symengine.py/blob/f931a7bfde92c9a61545ff8f7343cf70203d6f45/symengine/tests/test_ntheory.py#L147