### PR TITLE
Use `override` instead of `virtual` where appropriate

### DIFF
--- a/symengine/add.h
+++ b/symengine/add.h
@@ -47,7 +47,7 @@ public:
      *  @see Basic for an implementation to get the cached version.
      *  @return 64-bit integer value for the hash.
      */
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
 
     /**
      *  @brief Test equality.
@@ -55,7 +55,7 @@ public:
      *  @param o a constant reference to object to test against.
      *  @return True if `this` is equal to `o`.
      */
-    virtual bool __eq__(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
 
     /**
      *  @brief Compares `Add` objects.
@@ -63,7 +63,7 @@ public:
      *  @see `unified_compare()` for the actual implementation.
      *  @return 1 if `this` is equal to `o` otherwise (-1).
      */
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
 
     /**
      *  @brief Create an appropriate instance from dictionary quickly.
@@ -136,7 +136,7 @@ public:
      * @brief Returns the arguments of the Add.
      * @return list of arguments.
      */
-    virtual vec_basic get_args() const;
+    vec_basic get_args() const override;
 
     //!< @return const reference to the coefficient of the `Add`.
     inline const RCP<const Number> &get_coef() const

--- a/symengine/basic-methods.inc
+++ b/symengine/basic-methods.inc
@@ -1,4 +1,8 @@
 class EvalRealDoubleVisitorFinal;
-#define SYMENGINE_INCLUDE_METHODS(SUFFIX) \
-virtual void accept(Visitor &v) const SUFFIX \
-virtual void accept(EvalRealDoubleVisitorFinal &v) const SUFFIX
+#define _SYMENGINE_INCLUDE_METHODS(PREFIX, SUFFIX) \
+PREFIX void accept(Visitor &v) const SUFFIX \
+PREFIX void accept(EvalRealDoubleVisitorFinal &v) const SUFFIX
+
+#define SYMENGINE_INCLUDE_METHODS_BASE() _SYMENGINE_INCLUDE_METHODS(virtual, = 0;)
+
+#define SYMENGINE_INCLUDE_METHODS_DERIVED() _SYMENGINE_INCLUDE_METHODS(, override;)

--- a/symengine/basic-methods.inc
+++ b/symengine/basic-methods.inc
@@ -1,8 +1,9 @@
 class EvalRealDoubleVisitorFinal;
-#define _SYMENGINE_INCLUDE_METHODS(PREFIX, SUFFIX) \
-PREFIX void accept(Visitor &v) const SUFFIX \
-PREFIX void accept(EvalRealDoubleVisitorFinal &v) const SUFFIX
 
-#define SYMENGINE_INCLUDE_METHODS_BASE() _SYMENGINE_INCLUDE_METHODS(virtual, = 0;)
+#define SYMENGINE_INCLUDE_METHODS_BASE()                                       \
+    virtual void accept(Visitor &v) const = 0;                                 \
+    virtual void accept(EvalRealDoubleVisitorFinal &v) const = 0;
 
-#define SYMENGINE_INCLUDE_METHODS_DERIVED() _SYMENGINE_INCLUDE_METHODS(, override;)
+#define SYMENGINE_INCLUDE_METHODS_DERIVED()                                    \
+    void accept(Visitor &v) const override;                                    \
+    void accept(EvalRealDoubleVisitorFinal &v) const override;

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -201,7 +201,7 @@ public:
     //! Returns the list of arguments
     virtual vec_basic get_args() const = 0;
 
-    SYMENGINE_INCLUDE_METHODS(= 0;)
+    SYMENGINE_INCLUDE_METHODS_BASE()
 
     RCP<const Basic> diff(const RCP<const Symbol> &x, bool cache = true) const;
 };
@@ -335,12 +335,12 @@ struct hash<SymEngine::Basic>;
     {                                                                          \
         return type_code_id;                                                   \
     };                                                                         \
-    SYMENGINE_INCLUDE_METHODS(;)
+    SYMENGINE_INCLUDE_METHODS_DERIVED()
 #else
 #define IMPLEMENT_TYPEID(SYMENGINE_ID)                                         \
     /*! Type_code_id shared by all instances */                                \
     const static TypeID type_code_id = SYMENGINE_ID;                           \
-    SYMENGINE_INCLUDE_METHODS(;)
+    SYMENGINE_INCLUDE_METHODS_DERIVED()
 #endif
 
 #ifdef WITH_SYMENGINE_VIRTUAL_TYPEID

--- a/symengine/complex.h
+++ b/symengine/complex.h
@@ -53,33 +53,33 @@ public:
     bool is_canonical(const rational_class &real,
                       const rational_class &imaginary) const;
     //! \return size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     //! Get the real part of the complex number
-    virtual RCP<const Number> real_part() const;
+    RCP<const Number> real_part() const override;
     //! Get the imaginary part of the complex number
-    virtual RCP<const Number> imaginary_part() const;
+    RCP<const Number> imaginary_part() const override;
     //! Get the conjugate of the complex number
-    virtual RCP<const Basic> conjugate() const;
+    RCP<const Basic> conjugate() const override;
     //! \returns `false`
     // False is returned because complex cannot be compared with zero
-    inline virtual bool is_positive() const
+    inline bool is_positive() const override
     {
         return false;
     }
     //! \returns `false`
     // False is returned because complex cannot be compared with zero
-    inline virtual bool is_negative() const
+    inline bool is_negative() const override
     {
         return false;
     }
     //! \returns `true`
-    inline virtual bool is_complex() const
+    inline bool is_complex() const override
     {
         return true;
     }
@@ -96,17 +96,17 @@ public:
     static RCP<const Number> from_two_nums(const Number &re, const Number &im);
 
     //! \return `false` since `imaginary_` cannot be zero
-    virtual bool is_zero() const
+    bool is_zero() const override
     {
         return false;
     }
     //! \return `false` since `imaginary_` cannot be zero
-    virtual bool is_one() const
+    bool is_one() const override
     {
         return false;
     }
     //! \return `false` since `imaginary_` cannot be zero
-    virtual bool is_minus_one() const
+    bool is_minus_one() const override
     {
         return false;
     }
@@ -304,7 +304,7 @@ public:
     RCP<const Number> powcomp(const Integer &other) const;
 
     //! Converts the param `other` appropriately and then calls `addcomp`
