### PR TITLE
fix run-time warnings when using llvm 15

### DIFF
--- a/.github/workflows/build_doxygen.yml
+++ b/.github/workflows/build_doxygen.yml
@@ -9,12 +9,12 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
           fetch-depth: 0
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           CACHE_NUMBER: 0
         with:
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('doxygendoc.yml') }}
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('doxygendoc.yml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,14 +259,14 @@ jobs:
       run: echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
 
     - name: Cache ccache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ github.job }}-${{ env.OPTIONS }}-${{ runner.os }}-${{ github.sha }}
         restore-keys: ccache-${{ github.job }}-${{ env.OPTIONS }}-${{ runner.os }}-
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 2
 

--- a/.github/workflows/test_tutorials.yml
+++ b/.github/workflows/test_tutorials.yml
@@ -6,7 +6,7 @@ jobs:
   test_tutorials:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run tutorials
         run: |
           source bin/install_travis.sh

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -130,7 +130,12 @@ llvm::Function *LLVMVisitor::get_function_type(llvm::LLVMContext *context)
     F->addParamAttr(0, llvm::Attribute::NoCapture);
     F->addParamAttr(1, llvm::Attribute::NoCapture);
     F->addFnAttr(llvm::Attribute::NoUnwind);
+#if (LLVM_VERSION_MAJOR < 15)
     F->addFnAttr(llvm::Attribute::UWTable);
+#else
+    F->addFnAttr(llvm::Attribute::getWithUWTableKind(
+        *context, llvm::UWTableKind::Default));
+#endif
 #endif
     return F;
 }


### PR DESCRIPTION
- uwtable now takes a tablekind attribute
- see https://github.com/llvm/llvm-project/commit/6398903ac8c141820a84f3063b7956abe1742500
- resolves #1943
- also bump github actions checkout & cache versions in CI