### PR TITLE
recursively check for missing headers in install in CI

### DIFF
--- a/bin/test_make_install.py
+++ b/bin/test_make_install.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from os.path import join, relpath
+from os.path import join, relpath, sep
 import sys
 from glob import glob
 
@@ -9,15 +9,28 @@ install_dir = sys.argv[1]
 # Second argument is Folder containing symengine header files.
 symengine_dir = sys.argv[2]
 
-installed_files = set([relpath(x, install_dir) for x in glob(join(install_dir, '*.h'))])
-all_files = set([relpath(x, symengine_dir) for x in glob(join(symengine_dir, '*.h'))])
+
+def ignore(header_file):
+    ignore_folders = ["tests", "utilities"]
+    return any([f + sep in header_file for f in ignore_folders])
+
+
+def get_headers(folder):
+    header_files = [
+        relpath(header_file, folder)
+        for header_file in glob(join(folder, "**/*.h"), recursive=True)
+    ]
+    return set([f for f in header_files if not ignore(f)])
+
+installed_files = get_headers(install_dir)
+all_files = get_headers(symengine_dir)
 
 difference = all_files - installed_files
 
 if len(difference) == 0:
-    print('All files are installed!')
+    print("All files are installed!")
     exit(0)
 else:
     for fl in difference:
-        print('%s is not installed!' % fl)
+        print("%s is not installed!" % fl)
     exit(1)

--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -220,6 +220,7 @@ set(HEADERS
     printers/strprinter.h
     printers/latex.h
     printers/unicode.h
+    printers/stringbox.h
     printers.h
     rational.h
     real_double.h
@@ -259,6 +260,7 @@ set(HEADERS
     matrices/hadamard_product.h
     matrices/matrix_mul.h
     matrices/conjugate_matrix.h
+    matrices/size.h
     matrices/transpose.h
     matrices/trace.h
 )


### PR DESCRIPTION
- add missing headers to cmake install
- see #1950 