-    virtual RCP<const Number> add(const Number &other) const
+    RCP<const Number> add(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return addcomp(down_cast<const Rational &>(other));
@@ -317,7 +317,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `subcomp`
-    virtual RCP<const Number> sub(const Number &other) const
+    RCP<const Number> sub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return subcomp(down_cast<const Rational &>(other));
@@ -330,7 +330,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `rsubcomp`
-    virtual RCP<const Number> rsub(const Number &other) const
+    RCP<const Number> rsub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rsubcomp(down_cast<const Rational &>(other));
@@ -341,7 +341,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `mulcomp`
-    virtual RCP<const Number> mul(const Number &other) const
+    RCP<const Number> mul(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return mulcomp(down_cast<const Rational &>(other));
@@ -354,7 +354,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `divcomp`
-    virtual RCP<const Number> div(const Number &other) const
+    RCP<const Number> div(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return divcomp(down_cast<const Rational &>(other));
@@ -367,7 +367,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `rdivcomp`
-    virtual RCP<const Number> rdiv(const Number &other) const
+    RCP<const Number> rdiv(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return rdivcomp(down_cast<const Integer &>(other));
@@ -376,7 +376,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `powcomp`
-    virtual RCP<const Number> pow(const Number &other) const
+    RCP<const Number> pow(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return powcomp(down_cast<const Integer &>(other));
@@ -385,7 +385,7 @@ public:
         }
     };
 
-    virtual RCP<const Number> rpow(const Number &other) const
+    RCP<const Number> rpow(const Number &other) const override
     {
         throw NotImplementedError("Not Implemented");
     };

--- a/symengine/complex_double.h
+++ b/symengine/complex_double.h
@@ -22,33 +22,33 @@ public:
     //! Constructor of ComplexDouble class
     explicit ComplexDouble(std::complex<double> i);
     //! \return size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     //! Get the real part of the complex number
-    virtual RCP<const Number> real_part() const;
+    RCP<const Number> real_part() const override;
     //! Get the imaginary part of the complex number
-    virtual RCP<const Number> imaginary_part() const;
+    RCP<const Number> imaginary_part() const override;
     //! Get the conjugate of the complex number
-    virtual RCP<const Basic> conjugate() const;
+    RCP<const Basic> conjugate() const override;
     //! \returns `false`
     // False is returned because complex cannot be compared with zero
-    inline virtual bool is_positive() const
+    inline bool is_positive() const override
     {
         return false;
     }
     //! \returns `false`
     // False is returned because complex cannot be compared with zero
-    inline virtual bool is_negative() const
+    inline bool is_negative() const override
     {
         return false;
     }
     //! \returns `true`
-    inline virtual bool is_complex() const
+    inline bool is_complex() const override
     {
         return true;
     }
@@ -59,27 +59,27 @@ public:
     }
     //! \returns `false`
     // False is returned because std::complex<double> is not exact
-    inline virtual bool is_exact() const
+    inline bool is_exact() const override
     {
         return false;
     }
     //! Get `Evaluate` singleton to evaluate numerically
-    virtual Evaluate &get_eval() const;
+    Evaluate &get_eval() const override;
 
     //! \return `true` if equal to `0`
-    virtual bool is_zero() const
+    bool is_zero() const override
     {
         return i == 0.0;
     }
     //! \return `false`
     // A std::complex<double> is not exactly equal to `1`
-    virtual bool is_one() const
+    bool is_one() const override
     {
         return false;
     }
     //! \return `false`
     // A std::complex<double> is not exactly equal to `-1`
-    virtual bool is_minus_one() const
+    bool is_minus_one() const override
     {
         return false;
     }
@@ -130,7 +130,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `addcomp`
-    virtual RCP<const Number> add(const Number &other) const
+    RCP<const Number> add(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return addcomp(down_cast<const Rational &>(other));
@@ -193,7 +193,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `subcomp`
-    virtual RCP<const Number> sub(const Number &other) const
+    RCP<const Number> sub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return subcomp(down_cast<const Rational &>(other));
@@ -248,7 +248,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `subcomp`
-    virtual RCP<const Number> rsub(const Number &other) const
+    RCP<const Number> rsub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rsubcomp(down_cast<const Rational &>(other));
@@ -309,7 +309,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `mulcomp`
-    virtual RCP<const Number> mul(const Number &other) const
+    RCP<const Number> mul(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return mulcomp(down_cast<const Rational &>(other));
@@ -372,7 +372,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `divcomp`
-    virtual RCP<const Number> div(const Number &other) const
+    RCP<const Number> div(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return divcomp(down_cast<const Rational &>(other));
@@ -427,7 +427,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `divcomp`
-    virtual RCP<const Number> rdiv(const Number &other) const
+    RCP<const Number> rdiv(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rdivcomp(down_cast<const Rational &>(other));
@@ -488,7 +488,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `powcomp`
-    virtual RCP<const Number> pow(const Number &other) const
+    RCP<const Number> pow(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return powcomp(down_cast<const Rational &>(other));
@@ -544,7 +544,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `powcomp`
-    virtual RCP<const Number> rpow(const Number &other) const
+    RCP<const Number> rpow(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rpowcomp(down_cast<const Rational &>(other));

--- a/symengine/complex_mpc.cpp
+++ b/symengine/complex_mpc.cpp
@@ -654,7 +654,7 @@ RCP<const Number> ComplexMPC::rpow(const RealMPFR &other) const
 //! Evaluate functions with double precision
 class EvaluateMPC : public Evaluate
 {
-    virtual RCP<const Basic> sin(const Basic &x) const override
+    RCP<const Basic> sin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -663,7 +663,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> cos(const Basic &x) const override
+    RCP<const Basic> cos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -672,7 +672,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> tan(const Basic &x) const override
+    RCP<const Basic> tan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -681,7 +681,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> cot(const Basic &x) const override
+    RCP<const Basic> cot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -691,7 +691,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> sec(const Basic &x) const override
+    RCP<const Basic> sec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -701,7 +701,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> csc(const Basic &x) const override
+    RCP<const Basic> csc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -711,7 +711,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> asin(const Basic &x) const override
+    RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -720,7 +720,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acos(const Basic &x) const override
+    RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -729,7 +729,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> atan(const Basic &x) const override
+    RCP<const Basic> atan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -738,7 +738,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acot(const Basic &x) const override
+    RCP<const Basic> acot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -748,7 +748,7 @@ class EvaluateMPC : public Evaluate
         mpc_atan(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> asec(const Basic &x) const override
+    RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -758,7 +758,7 @@ class EvaluateMPC : public Evaluate
         mpc_acos(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acsc(const Basic &x) const override
+    RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -768,7 +768,7 @@ class EvaluateMPC : public Evaluate
         mpc_asin(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> sinh(const Basic &x) const override
+    RCP<const Basic> sinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -777,7 +777,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> csch(const Basic &x) const override
+    RCP<const Basic> csch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -787,7 +787,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> cosh(const Basic &x) const override
+    RCP<const Basic> cosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -796,7 +796,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> sech(const Basic &x) const override
+    RCP<const Basic> sech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -806,7 +806,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> tanh(const Basic &x) const override
+    RCP<const Basic> tanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -815,7 +815,7 @@ class EvaluateMPC : public Evaluate
                  MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> coth(const Basic &x) const override
+    RCP<const Basic> coth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -825,7 +825,7 @@ class EvaluateMPC : public Evaluate
         mpc_ui_div(t.get_mpc_t(), 1, t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> asinh(const Basic &x) const override
+    RCP<const Basic> asinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -834,7 +834,7 @@ class EvaluateMPC : public Evaluate
                   MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acsch(const Basic &x) const override
+    RCP<const Basic> acsch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -844,7 +844,7 @@ class EvaluateMPC : public Evaluate
         mpc_asinh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acosh(const Basic &x) const override
+    RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -853,7 +853,7 @@ class EvaluateMPC : public Evaluate
                   MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> atanh(const Basic &x) const override
+    RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -862,7 +862,7 @@ class EvaluateMPC : public Evaluate
                   MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> acoth(const Basic &x) const override
+    RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -872,7 +872,7 @@ class EvaluateMPC : public Evaluate
         mpc_atanh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> asech(const Basic &x) const override
+    RCP<const Basic> asech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -882,7 +882,7 @@ class EvaluateMPC : public Evaluate
         mpc_acosh(t.get_mpc_t(), t.get_mpc_t(), MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> log(const Basic &x) const override
+    RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -891,7 +891,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> abs(const Basic &x) const override
+    RCP<const Basic> abs(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpfr_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -900,11 +900,11 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> gamma(Basic const &aConst) const override
+    RCP<const Basic> gamma(Basic const &aConst) const override
     {
         throw NotImplementedError("Not Implemented.");
     }
-    virtual RCP<const Basic> exp(const Basic &x) const override
+    RCP<const Basic> exp(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         mpc_class t(down_cast<const ComplexMPC &>(x).as_mpc().get_prec());
@@ -913,7 +913,7 @@ class EvaluateMPC : public Evaluate
                 MPFR_RNDN);
         return complex_mpc(std::move(t));
     }
-    virtual RCP<const Basic> floor(const Basic &x) const override
+    RCP<const Basic> floor(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         integer_class re, im;
@@ -930,7 +930,7 @@ class EvaluateMPC : public Evaluate
         return Complex::from_two_nums(*integer(std::move(re)),
                                       *integer(std::move(im)));
     }
-    virtual RCP<const Basic> ceiling(const Basic &x) const override
+    RCP<const Basic> ceiling(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         integer_class re, im;
@@ -947,7 +947,7 @@ class EvaluateMPC : public Evaluate
         return Complex::from_two_nums(*integer(std::move(re)),
                                       *integer(std::move(im)));
     }
-    virtual RCP<const Basic> truncate(const Basic &x) const override
+    RCP<const Basic> truncate(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         integer_class re, im;
@@ -964,12 +964,12 @@ class EvaluateMPC : public Evaluate
         return Complex::from_two_nums(*integer(std::move(re)),
                                       *integer(std::move(im)));
     }
-    virtual RCP<const Basic> erf(const Basic &x) const override
+    RCP<const Basic> erf(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         throw NotImplementedError("erf is not implemented in mpc");
     }
-    virtual RCP<const Basic> erfc(const Basic &x) const override
+    RCP<const Basic> erfc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexMPC>(x))
         throw NotImplementedError("erfc is not implemented in mpc");

--- a/symengine/complex_mpc.h
+++ b/symengine/complex_mpc.h
@@ -97,56 +97,56 @@ public:
         return mpc_get_prec(i.get_mpc_t());
     }
     //! \return size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     //! Get the real part of the complex number
-    virtual RCP<const Number> real_part() const;
+    RCP<const Number> real_part() const override;
     //! Get the imaginary part of the complex number
-    virtual RCP<const Number> imaginary_part() const;
+    RCP<const Number> imaginary_part() const override;
     //! Get the conjugate of the complex number
-    virtual RCP<const Basic> conjugate() const;
+    RCP<const Basic> conjugate() const override;
     //! \return `true` if positive
-    inline virtual bool is_positive() const
+    inline bool is_positive() const override
     {
         return false;
     }
     //! \return `true` if negative
-    inline virtual bool is_negative() const
+    inline bool is_negative() const override
     {
         return false;
     }
     //! \returns `true`
-    inline virtual bool is_complex() const
+    inline bool is_complex() const override
     {
         return true;
     }
     //! \return `true` if this number is an exact number
-    inline virtual bool is_exact() const
+    inline bool is_exact() const override
     {
         return false;
     }
     //! Get `Evaluate` singleton to evaluate numerically
-    virtual Evaluate &get_eval() const;
+    Evaluate &get_eval() const override;
 
     //! \return `true` if equal to `0`
-    virtual bool is_zero() const
+    bool is_zero() const override
     {
         return mpc_cmp_si_si(i.get_mpc_t(), 0, 0) == 0;
     }
     //! \return `false`
     // A mpc_t is not exactly equal to `1`
-    virtual bool is_one() const
+    bool is_one() const override
     {
         return false;
     }
     //! \return `false`
     // A mpc_t is not exactly equal to `-1`
-    virtual bool is_minus_one() const
+    bool is_minus_one() const override
     {
         return false;
     }
@@ -163,7 +163,7 @@ public:
     RCP<const Number> add(const ComplexMPC &other) const;
 
     //! Converts the param `other` appropriately and then calls `add`
-    virtual RCP<const Number> add(const Number &other) const
+    RCP<const Number> add(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return add(down_cast<const Rational &>(other));
@@ -193,7 +193,7 @@ public:
     RCP<const Number> sub(const ComplexMPC &other) const;
 
     //! Converts the param `other` appropriately and then calls `sub`
-    virtual RCP<const Number> sub(const Number &other) const
+    RCP<const Number> sub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return sub(down_cast<const Rational &>(other));
@@ -222,7 +222,7 @@ public:
     RCP<const Number> rsub(const RealMPFR &other) const;
 
     //! Converts the param `other` appropriately and then calls `sub`
-    virtual RCP<const Number> rsub(const Number &other) const
+    RCP<const Number> rsub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rsub(down_cast<const Rational &>(other));
@@ -250,7 +250,7 @@ public:
     RCP<const Number> mul(const ComplexMPC &other) const;
 
     //! Converts the param `other` appropriately and then calls `mul`
-    virtual RCP<const Number> mul(const Number &other) const
+    RCP<const Number> mul(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return mul(down_cast<const Rational &>(other));
@@ -280,7 +280,7 @@ public:
     RCP<const Number> div(const ComplexMPC &other) const;
 
     //! Converts the param `other` appropriately and then calls `div`
-    virtual RCP<const Number> div(const Number &other) const
+    RCP<const Number> div(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return div(down_cast<const Rational &>(other));
@@ -309,7 +309,7 @@ public:
     RCP<const Number> rdiv(const RealMPFR &other) const;
 
     //! Converts the param `other` appropriately and then calls `div`
-    virtual RCP<const Number> rdiv(const Number &other) const
+    RCP<const Number> rdiv(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rdiv(down_cast<const Rational &>(other));
@@ -337,7 +337,7 @@ public:
     RCP<const Number> pow(const ComplexMPC &other) const;
 
     //! Converts the param `other` appropriately and then calls `pow`
-    virtual RCP<const Number> pow(const Number &other) const
+    RCP<const Number> pow(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return pow(down_cast<const Rational &>(other));
@@ -366,7 +366,7 @@ public:
     RCP<const Number> rpow(const RealMPFR &other) const;
 
     //! Converts the param `other` appropriately and then calls `pow`
-    virtual RCP<const Number> rpow(const Number &other) const
+    RCP<const Number> rpow(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rpow(down_cast<const Rational &>(other));

--- a/symengine/constants.h
+++ b/symengine/constants.h
@@ -26,24 +26,24 @@ public:
     //! Constant Constructor
     Constant(const std::string &name);
     //! \return Size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
     /*! Comparison operator
      * \param o - Object to be compared with
      * \return `0` if equal, `-1` , `1` according to string compare
      * */
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
     //! \return name of the Constant.
     inline std::string get_name() const
     {
         return name_;
     }
 
-    virtual vec_basic get_args() const
+    vec_basic get_args() const override
     {
         return {};
     }

--- a/symengine/cse.cpp
+++ b/symengine/cse.cpp
@@ -437,7 +437,7 @@ public:
           excluded_symbols(excluded_symbols_), replacements(replacements_)
     {
     }
-    virtual RCP<const Basic> apply(const RCP<const Basic> &orig_expr)
+    RCP<const Basic> apply(const RCP<const Basic> &orig_expr) override
     {
         RCP<const Basic> expr = orig_expr;
         if (is_a_Atom(*expr)) {

--- a/symengine/fields.h
+++ b/symengine/fields.h
@@ -555,8 +555,8 @@ public:
     //! \return true if canonical
     bool is_canonical(const GaloisFieldDict &dict) const;
     //! \return size of the hash
-    hash_t __hash__() const;
-    int compare(const Basic &o) const;
+    hash_t __hash__() const override;
+    int compare(const Basic &o) const override;
 
     // creates a GaloisField in cannonical form based on the
     // dictionary.
@@ -568,7 +568,7 @@ public:
     static RCP<const GaloisField> from_uintpoly(const UIntPoly &a,
                                                 const integer_class &modulo);
 
-    integer_class eval(const integer_class &x) const
+    integer_class eval(const integer_class &x) const override
     {
         return get_poly().gf_eval(x);
     }
@@ -597,18 +597,18 @@ public:
         return get_poly().dict_.rend();
     }
 
-    inline integer_class get_coeff(unsigned int x) const
+    inline integer_class get_coeff(unsigned int x) const override
     {
         return get_poly().get_coeff(x);
     }
 
-    virtual vec_basic get_args() const;
+    vec_basic get_args() const override;
     inline const std::vector<integer_class> &get_dict() const
     {
         return get_poly().dict_;
     }
 
-    inline int size() const
+    inline int size() const override
     {
         if (get_poly().empty())
             return 0;

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -26,7 +26,7 @@ public:
     //! Constructor
     OneArgFunction(const RCP<const Basic> &arg) : arg_{arg} {};
     //! \return the hash
-    inline hash_t __hash__() const
+    inline hash_t __hash__() const override
     {
         hash_t seed = this->get_type_code();
         hash_combine<Basic>(seed, *arg_);
@@ -37,7 +37,7 @@ public:
     {
         return arg_;
     }
-    virtual inline vec_basic get_args() const
+    inline vec_basic get_args() const override
     {
         return {arg_};
     }
@@ -54,14 +54,14 @@ public:
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual inline bool __eq__(const Basic &o) const
+    inline bool __eq__(const Basic &o) const override
     {
         return is_same_type(*this, o)
                and eq(*get_arg(),
                       *down_cast<const OneArgFunction &>(o).get_arg());
     }
     //! Structural equality comparator
-    virtual inline int compare(const Basic &o) const
+    inline int compare(const Basic &o) const override
     {
         SYMENGINE_ASSERT(is_same_type(*this, o))
         return get_arg()->__cmp__(
@@ -80,7 +80,7 @@ public:
     TwoArgBasic(const RCP<const Basic> &a, const RCP<const Basic> &b)
         : a_{a}, b_{b} {};
     //! \return the hash
-    inline hash_t __hash__() const
+    inline hash_t __hash__() const override
     {
         hash_t seed = this->get_type_code();
         hash_combine<Basic>(seed, *a_);
@@ -97,7 +97,7 @@ public:
     {
         return b_;
     }
-    virtual inline vec_basic get_args() const
+    inline vec_basic get_args() const override
     {
         return {a_, b_};
     }
@@ -115,7 +115,7 @@ public:
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual inline bool __eq__(const Basic &o) const
+    inline bool __eq__(const Basic &o) const override
     {
         return is_same_type(*this, o)
                and eq(*get_arg1(),
@@ -124,7 +124,7 @@ public:
                       *down_cast<const TwoArgBasic &>(o).get_arg2());
     }
     //! Structural equality comparator
-    virtual inline int compare(const Basic &o) const
+    inline int compare(const Basic &o) const override
     {
         SYMENGINE_ASSERT(is_same_type(*this, o))
         const TwoArgBasic &t = down_cast<const TwoArgBasic &>(o);
@@ -149,14 +149,14 @@ public:
     //! Constructor
     MultiArgFunction(const vec_basic &arg) : arg_{arg} {};
     //! \return the hash
-    inline hash_t __hash__() const
+    inline hash_t __hash__() const override
     {
         hash_t seed = this->get_type_code();
         for (const auto &a : arg_)
             hash_combine<Basic>(seed, *a);
         return seed;
     }
-    virtual inline vec_basic get_args() const
+    inline vec_basic get_args() const override
     {
         return arg_;
     }
@@ -170,14 +170,14 @@ public:
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual inline bool __eq__(const Basic &o) const
+    inline bool __eq__(const Basic &o) const override
     {
         return is_same_type(*this, o)
                and unified_eq(get_vec(),
                               down_cast<const MultiArgFunction &>(o).get_vec());
     }
     //! Structural equality comparator
-    virtual inline int compare(const Basic &o) const
+    inline int compare(const Basic &o) const override
     {
         SYMENGINE_ASSERT(is_same_type(*this, o))
         return unified_compare(
@@ -194,7 +194,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sign
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Sign
@@ -209,7 +209,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized floor
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Floor:
@@ -224,7 +224,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized ceiling
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Ceiling:
@@ -239,7 +239,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized truncate
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Truncate:
@@ -254,7 +254,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized conjugate
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Conjugate
@@ -320,7 +320,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sin
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Sin:
@@ -336,7 +336,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized cos
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Cos:
@@ -352,7 +352,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized tan
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 //! Canonicalize Tan:
 RCP<const Basic> tan(const RCP<const Basic> &arg);
@@ -367,7 +367,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized cot
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 //! Canonicalize Cot:
 RCP<const Basic> cot(const RCP<const Basic> &arg);
@@ -382,7 +382,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized csc
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 //! Canonicalize Csc:
 RCP<const Basic> csc(const RCP<const Basic> &arg);
@@ -397,7 +397,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sec
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 //! Canonicalize Sec:
 RCP<const Basic> sec(const RCP<const Basic> &arg);
@@ -412,7 +412,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized asin
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ASin:
@@ -428,7 +428,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acos
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ACos:
@@ -444,7 +444,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized asec
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ASec:
@@ -460,7 +460,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acsc
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ACsc:
@@ -476,7 +476,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized atan
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ATan:
@@ -492,7 +492,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acot
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ACot:
@@ -518,8 +518,8 @@ public:
         return get_arg2();
     }
     //! \return canonicalized `atan2`
-    virtual RCP<const Basic> create(const RCP<const Basic> &a,
-                                    const RCP<const Basic> &b) const;
+    RCP<const Basic> create(const RCP<const Basic> &a,
+                            const RCP<const Basic> &b) const override;
 };
 
 //! Canonicalize ATan2:
@@ -538,7 +538,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return canonicalized `log`
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Returns the Natural Logarithm from argument `arg`
@@ -560,7 +560,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return canonicalized lambertw
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Create a new LambertW instance:
@@ -600,8 +600,8 @@ public:
     bool is_canonical(const RCP<const Basic> &s,
                       const RCP<const Basic> &a) const;
     //! \return canonicalized `zeta`
-    virtual RCP<const Basic> create(const RCP<const Basic> &a,
-                                    const RCP<const Basic> &b) const;
+    RCP<const Basic> create(const RCP<const Basic> &a,
+                            const RCP<const Basic> &b) const override;
 };
 
 //! Create a new Zeta instance:
@@ -625,7 +625,7 @@ public:
     //! Rewrites in the form of zeta
     RCP<const Basic> rewrite_as_zeta() const;
     //! \return Canonicalized zeta
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
     using OneArgFunction::create;
 };
 
@@ -643,13 +643,13 @@ public:
     FunctionSymbol(std::string name, const vec_basic &arg);
     FunctionSymbol(std::string name, const RCP<const Basic> &arg);
     //! \return Size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o  Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     //! \return `name_`
     inline const std::string &get_name() const
     {
@@ -657,7 +657,7 @@ public:
     }
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
-    virtual RCP<const Basic> create(const vec_basic &x) const;
+    RCP<const Basic> create(const vec_basic &x) const override;
 };
 
 //! Create a new FunctionSymbol instance:
@@ -674,7 +674,7 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_FUNCTIONWRAPPER)
     FunctionWrapper(std::string name, const vec_basic &arg);
     FunctionWrapper(std::string name, const RCP<const Basic> &arg);
-    virtual RCP<const Basic> create(const vec_basic &v) const = 0;
+    RCP<const Basic> create(const vec_basic &v) const override = 0;
     virtual RCP<const Number> eval(long bits) const = 0;
     virtual RCP<const Basic> diff_impl(const RCP<const Symbol> &s) const = 0;
 };
@@ -710,9 +710,9 @@ public:
         return make_rcp<const Derivative>(arg, x);
     }
 
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     inline RCP<const Basic> get_arg() const
     {
         return arg_;
@@ -721,7 +721,7 @@ public:
     {
         return x_;
     }
-    virtual vec_basic get_args() const
+    vec_basic get_args() const override
     {
         vec_basic args = {arg_};
         args.insert(args.end(), x_.begin(), x_.end());
@@ -751,9 +751,9 @@ public:
         return make_rcp<const Subs>(arg, x);
     }
 
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     inline const RCP<const Basic> &get_arg() const
     {
         return arg_;
@@ -764,7 +764,7 @@ public:
     };
     virtual vec_basic get_variables() const;
     virtual vec_basic get_point() const;
-    virtual vec_basic get_args() const;
+    vec_basic get_args() const override;
 
     bool is_canonical(const RCP<const Basic> &arg,
                       const map_basic_basic &x) const;
@@ -801,7 +801,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sinh
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Sinh:
@@ -817,7 +817,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized csch
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Csch:
@@ -833,7 +833,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized cosh
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Cosh:
@@ -849,7 +849,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized sech
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Sech:
@@ -865,7 +865,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized tanh
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Tanh:
@@ -881,7 +881,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized coth
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Coth:
@@ -897,7 +897,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized asinh
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ASinh:
@@ -913,7 +913,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acsch
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ACsch:
@@ -929,7 +929,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acosh
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ACosh:
@@ -945,7 +945,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized atanh
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ATanh:
@@ -961,7 +961,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized acoth
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ACoth:
@@ -977,7 +977,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized asech
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize ASech:
@@ -1000,8 +1000,8 @@ public:
     bool is_canonical(const RCP<const Basic> &i,
                       const RCP<const Basic> &j) const;
     //! \return canonicalized `KroneckerDelta`
-    virtual RCP<const Basic> create(const RCP<const Basic> &a,
-                                    const RCP<const Basic> &b) const;
+    RCP<const Basic> create(const RCP<const Basic> &a,
+                            const RCP<const Basic> &b) const override;
 };
 
 //! Canonicalize KroneckerDelta:
@@ -1024,7 +1024,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
     //! \return canonicalized Max
-    virtual RCP<const Basic> create(const vec_basic &arg) const;
+    RCP<const Basic> create(const vec_basic &arg) const override;
 };
 
 //! Canonicalize LeviCivita:
@@ -1049,7 +1049,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized erf
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Erf:
@@ -1074,7 +1074,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized erfc
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Erfc:
@@ -1099,7 +1099,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized gamma
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Gamma:
@@ -1117,8 +1117,8 @@ public:
     bool is_canonical(const RCP<const Basic> &s,
                       const RCP<const Basic> &x) const;
     //! \return canonicalized `LowerGamma`
-    virtual RCP<const Basic> create(const RCP<const Basic> &a,
-                                    const RCP<const Basic> &b) const;
+    RCP<const Basic> create(const RCP<const Basic> &a,
+                            const RCP<const Basic> &b) const override;
 };
 
 //! Canonicalize LowerGamma:
@@ -1137,8 +1137,8 @@ public:
     bool is_canonical(const RCP<const Basic> &s,
                       const RCP<const Basic> &x) const;
     //! \return canonicalized `UpperGamma`
-    virtual RCP<const Basic> create(const RCP<const Basic> &a,
-                                    const RCP<const Basic> &b) const;
+    RCP<const Basic> create(const RCP<const Basic> &a,
+                            const RCP<const Basic> &b) const override;
 };
 
 //! Canonicalize UpperGamma:
@@ -1163,7 +1163,7 @@ public:
     bool is_canonical(const RCP<const Basic> &arg) const;
     RCP<const Basic> rewrite_as_gamma() const;
     //! \return canonicalized loggamma
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize LogGamma:
@@ -1194,8 +1194,8 @@ public:
     bool is_canonical(const RCP<const Basic> &s, const RCP<const Basic> &x);
     RCP<const Basic> rewrite_as_gamma() const;
     //! \return canonicalized `Beta`
-    virtual RCP<const Basic> create(const RCP<const Basic> &a,
-                                    const RCP<const Basic> &b) const;
+    RCP<const Basic> create(const RCP<const Basic> &a,
+                            const RCP<const Basic> &b) const override;
 };
 
 //! Canonicalize Beta:
@@ -1226,8 +1226,8 @@ public:
     bool is_canonical(const RCP<const Basic> &n, const RCP<const Basic> &x);
     RCP<const Basic> rewrite_as_zeta() const;
     //! \return canonicalized `PolyGamma`
-    virtual RCP<const Basic> create(const RCP<const Basic> &a,
-                                    const RCP<const Basic> &b) const;
+    RCP<const Basic> create(const RCP<const Basic> &a,
+                            const RCP<const Basic> &b) const override;
 };
 
 //! Canonicalize PolyGamma
@@ -1249,7 +1249,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return canonicalized abs
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 //! Canonicalize Abs:
@@ -1264,7 +1264,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
     //! \return canonicalized Max
-    virtual RCP<const Basic> create(const vec_basic &arg) const;
+    RCP<const Basic> create(const vec_basic &arg) const override;
 };
 
 //! Canonicalize Max:
@@ -1279,7 +1279,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const vec_basic &arg) const;
     //! \return canonicalized Max
-    virtual RCP<const Basic> create(const vec_basic &arg) const;
+    RCP<const Basic> create(const vec_basic &arg) const override;
 };
 
 //! Canonicalize Min:
@@ -1297,7 +1297,7 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &arg) const;
     //! \return Canonicalized UnevaluatedExpr
-    virtual RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 RCP<const Basic> unevaluated_expr(const RCP<const Basic> &arg);

--- a/symengine/infinity.cpp
+++ b/symengine/infinity.cpp
@@ -231,57 +231,57 @@ inline RCP<const Infty> infty(const RCP<const Number> &direction)
 
 class EvaluateInfty : public Evaluate
 {
-    virtual RCP<const Basic> sin(const Basic &x) const override
+    RCP<const Basic> sin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("sin is not defined for infinite values");
     }
-    virtual RCP<const Basic> cos(const Basic &x) const override
+    RCP<const Basic> cos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("cos is not defined for infinite values");
     }
-    virtual RCP<const Basic> tan(const Basic &x) const override
+    RCP<const Basic> tan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("tan is not defined for infinite values");
     }
-    virtual RCP<const Basic> cot(const Basic &x) const override
+    RCP<const Basic> cot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("cot is not defined for infinite values");
     }
-    virtual RCP<const Basic> sec(const Basic &x) const override
+    RCP<const Basic> sec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("sec is not defined for infinite values");
     }
-    virtual RCP<const Basic> csc(const Basic &x) const override
+    RCP<const Basic> csc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("csc is not defined for infinite values");
     }
-    virtual RCP<const Basic> asin(const Basic &x) const override
+    RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("asin is not defined for infinite values");
     }
-    virtual RCP<const Basic> acos(const Basic &x) const override
+    RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("acos is not defined for infinite values");
     }
-    virtual RCP<const Basic> acsc(const Basic &x) const override
+    RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("acsc is not defined for infinite values");
     }
-    virtual RCP<const Basic> asec(const Basic &x) const override
+    RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         throw DomainError("asec is not defined for infinite values");
     }
-    virtual RCP<const Basic> atan(const Basic &x) const override
+    RCP<const Basic> atan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -293,7 +293,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("atan is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> acot(const Basic &x) const override
+    RCP<const Basic> acot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -303,7 +303,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("acot is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> sinh(const Basic &x) const override
+    RCP<const Basic> sinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -313,7 +313,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("sinh is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> csch(const Basic &x) const override
+    RCP<const Basic> csch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -323,7 +323,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("csch is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> cosh(const Basic &x) const override
+    RCP<const Basic> cosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -333,7 +333,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("cosh is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> sech(const Basic &x) const override
+    RCP<const Basic> sech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -343,7 +343,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("sech is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> tanh(const Basic &x) const override
+    RCP<const Basic> tanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -355,7 +355,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("tanh is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> coth(const Basic &x) const override
+    RCP<const Basic> coth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -367,7 +367,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("coth is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> asinh(const Basic &x) const override
+    RCP<const Basic> asinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -377,7 +377,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("asinh is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> acosh(const Basic &x) const override
+    RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -387,7 +387,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("acosh is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> acsch(const Basic &x) const override
+    RCP<const Basic> acsch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -397,7 +397,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("acsch is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> asech(const Basic &x) const override
+    RCP<const Basic> asech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -407,7 +407,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("asech is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> atanh(const Basic &x) const override
+    RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -419,7 +419,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("atanh is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> acoth(const Basic &x) const override
+    RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -429,12 +429,12 @@ class EvaluateInfty : public Evaluate
             throw DomainError("acoth is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> abs(const Basic &x) const override
+    RCP<const Basic> abs(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         return Inf;
     }
-    virtual RCP<const Basic> log(const Basic &x) const override
+    RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -444,7 +444,7 @@ class EvaluateInfty : public Evaluate
             return ComplexInf;
         }
     }
-    virtual RCP<const Basic> gamma(const Basic &x) const override
+    RCP<const Basic> gamma(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -454,7 +454,7 @@ class EvaluateInfty : public Evaluate
             return ComplexInf;
         }
     }
-    virtual RCP<const Basic> exp(const Basic &x) const override
+    RCP<const Basic> exp(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -466,7 +466,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("exp is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> floor(const Basic &x) const override
+    RCP<const Basic> floor(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -478,7 +478,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("floor is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> ceiling(const Basic &x) const override
+    RCP<const Basic> ceiling(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -490,7 +490,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("ceiling is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> truncate(const Basic &x) const override
+    RCP<const Basic> truncate(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -502,7 +502,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("truncate is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> erf(const Basic &x) const override
+    RCP<const Basic> erf(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);
@@ -514,7 +514,7 @@ class EvaluateInfty : public Evaluate
             throw DomainError("erf is not defined for Complex Infinity");
         }
     }
-    virtual RCP<const Basic> erfc(const Basic &x) const override
+    RCP<const Basic> erfc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<Infty>(x))
         const Infty &s = down_cast<const Infty &>(x);

--- a/symengine/infinity.h
+++ b/symengine/infinity.h
@@ -34,44 +34,44 @@ public:
     //! \return true if canonical
     bool is_canonical(const RCP<const Number> &num) const;
     //! \return size of the hash
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
 
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
     // Implement these
-    bool __eq__(const Basic &o) const;
-    int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
 
-    virtual vec_basic get_args() const
+    vec_basic get_args() const override
     {
         return {_direction};
     }
 
     //! \return `true` if `0`
-    inline bool is_zero() const
+    inline bool is_zero() const override
     {
         return false;
     }
     //! \return `true` if `1`
-    inline bool is_one() const
+    inline bool is_one() const override
     {
         return false;
     }
     //! \return `true` if `-1`
-    inline bool is_minus_one() const
+    inline bool is_minus_one() const override
     {
         return false;
     }
 
     //! \return `true` if this number is an exact number
-    inline virtual bool is_exact() const
+    inline bool is_exact() const override
     {
         return false;
     }
     // //! Get `Evaluate` singleton to evaluate numerically
-    virtual Evaluate &get_eval() const;
+    Evaluate &get_eval() const override;
 
     inline RCP<const Number> get_direction() const
     {
@@ -82,29 +82,29 @@ public:
     bool is_positive_infinity() const;
     bool is_negative_infinity() const;
 
-    inline bool is_positive() const
+    inline bool is_positive() const override
     {
         return is_positive_infinity();
     }
 
-    inline bool is_negative() const
+    inline bool is_negative() const override
     {
         return is_negative_infinity();
     }
 
-    inline bool is_complex() const
+    inline bool is_complex() const override
     {
         return is_unsigned_infinity();
     }
     //! \return the conjugate if the class is complex
-    virtual RCP<const Basic> conjugate() const;
+    RCP<const Basic> conjugate() const override;
 
     // Think about it again
-    RCP<const Number> add(const Number &other) const;
-    RCP<const Number> mul(const Number &other) const;
-    RCP<const Number> div(const Number &other) const;
-    RCP<const Number> pow(const Number &other) const;
-    RCP<const Number> rpow(const Number &other) const;
+    RCP<const Number> add(const Number &other) const override;
+    RCP<const Number> mul(const Number &other) const override;
+    RCP<const Number> div(const Number &other) const override;
+    RCP<const Number> pow(const Number &other) const override;
+    RCP<const Number> rpow(const Number &other) const override;
 };
 
 inline RCP<const Infty> infty(int n = 1)

--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -27,18 +27,15 @@ public:
     // explicit Integer(integer_class i);
     Integer(const integer_class &_i)
         : i(_i){SYMENGINE_ASSIGN_TYPEID()} Integer(integer_class && _i)
-        : i(std::move(_i))
-    {
-        SYMENGINE_ASSIGN_TYPEID()
-    }
-    //! \return size of the hash
-    virtual hash_t __hash__() const;
+        : i(std::move(_i)){SYMENGINE_ASSIGN_TYPEID()}
+          //! \return size of the hash
+          hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
 
     //! Convert to `int`, raise an exception if it does not fit
     signed long int as_int() const;
@@ -50,33 +47,33 @@ public:
         return this->i;
     }
     //! \return `true` if `0`
-    inline virtual bool is_zero() const
+    inline bool is_zero() const override
     {
         return this->i == 0u;
     }
     //! \return `true` if `1`
-    inline virtual bool is_one() const
+    inline bool is_one() const override
     {
         return this->i == 1u;
     }
     //! \return `true` if `-1`
-    inline virtual bool is_minus_one() const
+    inline bool is_minus_one() const override
     {
         return this->i == -1;
     }
     //! \return `true` if positive
-    inline virtual bool is_positive() const
+    inline bool is_positive() const override
     {
         return this->i > 0u;
     }
     //! \return `true` if negative
-    inline virtual bool is_negative() const
+    inline bool is_negative() const override
     {
         return this->i < 0u;
     }
     //! \returns `false`
     // False is returned because a pure integer cannot have an imaginary part
-    inline virtual bool is_complex() const
+    inline bool is_complex() const override
     {
         return false;
     }
@@ -124,7 +121,7 @@ public:
     /* These are general methods, overriden from the Number class, that need to
      * check types to decide what operation to do, and so are a bit slower. */
     //! Slower Addition
-    virtual RCP<const Number> add(const Number &other) const
+    RCP<const Number> add(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return addint(down_cast<const Integer &>(other));
@@ -133,7 +130,7 @@ public:
         }
     };
     //! Slower Subtraction
-    virtual RCP<const Number> sub(const Number &other) const
+    RCP<const Number> sub(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return subint(down_cast<const Integer &>(other));
@@ -142,13 +139,13 @@ public:
         }
     };
 
-    virtual RCP<const Number> rsub(const Number &other) const
+    RCP<const Number> rsub(const Number &other) const override
     {
         throw NotImplementedError("Not Implemented");
     };
 
     //! Slower Multiplication
-    virtual RCP<const Number> mul(const Number &other) const
+    RCP<const Number> mul(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return mulint(down_cast<const Integer &>(other));
@@ -157,7 +154,7 @@ public:
         }
     };
     //! Slower Division
-    virtual RCP<const Number> div(const Number &other) const
+    RCP<const Number> div(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return divint(down_cast<const Integer &>(other));
@@ -166,10 +163,10 @@ public:
         }
     };
 
-    virtual RCP<const Number> rdiv(const Number &other) const;
+    RCP<const Number> rdiv(const Number &other) const override;
 
     //! Slower power evaluation
-    virtual RCP<const Number> pow(const Number &other) const
+    RCP<const Number> pow(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return powint(down_cast<const Integer &>(other));
@@ -178,7 +175,7 @@ public:
         }
     };
 
-    virtual RCP<const Number> rpow(const Number &other) const
+    RCP<const Number> rpow(const Number &other) const override
     {
         throw NotImplementedError("Not Implemented");
     };

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -316,16 +316,16 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
         std::string &ss_;
         MemoryBufferRefCallback(std::string &ss) : ss_(ss) {}
 
-        virtual void notifyObjectCompiled(const llvm::Module *M,
-                                          llvm::MemoryBufferRef obj)
+        void notifyObjectCompiled(const llvm::Module *M,
+                                  llvm::MemoryBufferRef obj) override
         {
             const char *c = obj.getBufferStart();
             // Saving the object code in a std::string
             ss_.assign(c, obj.getBufferSize());
         }
 
-        virtual std::unique_ptr<llvm::MemoryBuffer>
-        getObject(const llvm::Module *M)
+        std::unique_ptr<llvm::MemoryBuffer>
+        getObject(const llvm::Module *M) override
         {
             return NULL;
         }
@@ -1007,15 +1007,15 @@ void LLVMVisitor::loads(const std::string &s)
 
     public:
         MCJITObjectLoader(const std::string &s) : s_(s) {}
-        virtual void notifyObjectCompiled(const llvm::Module *M,
-                                          llvm::MemoryBufferRef obj)
+        void notifyObjectCompiled(const llvm::Module *M,
+                                  llvm::MemoryBufferRef obj) override
         {
         }
 
         // No need to check M because there is only one function
         // Return it after reading from the file.
-        virtual std::unique_ptr<llvm::MemoryBuffer>
-        getObject(const llvm::Module *M)
+        std::unique_ptr<llvm::MemoryBuffer>
+        getObject(const llvm::Module *M) override
         {
             return llvm::MemoryBuffer::getMemBufferCopy(llvm::StringRef(s_));
         }

--- a/symengine/logic.h
+++ b/symengine/logic.h
@@ -31,13 +31,13 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_BOOLEAN_ATOM)
     BooleanAtom(bool b);
     //! \return the hash
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
     bool get_val() const;
-    virtual vec_basic get_args() const;
-    virtual bool __eq__(const Basic &o) const;
+    vec_basic get_args() const override;
+    bool __eq__(const Basic &o) const override;
     //! Structural equality comparator
-    virtual int compare(const Basic &o) const;
-    virtual RCP<const Boolean> logical_not() const;
+    int compare(const Basic &o) const override;
+    RCP<const Boolean> logical_not() const override;
 };
 
 extern SYMENGINE_EXPORT RCP<const BooleanAtom> boolTrue;
@@ -60,15 +60,15 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_CONTAINS)
     //! Constructor
     Contains(const RCP<const Basic> &expr, const RCP<const Set> &set);
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
     RCP<const Basic> get_expr() const;
     RCP<const Set> get_set() const;
-    virtual vec_basic get_args() const;
-    virtual bool __eq__(const Basic &o) const;
+    vec_basic get_args() const override;
+    bool __eq__(const Basic &o) const override;
     RCP<const Basic> create(const RCP<const Basic> &lhs,
                             const RCP<const Set> &rhs) const;
     //! Structural equality comparator
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
 };
 
 RCP<const Boolean> contains(const RCP<const Basic> &expr,
@@ -89,12 +89,12 @@ public:
     //! Constructor
     Piecewise(PiecewiseVec &&vec);
     bool is_canonical(const PiecewiseVec &vec);
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
     const PiecewiseVec &get_vec() const;
-    virtual vec_basic get_args() const;
-    virtual bool __eq__(const Basic &o) const;
+    vec_basic get_args() const override;
+    bool __eq__(const Basic &o) const override;
     //! Structural equality comparator
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
 };
 
 // Vec is vector of pairs of RCP<const Basic> and RCP<const Boolean> to
@@ -111,14 +111,14 @@ public:
     And(const set_boolean &s);
     bool is_canonical(const set_boolean &container_);
     //! \return the hash
-    hash_t __hash__() const;
-    virtual vec_basic get_args() const;
+    hash_t __hash__() const override;
+    vec_basic get_args() const override;
     RCP<const Basic> create(const set_boolean &a) const;
-    virtual bool __eq__(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
     //! Structural equality comparator
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
     const set_boolean &get_container() const;
-    virtual RCP<const Boolean> logical_not() const;
+    RCP<const Boolean> logical_not() const override;
 };
 
 class Or : public Boolean
@@ -131,13 +131,13 @@ public:
     Or(const set_boolean &s);
     bool is_canonical(const set_boolean &container_);
     //! \return the hash
-    hash_t __hash__() const;
-    virtual vec_basic get_args() const;
-    virtual bool __eq__(const Basic &o) const;
+    hash_t __hash__() const override;
+    vec_basic get_args() const override;
+    bool __eq__(const Basic &o) const override;
     //! Structural equality comparator
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
     const set_boolean &get_container() const;
-    virtual RCP<const Boolean> logical_not() const;
+    RCP<const Boolean> logical_not() const override;
 };
 
 class Not : public Boolean
@@ -150,13 +150,13 @@ public:
     Not(const RCP<const Boolean> &s);
     bool is_canonical(const RCP<const Boolean> &s);
     //! \return the hash
-    hash_t __hash__() const;
-    virtual vec_basic get_args() const;
-    virtual bool __eq__(const Basic &o) const;
+    hash_t __hash__() const override;
+    vec_basic get_args() const override;
+    bool __eq__(const Basic &o) const override;
     //! Structural equality comparator
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
     RCP<const Boolean> get_arg() const;
-    virtual RCP<const Boolean> logical_not() const;
+    RCP<const Boolean> logical_not() const override;
 };
 
 class Xor : public Boolean
@@ -168,10 +168,10 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_XOR)
     Xor(const vec_boolean &s);
     bool is_canonical(const vec_boolean &container_);
-    hash_t __hash__() const;
-    virtual vec_basic get_args() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    hash_t __hash__() const override;
+    vec_basic get_args() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     const vec_boolean &get_container() const;
 };
 
@@ -191,9 +191,9 @@ class Equality : public Relational
 public:
     IMPLEMENT_TYPEID(SYMENGINE_EQUALITY)
     Equality(const RCP<const Basic> &lhs, const RCP<const Basic> &rhs);
-    virtual RCP<const Basic> create(const RCP<const Basic> &lhs,
-                                    const RCP<const Basic> &rhs) const;
-    virtual RCP<const Boolean> logical_not() const;
+    RCP<const Basic> create(const RCP<const Basic> &lhs,
+                            const RCP<const Basic> &rhs) const override;
+    RCP<const Boolean> logical_not() const override;
 };
 
 class Unequality : public Relational
@@ -202,9 +202,9 @@ class Unequality : public Relational
 public:
     IMPLEMENT_TYPEID(SYMENGINE_UNEQUALITY)
     Unequality(const RCP<const Basic> &lhs, const RCP<const Basic> &rhs);
-    virtual RCP<const Basic> create(const RCP<const Basic> &lhs,
-                                    const RCP<const Basic> &rhs) const;
-    virtual RCP<const Boolean> logical_not() const;
+    RCP<const Basic> create(const RCP<const Basic> &lhs,
+                            const RCP<const Basic> &rhs) const override;
+    RCP<const Boolean> logical_not() const override;
 };
 
 class LessThan : public Relational
@@ -213,9 +213,9 @@ class LessThan : public Relational
 public:
     IMPLEMENT_TYPEID(SYMENGINE_LESSTHAN)
     LessThan(const RCP<const Basic> &lhs, const RCP<const Basic> &rhs);
-    virtual RCP<const Basic> create(const RCP<const Basic> &lhs,
-                                    const RCP<const Basic> &rhs) const;
-    virtual RCP<const Boolean> logical_not() const;
+    RCP<const Basic> create(const RCP<const Basic> &lhs,
+                            const RCP<const Basic> &rhs) const override;
+    RCP<const Boolean> logical_not() const override;
 };
 
 class StrictLessThan : public Relational
