### PR TITLE
Actually use primesieve when enabled

### DIFF
--- a/symengine/prime_sieve.h
+++ b/symengine/prime_sieve.h
@@ -2,6 +2,7 @@
 #define SYMENGINE_PRIME_SIEVE_H
 
 #include <vector>
+#include <symengine/symengine_config.h>
 
 // Sieve class stores all the primes upto a limit. When a prime or a list of
 // prime


### PR DESCRIPTION
Add the missing include for the config file where the macro that enables primesieve is defined