@@ -224,9 +224,9 @@ class StrictLessThan : public Relational
 public:
     IMPLEMENT_TYPEID(SYMENGINE_STRICTLESSTHAN)
     StrictLessThan(const RCP<const Basic> &lhs, const RCP<const Basic> &rhs);
-    virtual RCP<const Basic> create(const RCP<const Basic> &lhs,
-                                    const RCP<const Basic> &rhs) const;
-    virtual RCP<const Boolean> logical_not() const;
+    RCP<const Basic> create(const RCP<const Basic> &lhs,
+                            const RCP<const Basic> &rhs) const override;
+    RCP<const Boolean> logical_not() const override;
 };
 
 inline bool is_a_Relational(const Basic &b)

--- a/symengine/mul.h
+++ b/symengine/mul.h
@@ -83,13 +83,13 @@ public:
     //! dictionary:
     Mul(const RCP<const Number> &coef, map_basic_basic &&dict);
     //! \return size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
 
     // Performs canonicalization first:
     //! Create a Mul from a dict
@@ -120,7 +120,7 @@ public:
     bool is_canonical(const RCP<const Number> &coef,
                       const map_basic_basic &dict) const;
 
-    virtual vec_basic get_args() const;
+    vec_basic get_args() const override;
 
     inline const RCP<const Number> &get_coef() const
     {

--- a/symengine/nan.cpp
+++ b/symengine/nan.cpp
@@ -58,167 +58,167 @@ RCP<const Number> NaN::rpow(const Number &other) const
 
 class EvaluateNaN : public Evaluate
 {
-    virtual RCP<const Basic> sin(const Basic &x) const override
+    RCP<const Basic> sin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> cos(const Basic &x) const override
+    RCP<const Basic> cos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> tan(const Basic &x) const override
+    RCP<const Basic> tan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> cot(const Basic &x) const override
+    RCP<const Basic> cot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> sec(const Basic &x) const override
+    RCP<const Basic> sec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> csc(const Basic &x) const override
+    RCP<const Basic> csc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> asin(const Basic &x) const override
+    RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> acos(const Basic &x) const override
+    RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> acsc(const Basic &x) const override
+    RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> asec(const Basic &x) const override
+    RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> atan(const Basic &x) const override
+    RCP<const Basic> atan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> acot(const Basic &x) const override
+    RCP<const Basic> acot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> sinh(const Basic &x) const override
+    RCP<const Basic> sinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> csch(const Basic &x) const override
+    RCP<const Basic> csch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> cosh(const Basic &x) const override
+    RCP<const Basic> cosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> sech(const Basic &x) const override
+    RCP<const Basic> sech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> tanh(const Basic &x) const override
+    RCP<const Basic> tanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> coth(const Basic &x) const override
+    RCP<const Basic> coth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> asinh(const Basic &x) const override
+    RCP<const Basic> asinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> acosh(const Basic &x) const override
+    RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> acsch(const Basic &x) const override
+    RCP<const Basic> acsch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> asech(const Basic &x) const override
+    RCP<const Basic> asech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> atanh(const Basic &x) const override
+    RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> acoth(const Basic &x) const override
+    RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> abs(const Basic &x) const override
+    RCP<const Basic> abs(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> log(const Basic &x) const override
+    RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> gamma(const Basic &x) const override
+    RCP<const Basic> gamma(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> exp(const Basic &x) const override
+    RCP<const Basic> exp(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> floor(const Basic &x) const override
+    RCP<const Basic> floor(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> ceiling(const Basic &x) const override
+    RCP<const Basic> ceiling(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> truncate(const Basic &x) const override
+    RCP<const Basic> truncate(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> erf(const Basic &x) const override
+    RCP<const Basic> erf(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;
     }
-    virtual RCP<const Basic> erfc(const Basic &x) const override
+    RCP<const Basic> erfc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<NaN>(x))
         return Nan;

--- a/symengine/nan.h
+++ b/symengine/nan.h
@@ -24,58 +24,58 @@ public:
     NaN();
 
     //! \return size of the hash
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
 
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    bool __eq__(const Basic &o) const;
-    int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
 
     //! \return `true` if `0`
-    inline bool is_zero() const
+    inline bool is_zero() const override
     {
         return false;
     }
     //! \return `true` if `1`
-    inline bool is_one() const
+    inline bool is_one() const override
     {
         return false;
     }
     //! \return `true` if `-1`
-    inline bool is_minus_one() const
+    inline bool is_minus_one() const override
     {
         return false;
     }
 
-    inline bool is_positive() const
+    inline bool is_positive() const override
     {
         return false;
     }
 
-    inline bool is_negative() const
+    inline bool is_negative() const override
     {
         return false;
     }
 
-    inline bool is_complex() const
+    inline bool is_complex() const override
     {
         return false;
     }
     //! \return the conjugate if the class is complex
-    virtual RCP<const Basic> conjugate() const;
-    inline bool is_exact() const
+    RCP<const Basic> conjugate() const override;
+    inline bool is_exact() const override
     {
         return false;
     }
-    virtual Evaluate &get_eval() const;
+    Evaluate &get_eval() const override;
 
-    RCP<const Number> add(const Number &other) const;
-    RCP<const Number> mul(const Number &other) const;
-    RCP<const Number> div(const Number &other) const;
-    RCP<const Number> pow(const Number &other) const;
-    RCP<const Number> rpow(const Number &other) const;
+    RCP<const Number> add(const Number &other) const override;
+    RCP<const Number> mul(const Number &other) const override;
+    RCP<const Number> div(const Number &other) const override;
+    RCP<const Number> pow(const Number &other) const override;
+    RCP<const Number> rpow(const Number &other) const override;
 };
 
 } // namespace SymEngine

--- a/symengine/ntheory_funcs.h
+++ b/symengine/ntheory_funcs.h
@@ -23,7 +23,7 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_PRIMEPI)
     PrimePi(const RCP<const Basic> &arg);
     bool is_canonical(const RCP<const Basic> &arg) const;
-    RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 RCP<const Basic> primepi(const RCP<const Basic> &arg);
@@ -39,7 +39,7 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_PRIMORIAL)
     Primorial(const RCP<const Basic> &arg);
     bool is_canonical(const RCP<const Basic> &arg) const;
-    RCP<const Basic> create(const RCP<const Basic> &arg) const;
+    RCP<const Basic> create(const RCP<const Basic> &arg) const override;
 };
 
 RCP<const Basic> primorial(const RCP<const Basic> &arg);

--- a/symengine/number.h
+++ b/symengine/number.h
@@ -63,7 +63,7 @@ public:
     virtual RCP<const Number> pow(const Number &other) const = 0;
     virtual RCP<const Number> rpow(const Number &other) const = 0;
 
-    virtual vec_basic get_args() const
+    vec_basic get_args() const override
     {
         return {};
     }

--- a/symengine/polys/msymenginepoly.h
+++ b/symengine/polys/msymenginepoly.h
@@ -330,7 +330,7 @@ public:
         return make_rcp<const Poly>(vars, std::move(d));
     }
 
-    int compare(const Basic &o) const
+    int compare(const Basic &o) const override
     {
         SYMENGINE_ASSERT(is_a<Poly>(o))
 
@@ -392,7 +392,7 @@ public:
         return Container(std::move(d), numeric_cast<unsigned>(s.size()));
     }
 
-    inline vec_basic get_args() const
+    inline vec_basic get_args() const override
     {
         return {};
     }
@@ -407,7 +407,7 @@ public:
         return vars_;
     }
 
-    bool __eq__(const Basic &o) const
+    bool __eq__(const Basic &o) const override
     {
         // TODO : fix for when vars are different, but there is an intersection
         if (not is_a<Poly>(o))
@@ -444,7 +444,7 @@ public:
 
           IMPLEMENT_TYPEID(SYMENGINE_MINTPOLY)
 
-              hash_t __hash__() const;
+              hash_t __hash__() const override;
     RCP<const Basic> as_symbolic() const;
 
     integer_class eval(
@@ -459,7 +459,7 @@ public:
 
           IMPLEMENT_TYPEID(SYMENGINE_MEXPRPOLY)
 
-              hash_t __hash__() const;
+              hash_t __hash__() const override;
     RCP<const Basic> as_symbolic() const;
     Expression
     eval(std::map<RCP<const Basic>, Expression, RCPBasicKeyLess> &vals) const;

--- a/symengine/polys/uexprpoly.h
+++ b/symengine/polys/uexprpoly.h
@@ -164,7 +164,7 @@ public:
     //! Constructor of UExprPoly class
     UExprPoly(const RCP<const Basic> &var, UExprDict &&dict);
 
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
 
     typedef Expression coef_type;
 

--- a/symengine/polys/uintpoly.h
+++ b/symengine/polys/uintpoly.h
@@ -120,7 +120,7 @@ public:
     UIntPoly(const RCP<const Basic> &var, UIntDict &&dict);
 
     //! \return size of the hash
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
 }; // UIntPoly
 
 // true & sets `out` to b/a if a exactly divides b, otherwise false & undefined

--- a/symengine/polys/uintpoly_flint.h
+++ b/symengine/polys/uintpoly_flint.h
@@ -138,7 +138,7 @@ public:
     //! Constructor of UIntPolyFlint class
     UIntPolyFlint(const RCP<const Basic> &var, fzp_t &&dict);
     //! \return size of the hash
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
 
 }; // UIntPolyFlint
 
@@ -149,7 +149,7 @@ public:
     //! Constructor of URatPolyFlint class
     URatPolyFlint(const RCP<const Basic> &var, fqp_t &&dict);
     //! \return size of the hash
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
 }; // URatPolyFlint
 
 template <typename Container, template <typename X, typename Y> class BaseType,

--- a/symengine/polys/upolybase.h
+++ b/symengine/polys/upolybase.h
@@ -366,14 +366,14 @@ public:
     typedef Container container_type;
 
     //! \returns `-1`,`0` or `1` after comparing
-    virtual int compare(const Basic &o) const = 0;
-    virtual hash_t __hash__() const = 0;
+    int compare(const Basic &o) const override = 0;
+    hash_t __hash__() const override = 0;
 
     // return `degree` + 1. `0` returned for zero poly.
     virtual int size() const = 0;
 
     //! \returns `true` if two objects are equal
-    inline bool __eq__(const Basic &o) const
+    inline bool __eq__(const Basic &o) const override
     {
         if (is_a<Poly>(o))
             return eq(*var_, *(down_cast<const Poly &>(o).var_))
@@ -391,7 +391,7 @@ public:
         return poly_;
     }
 
-    inline vec_basic get_args() const
+    inline vec_basic get_args() const override
     {
         return {};
     }

--- a/symengine/polys/uratpoly.h
+++ b/symengine/polys/uratpoly.h
@@ -43,7 +43,7 @@ public:
     URatPoly(const RCP<const Basic> &var, URatDict &&dict);
 
     //! \return size of the hash
-    hash_t __hash__() const;
+    hash_t __hash__() const override;
 }; // URatPoly
 
 // true & sets `out` to b/a if a exactly divides b, otherwise false & undefined

--- a/symengine/pow.h
+++ b/symengine/pow.h
@@ -24,13 +24,13 @@ public:
     //! Pow Constructor
     Pow(const RCP<const Basic> &base, const RCP<const Basic> &exp);
     //! \return Size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     //! \return `true` if canonical
     bool is_canonical(const Basic &base, const Basic &exp) const;
     //! \return `base` of `base**exp`
@@ -44,7 +44,7 @@ public:
         return exp_;
     }
 
-    virtual vec_basic get_args() const;
+    vec_basic get_args() const override;
 };
 
 //! \return Pow from `a` and `b`

--- a/symengine/printers/codegen.h
+++ b/symengine/printers/codegen.h
@@ -51,7 +51,7 @@ public:
     using CodePrinter::str_;
     void bvisit(const Infty &x);
     void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
-                    const RCP<const Basic> &b);
+                    const RCP<const Basic> &b) override;
 };
 
 class C99CodePrinter : public BaseVisitor<C99CodePrinter, C89CodePrinter>
@@ -62,7 +62,7 @@ public:
     using C89CodePrinter::str_;
     void bvisit(const Infty &x);
     void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
-                    const RCP<const Basic> &b);
+                    const RCP<const Basic> &b) override;
     void bvisit(const Gamma &x);
     void bvisit(const LogGamma &x);
 };
@@ -75,7 +75,7 @@ public:
     using CodePrinter::str_;
     void bvisit(const Constant &x);
     void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
-                    const RCP<const Basic> &b);
+                    const RCP<const Basic> &b) override;
     void bvisit(const Abs &x);
     void bvisit(const Sin &x);
     void bvisit(const Cos &x);

--- a/symengine/printers/latex.h
+++ b/symengine/printers/latex.h
@@ -61,13 +61,13 @@ private:
 protected:
     void print_with_args(const Basic &x, const std::string &join,
                          std::ostringstream &s);
-    virtual std::string parenthesize(const std::string &expr);
-    virtual void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
-                            const RCP<const Basic> &b);
-    virtual bool split_mul_coef();
-    virtual std::string print_mul();
-    virtual std::string print_div(const std::string &num,
-                                  const std::string &den, bool paren);
+    std::string parenthesize(const std::string &expr) override;
+    void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
+                    const RCP<const Basic> &b) override;
+    bool split_mul_coef() override;
+    std::string print_mul() override;
+    std::string print_div(const std::string &num, const std::string &den,
+                          bool paren) override;
 };
 } // namespace SymEngine
 

--- a/symengine/printers/sbml.h
+++ b/symengine/printers/sbml.h
@@ -13,8 +13,8 @@ public:
     using StrPrinter::apply;
     using StrPrinter::bvisit;
     static const std::vector<std::string> names_;
-    virtual void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
-                            const RCP<const Basic> &b);
+    void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
+                    const RCP<const Basic> &b) override;
     void bvisit(const BooleanAtom &x);
     void bvisit(const And &x);
     void bvisit(const Or &x);

--- a/symengine/printers/strprinter.h
+++ b/symengine/printers/strprinter.h
@@ -204,9 +204,9 @@ class JuliaStrPrinter : public BaseVisitor<JuliaStrPrinter, StrPrinter>
 {
 public:
     using StrPrinter::bvisit;
-    virtual void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
-                            const RCP<const Basic> &b);
-    virtual std::string get_imag_symbol();
+    void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
+                    const RCP<const Basic> &b) override;
+    std::string get_imag_symbol() override;
     void bvisit(const Constant &x);
     void bvisit(const NaN &x);
     void bvisit(const Infty &x);

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -31,13 +31,13 @@ public:
     static RCP<const Number> from_mpq(const rational_class &i);
     static RCP<const Number> from_mpq(rational_class &&i);
     //! \return size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     //! \return true if canonical
     bool is_canonical(const rational_class &i) const;
 
@@ -52,17 +52,17 @@ public:
         return this->i;
     }
     //! \return `true` if `0`
-    virtual bool is_zero() const
+    bool is_zero() const override
     {
         return this->i == 0;
     }
     //! \return `true` if `1`
-    virtual bool is_one() const
+    bool is_one() const override
     {
         return this->i == 1;
     }
     //! \return `true` if `-1`
-    virtual bool is_minus_one() const
+    bool is_minus_one() const override
     {
         return this->i == -1;
     }
@@ -72,18 +72,18 @@ public:
         return this->i == 1;
     }
     //! \return `true` if positive
-    inline virtual bool is_positive() const
+    inline bool is_positive() const override
     {
         return i > 0;
     }
     //! \return `true` if negative
-    inline virtual bool is_negative() const
+    inline bool is_negative() const override
     {
         return i < 0;
     }
     //! \returns `false`
     // False is returned because a rational cannot have an imaginary part
-    inline virtual bool is_complex() const
+    inline bool is_complex() const override
     {
         return false;
     }
@@ -94,10 +94,10 @@ public:
         return make_rcp<const Rational>(-i);
     }
 
-    virtual bool is_perfect_power(bool is_expected = false) const;
+    bool is_perfect_power(bool is_expected = false) const override;
     // \return true if there is a exact nth root of self.
-    virtual bool nth_root(const Ptr<RCP<const Number>> &,
-                          unsigned long n) const;
+    bool nth_root(const Ptr<RCP<const Number>> &,
+                  unsigned long n) const override;
 
     /*! Add Rationals
      * \param other of type Rational
@@ -233,7 +233,7 @@ public:
     RCP<const Basic> rpowrat(const Integer &other) const;
 
     //! Converts the param `other` appropriately and then calls `addrat`
-    virtual RCP<const Number> add(const Number &other) const
+    RCP<const Number> add(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return addrat(down_cast<const Rational &>(other));
@@ -244,7 +244,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `subrat`
-    virtual RCP<const Number> sub(const Number &other) const
+    RCP<const Number> sub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return subrat(down_cast<const Rational &>(other));
@@ -255,7 +255,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `rsubrat`
-    virtual RCP<const Number> rsub(const Number &other) const
+    RCP<const Number> rsub(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return rsubrat(down_cast<const Integer &>(other));
@@ -264,7 +264,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `mulrat`
-    virtual RCP<const Number> mul(const Number &other) const
+    RCP<const Number> mul(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return mulrat(down_cast<const Rational &>(other));
@@ -275,7 +275,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `divrat`
-    virtual RCP<const Number> div(const Number &other) const
+    RCP<const Number> div(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return divrat(down_cast<const Rational &>(other));
@@ -286,7 +286,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `rdivrat`
-    virtual RCP<const Number> rdiv(const Number &other) const
+    RCP<const Number> rdiv(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return rdivrat(down_cast<const Integer &>(other));
@@ -295,7 +295,7 @@ public:
         }
     };
     //! Converts the param `other` appropriately and then calls `powrat`
-    virtual RCP<const Number> pow(const Number &other) const
+    RCP<const Number> pow(const Number &other) const override
     {
         if (is_a<Integer>(other)) {
             return powrat(down_cast<const Integer &>(other));
@@ -304,7 +304,7 @@ public:
         }
     };
 
-    virtual RCP<const Number> rpow(const Number &other) const
+    RCP<const Number> rpow(const Number &other) const override
     {
         throw NotImplementedError("Not Implemented");
     };

--- a/symengine/real_double.cpp
+++ b/symengine/real_double.cpp
@@ -59,92 +59,92 @@ RCP<const Number> number(double x)
 template <class T>
 class EvaluateDouble : public Evaluate
 {
-    virtual RCP<const Basic> sin(const Basic &x) const override
+    RCP<const Basic> sin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::sin(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> cos(const Basic &x) const override
+    RCP<const Basic> cos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::cos(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> tan(const Basic &x) const override
+    RCP<const Basic> tan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::tan(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> cot(const Basic &x) const override
+    RCP<const Basic> cot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(1.0 / std::tan(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> sec(const Basic &x) const override
+    RCP<const Basic> sec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(1.0 / std::cos(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> csc(const Basic &x) const override
+    RCP<const Basic> csc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(1.0 / std::sin(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> atan(const Basic &x) const override
+    RCP<const Basic> atan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::atan(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> acot(const Basic &x) const override
+    RCP<const Basic> acot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::atan(1.0 / down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> sinh(const Basic &x) const override
+    RCP<const Basic> sinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::sinh(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> csch(const Basic &x) const override
+    RCP<const Basic> csch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(1.0 / std::sinh(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> cosh(const Basic &x) const override
+    RCP<const Basic> cosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::cosh(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> sech(const Basic &x) const override
+    RCP<const Basic> sech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(1.0 / std::cosh(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> tanh(const Basic &x) const override
+    RCP<const Basic> tanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::tanh(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> coth(const Basic &x) const override
+    RCP<const Basic> coth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(1.0 / std::tanh(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> asinh(const Basic &x) const override
+    RCP<const Basic> asinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::asinh(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> acsch(const Basic &x) const override
+    RCP<const Basic> acsch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::asinh(1.0 / down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> abs(const Basic &x) const override
+    RCP<const Basic> abs(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::abs(down_cast<const T &>(x).i));
     }
-    virtual RCP<const Basic> exp(const Basic &x) const override
+    RCP<const Basic> exp(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<T>(x))
         return number(std::exp(down_cast<const T &>(x).i));
@@ -153,12 +153,12 @@ class EvaluateDouble : public Evaluate
 
 class EvaluateRealDouble : public EvaluateDouble<RealDouble>
 {
-    virtual RCP<const Basic> gamma(const Basic &x) const override
+    RCP<const Basic> gamma(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         return number(std::tgamma(down_cast<const RealDouble &>(x).i));
     }
-    virtual RCP<const Basic> asin(const Basic &x) const override
+    RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -168,7 +168,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::asin(std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> acos(const Basic &x) const override
+    RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -178,7 +178,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::acos(std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> acsc(const Basic &x) const override
+    RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -188,7 +188,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::asin(1.0 / std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> asec(const Basic &x) const override
+    RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -198,7 +198,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::acos(1.0 / std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> acosh(const Basic &x) const override
+    RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -208,7 +208,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::acosh(std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> atanh(const Basic &x) const override
+    RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -218,7 +218,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::atanh(std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> acoth(const Basic &x) const override
+    RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -228,7 +228,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::atanh(1.0 / std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> asech(const Basic &x) const override
+    RCP<const Basic> asech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -238,7 +238,7 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::acosh(1.0 / std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> log(const Basic &x) const override
+    RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         double d = down_cast<const RealDouble &>(x).i;
@@ -248,33 +248,33 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
             return number(std::log(std::complex<double>(d)));
         }
     }
-    virtual RCP<const Basic> floor(const Basic &x) const override
+    RCP<const Basic> floor(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         integer_class i;
         mp_set_d(i, std::floor(down_cast<const RealDouble &>(x).i));
         return integer(std::move(i));
     }
-    virtual RCP<const Basic> ceiling(const Basic &x) const override
+    RCP<const Basic> ceiling(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         integer_class i;
         mp_set_d(i, std::ceil(down_cast<const RealDouble &>(x).i));
         return integer(std::move(i));
     }
-    virtual RCP<const Basic> truncate(const Basic &x) const override
+    RCP<const Basic> truncate(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         integer_class i;
         mp_set_d(i, std::trunc(down_cast<const RealDouble &>(x).i));
         return integer(std::move(i));
     }
-    virtual RCP<const Basic> erf(const Basic &x) const override
+    RCP<const Basic> erf(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         return number(std::erf(down_cast<const RealDouble &>(x).i));
     }
-    virtual RCP<const Basic> erfc(const Basic &x) const override
+    RCP<const Basic> erfc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealDouble>(x))
         return number(std::erfc(down_cast<const RealDouble &>(x).i));
@@ -283,57 +283,57 @@ class EvaluateRealDouble : public EvaluateDouble<RealDouble>
 
 class EvaluateComplexDouble : public EvaluateDouble<ComplexDouble>
 {
-    virtual RCP<const Basic> gamma(const Basic &x) const override
+    RCP<const Basic> gamma(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         throw NotImplementedError("Not Implemented.");
     }
-    virtual RCP<const Basic> asin(const Basic &x) const override
+    RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::asin(down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> acos(const Basic &x) const override
+    RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::acos(down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> acsc(const Basic &x) const override
+    RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::asin(1.0 / down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> asec(const Basic &x) const override
+    RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::acos(1.0 / down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> acosh(const Basic &x) const override
+    RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::acosh(down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> atanh(const Basic &x) const override
+    RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::atanh(down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> acoth(const Basic &x) const override
+    RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::atanh(1.0 / down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> asech(const Basic &x) const override
+    RCP<const Basic> asech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::acosh(1.0 / down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> log(const Basic &x) const override
+    RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         return number(std::log(down_cast<const ComplexDouble &>(x).i));
     }
-    virtual RCP<const Basic> floor(const Basic &x) const override
+    RCP<const Basic> floor(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         integer_class re, im;
@@ -342,7 +342,7 @@ class EvaluateComplexDouble : public EvaluateDouble<ComplexDouble>
         return Complex::from_two_nums(*integer(std::move(re)),
                                       *integer(std::move(im)));
     }
-    virtual RCP<const Basic> ceiling(const Basic &x) const override
+    RCP<const Basic> ceiling(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         integer_class re, im;
@@ -351,7 +351,7 @@ class EvaluateComplexDouble : public EvaluateDouble<ComplexDouble>
         return Complex::from_two_nums(*integer(std::move(re)),
                                       *integer(std::move(im)));
     }
-    virtual RCP<const Basic> truncate(const Basic &x) const override
+    RCP<const Basic> truncate(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         integer_class re, im;
@@ -360,12 +360,12 @@ class EvaluateComplexDouble : public EvaluateDouble<ComplexDouble>
         return Complex::from_two_nums(*integer(std::move(re)),
                                       *integer(std::move(im)));
     }
-    virtual RCP<const Basic> erf(const Basic &x) const override
+    RCP<const Basic> erf(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         throw NotImplementedError("erf is not implemented for Complex numbers");
     }
-    virtual RCP<const Basic> erfc(const Basic &x) const override
+    RCP<const Basic> erfc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<ComplexDouble>(x))
         throw NotImplementedError(

--- a/symengine/real_double.h
+++ b/symengine/real_double.h
@@ -26,20 +26,20 @@ public:
     //! Constructor of RealDouble class
     explicit RealDouble(double i);
     //! \return size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     //! \return `true` if positive
-    inline virtual bool is_positive() const
+    inline bool is_positive() const override
     {
         return i > 0;
     }
     //! \return `true` if negative
-    inline virtual bool is_negative() const
+    inline bool is_negative() const override
     {
         return i < 0;
     }
@@ -49,33 +49,33 @@ public:
         return i;
     }
     //! \return `true` if this number is an exact number
-    inline virtual bool is_exact() const
+    inline bool is_exact() const override
     {
         return false;
     }
     //! Get `Evaluate` singleton to evaluate numerically
-    virtual Evaluate &get_eval() const;
+    Evaluate &get_eval() const override;
 
     //! \return `true` when equals to 0
-    virtual bool is_zero() const
+    bool is_zero() const override
     {
         return this->i == 0.0;
     }
     //! \return `false`
     // A double is not exactly equal to `1`
-    virtual bool is_one() const
+    bool is_one() const override
     {
         return false;
     }
     //! \return `false`
     // A double is not exactly equal to `-1`
-    virtual bool is_minus_one() const
+    bool is_minus_one() const override
     {
         return false;
     }
     //! \returns `false`
     // False is returned because a RealDouble cannot have a imaginary part
-    virtual bool is_complex() const
+    bool is_complex() const override
     {
         return false;
     }
@@ -117,7 +117,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `addreal`
-    virtual RCP<const Number> add(const Number &other) const
+    RCP<const Number> add(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return addreal(down_cast<const Rational &>(other));
@@ -169,7 +169,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `subreal`
-    virtual RCP<const Number> sub(const Number &other) const
+    RCP<const Number> sub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return subreal(down_cast<const Rational &>(other));
@@ -213,7 +213,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `subreal`
-    virtual RCP<const Number> rsub(const Number &other) const
+    RCP<const Number> rsub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rsubreal(down_cast<const Rational &>(other));
@@ -266,7 +266,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `mulreal`
-    virtual RCP<const Number> mul(const Number &other) const
+    RCP<const Number> mul(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return mulreal(down_cast<const Rational &>(other));
@@ -318,7 +318,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `divreal`
-    virtual RCP<const Number> div(const Number &other) const
+    RCP<const Number> div(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return divreal(down_cast<const Rational &>(other));
@@ -362,7 +362,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `divreal`
-    virtual RCP<const Number> rdiv(const Number &other) const
+    RCP<const Number> rdiv(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rdivreal(down_cast<const Rational &>(other));
@@ -419,7 +419,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `powreal`
-    virtual RCP<const Number> pow(const Number &other) const
+    RCP<const Number> pow(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return powreal(down_cast<const Rational &>(other));
@@ -471,7 +471,7 @@ public:
     }
 
     //! Converts the param `other` appropriately and then calls `powreal`
-    virtual RCP<const Number> rpow(const Number &other) const
+    RCP<const Number> rpow(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rpowreal(down_cast<const Rational &>(other));

--- a/symengine/real_mpfr.cpp
+++ b/symengine/real_mpfr.cpp
@@ -696,7 +696,7 @@ RCP<const Number> RealMPFR::rpowreal(const ComplexDouble &other) const
 //! Evaluate functions with double precision
 class EvaluateMPFR : public Evaluate
 {
-    virtual RCP<const Basic> sin(const Basic &x) const override
+    RCP<const Basic> sin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -704,7 +704,7 @@ class EvaluateMPFR : public Evaluate
                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> cos(const Basic &x) const override
+    RCP<const Basic> cos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -712,7 +712,7 @@ class EvaluateMPFR : public Evaluate
                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> tan(const Basic &x) const override
+    RCP<const Basic> tan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -720,7 +720,7 @@ class EvaluateMPFR : public Evaluate
                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> cot(const Basic &x) const override
+    RCP<const Basic> cot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -728,7 +728,7 @@ class EvaluateMPFR : public Evaluate
                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> sec(const Basic &x) const override
+    RCP<const Basic> sec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -736,7 +736,7 @@ class EvaluateMPFR : public Evaluate
                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> csc(const Basic &x) const override
+    RCP<const Basic> csc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -744,7 +744,7 @@ class EvaluateMPFR : public Evaluate
                  MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> asin(const Basic &x) const override
+    RCP<const Basic> asin(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -763,7 +763,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> acos(const Basic &x) const override
+    RCP<const Basic> acos(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -782,7 +782,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> atan(const Basic &x) const override
+    RCP<const Basic> atan(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -790,7 +790,7 @@ class EvaluateMPFR : public Evaluate
                   MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> acot(const Basic &x) const override
+    RCP<const Basic> acot(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -799,7 +799,7 @@ class EvaluateMPFR : public Evaluate
         mpfr_atan(t.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> asec(const Basic &x) const override
+    RCP<const Basic> asec(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -820,7 +820,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> acsc(const Basic &x) const override
+    RCP<const Basic> acsc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -841,7 +841,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> sinh(const Basic &x) const override
+    RCP<const Basic> sinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -849,7 +849,7 @@ class EvaluateMPFR : public Evaluate
                   MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> csch(const Basic &x) const override
+    RCP<const Basic> csch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -857,7 +857,7 @@ class EvaluateMPFR : public Evaluate
                   MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> cosh(const Basic &x) const override
+    RCP<const Basic> cosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -865,7 +865,7 @@ class EvaluateMPFR : public Evaluate
                   MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> sech(const Basic &x) const override
+    RCP<const Basic> sech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -873,7 +873,7 @@ class EvaluateMPFR : public Evaluate
                   MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> tanh(const Basic &x) const override
+    RCP<const Basic> tanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -881,7 +881,7 @@ class EvaluateMPFR : public Evaluate
                   MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> coth(const Basic &x) const override
+    RCP<const Basic> coth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -889,7 +889,7 @@ class EvaluateMPFR : public Evaluate
                   MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> asinh(const Basic &x) const override
+    RCP<const Basic> asinh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -897,7 +897,7 @@ class EvaluateMPFR : public Evaluate
                    down_cast<const RealMPFR &>(x).i.get_mpfr_t(), MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> acsch(const Basic &x) const override
+    RCP<const Basic> acsch(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -906,7 +906,7 @@ class EvaluateMPFR : public Evaluate
         mpfr_asinh(t.get_mpfr_t(), t.get_mpfr_t(), MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> acosh(const Basic &x) const override
+    RCP<const Basic> acosh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -925,7 +925,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> atanh(const Basic &x) const override
+    RCP<const Basic> atanh(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -944,7 +944,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> acoth(const Basic &x) const override
+    RCP<const Basic> acoth(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -965,7 +965,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> asech(const Basic &x) const override
+    RCP<const Basic> asech(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -986,7 +986,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> log(const Basic &x) const override
+    RCP<const Basic> log(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -1005,7 +1005,7 @@ class EvaluateMPFR : public Evaluate
             "Result is complex. Recompile with MPC support.");
 #endif
     }
-    virtual RCP<const Basic> abs(const Basic &x) const override
+    RCP<const Basic> abs(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_class t(down_cast<const RealMPFR &>(x).i.get_prec());
@@ -1014,7 +1014,7 @@ class EvaluateMPFR : public Evaluate
         return real_mpfr(std::move(t));
     }
 
-    virtual RCP<const Basic> gamma(const Basic &x) const override
+    RCP<const Basic> gamma(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -1026,7 +1026,7 @@ class EvaluateMPFR : public Evaluate
             throw NotImplementedError("Not Implemented.");
         }
     }
-    virtual RCP<const Basic> exp(const Basic &x) const override
+    RCP<const Basic> exp(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -1034,7 +1034,7 @@ class EvaluateMPFR : public Evaluate
         mpfr_exp(t.get_mpfr_t(), x_, MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> floor(const Basic &x) const override
+    RCP<const Basic> floor(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -1043,7 +1043,7 @@ class EvaluateMPFR : public Evaluate
         mp_demote(i);
         return integer(std::move(i));
     }
-    virtual RCP<const Basic> ceiling(const Basic &x) const override
+    RCP<const Basic> ceiling(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -1052,7 +1052,7 @@ class EvaluateMPFR : public Evaluate
         mp_demote(i);
         return integer(std::move(i));
     }
-    virtual RCP<const Basic> truncate(const Basic &x) const override
+    RCP<const Basic> truncate(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -1061,7 +1061,7 @@ class EvaluateMPFR : public Evaluate
         mp_demote(i);
         return integer(std::move(i));
     }
-    virtual RCP<const Basic> erf(const Basic &x) const override
+    RCP<const Basic> erf(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();
@@ -1069,7 +1069,7 @@ class EvaluateMPFR : public Evaluate
         mpfr_erf(t.get_mpfr_t(), x_, MPFR_RNDN);
         return real_mpfr(std::move(t));
     }
-    virtual RCP<const Basic> erfc(const Basic &x) const override
+    RCP<const Basic> erfc(const Basic &x) const override
     {
         SYMENGINE_ASSERT(is_a<RealMPFR>(x))
         mpfr_srcptr x_ = down_cast<const RealMPFR &>(x).i.get_mpfr_t();

--- a/symengine/real_mpfr.h
+++ b/symengine/real_mpfr.h
@@ -99,51 +99,51 @@ public:
         return mpfr_get_prec(i.get_mpfr_t());
     }
     //! \return size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     //! \return `true` if positive
-    inline virtual bool is_positive() const
+    inline bool is_positive() const override
     {
         return mpfr_cmp_si(i.get_mpfr_t(), 0) > 0;
     }
     //! \return `true` if negative
-    inline virtual bool is_negative() const
+    inline bool is_negative() const override
     {
         return mpfr_cmp_si(i.get_mpfr_t(), 0) < 0;
     }
     //! \return `true` if this number is an exact number
-    inline virtual bool is_exact() const
+    inline bool is_exact() const override
     {
         return false;
     }
     //! Get `Evaluate` singleton to evaluate numerically
-    virtual Evaluate &get_eval() const;
+    Evaluate &get_eval() const override;
 
     //! \return if equal to `0`
-    virtual bool is_zero() const
+    bool is_zero() const override
     {
         return mpfr_cmp_si(i.get_mpfr_t(), 0) == 0;
     }
     //! \return `false`
     // A mpfr_t is not exactly equal to `1`
-    virtual bool is_one() const
+    bool is_one() const override
     {
         return false;
     }
     //! \return `false`
     // A mpfr_t is not exactly equal to `-1`
-    virtual bool is_minus_one() const
+    bool is_minus_one() const override
     {
         return false;
     }
     //! \returns `false`
     // False is returned because an 'mpfr' cannot have an imaginary part
-    virtual bool is_complex() const
+    bool is_complex() const override
     {
         return false;
     }
@@ -159,7 +159,7 @@ public:
     RCP<const Number> addreal(const RealMPFR &other) const;
 
     //! Converts the param `other` appropriately and then calls `addreal`
-    virtual RCP<const Number> add(const Number &other) const
+    RCP<const Number> add(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return addreal(down_cast<const Rational &>(other));
@@ -186,7 +186,7 @@ public:
     RCP<const Number> subreal(const RealMPFR &other) const;
 
     //! Converts the param `other` appropriately and then calls `subreal`
-    virtual RCP<const Number> sub(const Number &other) const
+    RCP<const Number> sub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return subreal(down_cast<const Rational &>(other));
@@ -212,7 +212,7 @@ public:
     RCP<const Number> rsubreal(const ComplexDouble &other) const;
 
     //! Converts the param `other` appropriately and then calls `subreal`
-    virtual RCP<const Number> rsub(const Number &other) const
+    RCP<const Number> rsub(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rsubreal(down_cast<const Rational &>(other));
@@ -237,7 +237,7 @@ public:
     RCP<const Number> mulreal(const RealMPFR &other) const;
 
     //! Converts the param `other` appropriately and then calls `mulreal`
-    virtual RCP<const Number> mul(const Number &other) const
+    RCP<const Number> mul(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return mulreal(down_cast<const Rational &>(other));
@@ -264,7 +264,7 @@ public:
     RCP<const Number> divreal(const RealMPFR &other) const;
 
     //! Converts the param `other` appropriately and then calls `divreal`
-    virtual RCP<const Number> div(const Number &other) const
+    RCP<const Number> div(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return divreal(down_cast<const Rational &>(other));
@@ -290,7 +290,7 @@ public:
     RCP<const Number> rdivreal(const ComplexDouble &other) const;
 
     //! Converts the param `other` appropriately and then calls `divreal`
-    virtual RCP<const Number> rdiv(const Number &other) const
+    RCP<const Number> rdiv(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rdivreal(down_cast<const Rational &>(other));
@@ -315,7 +315,7 @@ public:
     RCP<const Number> powreal(const RealMPFR &other) const;
 
     //! Converts the param `other` appropriately and then calls `powreal`
-    virtual RCP<const Number> pow(const Number &other) const
+    RCP<const Number> pow(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return powreal(down_cast<const Rational &>(other));
@@ -341,7 +341,7 @@ public:
     RCP<const Number> rpowreal(const ComplexDouble &other) const;
 
     //! Converts the param `other` appropriately and then calls `powreal`
-    virtual RCP<const Number> rpow(const Number &other) const
+    RCP<const Number> rpow(const Number &other) const override
     {
         if (is_a<Rational>(other)) {
             return rpowreal(down_cast<const Rational &>(other));

--- a/symengine/series.h
+++ b/symengine/series.h
@@ -37,12 +37,12 @@ public:
         : p_(std::move(p)), var_(var), degree_(degree)
     {
     }
-    inline virtual unsigned get_degree() const
+    inline unsigned get_degree() const override
     {
         return degree_;
     }
 
-    inline virtual const std::string &get_var() const
+    inline const std::string &get_var() const override
     {
         return var_;
     }
@@ -52,44 +52,44 @@ public:
         return p_;
     }
 
-    inline virtual bool is_zero() const
+    inline bool is_zero() const override
     {
         return false;
     }
 
-    inline virtual bool is_one() const
+    inline bool is_one() const override
     {
         return false;
     }
 
-    inline virtual bool is_minus_one() const
+    inline bool is_minus_one() const override
     {
         return false;
     }
 
-    inline virtual bool is_negative() const
+    inline bool is_negative() const override
     {
         return false;
     }
 
-    inline virtual bool is_positive() const
+    inline bool is_positive() const override
     {
         return false;
     }
 
-    inline virtual bool is_complex() const
+    inline bool is_complex() const override
     {
         return false;
     }
 
-    inline virtual bool __eq__(const Basic &o) const
+    inline bool __eq__(const Basic &o) const override
     {
         return (is_a<Series>(o) and var_ == down_cast<const Series &>(o).var_
                 and p_ == down_cast<const Series &>(o).p_
                 and degree_ == down_cast<const Series &>(o).degree_);
     }
 
-    virtual RCP<const Number> add(const Number &other) const
+    RCP<const Number> add(const Number &other) const override
     {
         if (is_a<Series>(other)) {
             const Series &o = down_cast<const Series &>(other);
@@ -107,7 +107,7 @@ public:
         }
     }
 
-    virtual RCP<const Number> mul(const Number &other) const
+    RCP<const Number> mul(const Number &other) const override
     {
         if (is_a<Series>(other)) {
             const Series &o = down_cast<const Series &>(other);
@@ -125,7 +125,7 @@ public:
         }
     }
 
-    virtual RCP<const Number> pow(const Number &other) const
+    RCP<const Number> pow(const Number &other) const override
     {
         auto deg = degree_;
         Poly p;
@@ -163,7 +163,7 @@ public:
         return make_rcp<Series>(p, var_, deg);
     }
 
-    virtual RCP<const Number> rpow(const Number &other) const
+    RCP<const Number> rpow(const Number &other) const override
     {
         if (other.get_type_code() < Series::type_code_id) {
             Poly p = Series::series(other.rcp_from_this(), var_, degree_)->p_;

--- a/symengine/series_flint.h
+++ b/symengine/series_flint.h
@@ -20,11 +20,11 @@ public:
     URatPSeriesFlint(const fqp_t p, const std::string varname,
                      const unsigned degree);
     IMPLEMENT_TYPEID(SYMENGINE_URATPSERIESFLINT)
-    virtual int compare(const Basic &o) const;
-    virtual hash_t __hash__() const;
-    virtual RCP<const Basic> as_basic() const;
-    virtual umap_int_basic as_dict() const;
-    virtual RCP<const Basic> get_coeff(int) const;
+    int compare(const Basic &o) const override;
+    hash_t __hash__() const override;
+    RCP<const Basic> as_basic() const override;
+    umap_int_basic as_dict() const override;
+    RCP<const Basic> get_coeff(int) const override;
 
     static RCP<const URatPSeriesFlint>
     series(const RCP<const Basic> &t, const std::string &x, unsigned int prec);

--- a/symengine/series_generic.h
+++ b/symengine/series_generic.h
@@ -39,12 +39,12 @@ public:
 
     static RCP<const UnivariateSeries>
     series(const RCP<const Basic> &t, const std::string &x, unsigned int prec);
-    virtual hash_t __hash__() const;
-    virtual int compare(const Basic &o) const;
+    hash_t __hash__() const override;
+    int compare(const Basic &o) const override;
     bool operator==(const UnivariateSeries &u) const;
-    virtual RCP<const Basic> as_basic() const;
-    virtual umap_int_basic as_dict() const;
-    virtual RCP<const Basic> get_coeff(int) const;
+    RCP<const Basic> as_basic() const override;
+    umap_int_basic as_dict() const override;
+    RCP<const Basic> get_coeff(int) const override;
     static UExprDict var(const std::string &s);
 
     static Expression convert(const Basic &x);

--- a/symengine/sets.h
+++ b/symengine/sets.h
@@ -25,7 +25,7 @@ typedef std::set<RCP<const Set>, RCPBasicKeyLess> set_set;
 class Set : public Basic
 {
 public:
-    virtual vec_basic get_args() const = 0;
+    vec_basic get_args() const override = 0;
     virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const = 0;
     virtual RCP<const Set> set_union(const RCP<const Set> &o) const = 0;
     virtual RCP<const Set> set_complement(const RCP<const Set> &o) const = 0;
@@ -59,10 +59,10 @@ public:
         operator=(EmptySet const &)
         = delete;
     const static RCP<const EmptySet> &getInstance();
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -70,10 +70,10 @@ public:
     template <typename T_, typename... Args>
     friend inline RCP<T_> make_rcp(Args &&...args);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override
     {
         return boolean(false);
     };
@@ -92,10 +92,10 @@ public:
     // UniversalSet(UniversalSet const&) = delete;
     void operator=(UniversalSet const &) = delete;
     const static RCP<const UniversalSet> &getInstance();
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -103,10 +103,10 @@ public:
     template <typename T_, typename... Args>
     friend inline RCP<T_> make_rcp(Args &&...args);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override
     {
         return boolean(true);
     };
@@ -119,10 +119,10 @@ private:
 
 public:
     IMPLEMENT_TYPEID(SYMENGINE_FINITESET)
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return vec_basic(container_.begin(), container_.end());
     }
@@ -130,10 +130,10 @@ public:
     FiniteSet(const set_basic &container);
     static bool is_canonical(const set_basic &container);
 
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
     RCP<const Set> create(const set_basic &container) const;
 
     inline const set_basic &get_container() const
@@ -151,9 +151,9 @@ private:
 
 public:
     IMPLEMENT_TYPEID(SYMENGINE_INTERVAL)
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
 
     Interval(const RCP<const Number> &start, const RCP<const Number> &end,
              const bool left_open = false, const bool right_open = false);
@@ -167,11 +167,11 @@ public:
                              const RCP<const Number> &end, bool left_open,
                              bool right_open);
 
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
-    virtual vec_basic get_args() const;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
+    vec_basic get_args() const override;
 
     inline const RCP<const Number> &get_start() const
     {
@@ -203,10 +203,10 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_COMPLEXES)
     void operator=(Complexes const &) = delete;
     const static RCP<const Complexes> &getInstance();
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -214,10 +214,10 @@ public:
     template <typename T_, typename... Args>
     friend inline RCP<T_> make_rcp(Args &&...args);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 };
 
 class Reals : public Set
@@ -232,10 +232,10 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_REALS)
     void operator=(Reals const &) = delete;
     const static RCP<const Reals> &getInstance();
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -243,10 +243,10 @@ public:
     template <typename T_, typename... Args>
     friend inline RCP<T_> make_rcp(Args &&...args);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 };
 
 class Rationals : public Set
@@ -261,10 +261,10 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_RATIONALS)
     void operator=(Rationals const &) = delete;
     const static RCP<const Rationals> &getInstance();
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -272,10 +272,10 @@ public:
     template <typename T_, typename... Args>
     friend inline RCP<T_> make_rcp(Args &&...args);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 };
 
 class Integers : public Set
@@ -290,10 +290,10 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_INTEGERS)
     void operator=(Integers const &) = delete;
     const static RCP<const Integers> &getInstance();
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -301,10 +301,10 @@ public:
     template <typename T_, typename... Args>
     friend inline RCP<T_> make_rcp(Args &&...args);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 };
 
 class Naturals : public Set
@@ -319,10 +319,10 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_NATURALS)
     void operator=(Naturals const &) = delete;
     const static RCP<const Naturals> &getInstance();
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -330,10 +330,10 @@ public:
     template <typename T_, typename... Args>
     friend inline RCP<T_> make_rcp(Args &&...args);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 };
 
 class Naturals0 : public Set
@@ -348,10 +348,10 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_NATURALS0)
     void operator=(Naturals0 const &) = delete;
     const static RCP<const Naturals0> &getInstance();
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -359,10 +359,10 @@ public:
     template <typename T_, typename... Args>
     friend inline RCP<T_> make_rcp(Args &&...args);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 };
 
 class Union : public Set
@@ -372,17 +372,17 @@ private:
 
 public:
     IMPLEMENT_TYPEID(SYMENGINE_UNION)
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const;
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override;
     Union(const set_set &in);
     static bool is_canonical(const set_set &in);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 
     inline const set_set &get_container() const
     {
@@ -399,17 +399,17 @@ private:
 
 public:
     IMPLEMENT_TYPEID(SYMENGINE_INTERSECTION)
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const;
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override;
     Intersection(const set_set &in);
     static bool is_canonical(const set_set &in);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 
     inline const set_set &get_container() const
     {
@@ -428,19 +428,19 @@ private:
 
 public:
     IMPLEMENT_TYPEID(SYMENGINE_COMPLEMENT)
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {universe_, container_};
     }
     Complement(const RCP<const Set> &universe, const RCP<const Set> &container);
 
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 
     inline const RCP<const Set> &get_universe() const
     {
@@ -460,10 +460,10 @@ private:
 
 public:
     IMPLEMENT_TYPEID(SYMENGINE_CONDITIONSET)
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {sym, condition_};
     }
@@ -471,10 +471,10 @@ public:
                  const RCP<const Boolean> &condition);
     static bool is_canonical(const RCP<const Basic> &sym,
                              const RCP<const Boolean> &condition);
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
     inline const RCP<const Basic> &get_symbol() const
     {
         return this->sym;
@@ -495,10 +495,10 @@ private:
 
 public:
     IMPLEMENT_TYPEID(SYMENGINE_IMAGESET)
-    virtual hash_t __hash__() const;
-    virtual bool __eq__(const Basic &o) const;
-    virtual int compare(const Basic &o) const;
-    virtual vec_basic get_args() const
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
+    vec_basic get_args() const override
     {
         return {sym_, expr_, base_};
     }
@@ -508,10 +508,10 @@ public:
     static bool is_canonical(const RCP<const Basic> &sym,
                              const RCP<const Basic> &expr,
                              const RCP<const Set> &base);
-    virtual RCP<const Set> set_intersection(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_union(const RCP<const Set> &o) const;
-    virtual RCP<const Set> set_complement(const RCP<const Set> &o) const;
-    virtual RCP<const Boolean> contains(const RCP<const Basic> &a) const;
+    RCP<const Set> set_intersection(const RCP<const Set> &o) const override;
+    RCP<const Set> set_union(const RCP<const Set> &o) const override;
+    RCP<const Set> set_complement(const RCP<const Set> &o) const override;
+    RCP<const Boolean> contains(const RCP<const Basic> &a) const override;
 
     inline const RCP<const Basic> &get_symbol() const
     {

--- a/symengine/symbol.h
+++ b/symengine/symbol.h
@@ -22,25 +22,25 @@ public:
     //! Symbol Constructor
     explicit Symbol(const std::string &name);
     //! \return Size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
 
     /*! Comparison operator
      * \param o - Object to be compared with
      * \return `0` if equal, `-1` , `1` according to string compare
      * */
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
     //! \return name of the Symbol.
     inline const std::string &get_name() const
     {
         return name_;
     }
 
-    virtual vec_basic get_args() const
+    vec_basic get_args() const override
     {
         return {};
     }
@@ -61,17 +61,17 @@ public:
     explicit Dummy();
     explicit Dummy(const std::string &name);
     //! \return Size of the hash
-    virtual hash_t __hash__() const;
+    hash_t __hash__() const override;
     /*! Equality comparator
      * \param o - Object to be compared with
      * \return whether the 2 objects are equal
      * */
-    virtual bool __eq__(const Basic &o) const;
+    bool __eq__(const Basic &o) const override;
     /*! Comparison operator
      * \param o - Object to be compared with
      * \return `0` if equal, `-1` , `1` according to string compare
      * */
-    virtual int compare(const Basic &o) const;
+    int compare(const Basic &o) const override;
     size_t get_index() const
     {
         return dummy_index;

--- a/symengine/symengine_exception.h
+++ b/symengine/symengine_exception.h
@@ -41,7 +41,7 @@ public:
         : SymEngineException(msg, SYMENGINE_RUNTIME_ERROR)
     {
     }
-    const char *what() const throw()
+    const char *what() const throw() override
     {
         return m_msg.c_str();
     }

--- a/symengine/tuple.h
+++ b/symengine/tuple.h
@@ -15,12 +15,12 @@ public:
     IMPLEMENT_TYPEID(SYMENGINE_TUPLE)
     Tuple(const vec_basic &container);
 
-    hash_t __hash__() const;
-    bool __eq__(const Basic &o) const;
-    int compare(const Basic &o) const;
+    hash_t __hash__() const override;
+    bool __eq__(const Basic &o) const override;
+    int compare(const Basic &o) const override;
     static bool is_canonical(const vec_basic &container);
 
-    virtual vec_basic get_args() const
+    vec_basic get_args() const override
     {
         return vec_basic(container_.begin(), container_.end());
     }


### PR DESCRIPTION
as recommended here:
- https://rules.sonarsource.com/cpp/RSPEC-3471
- https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final

Mostly automatic changes from the clang-tidy check `modernize-use-override`, plus a manual change (https://github.com/symengine/symengine/commit/3d43d66f5cde057823864c4b7613790b5acfaafe) of the SYMENGINE_INCLUDE_METHODS macro to use `virtual` in base classes and `override` in derived classes 