### PR TITLE
use new llvm pass manager instead of legacy pass manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
             WITH_LATEST_GCC: yes
             WITH_COVERAGE: yes
             WITH_MPC: yes
-            WITH_LLVM: 12
             USE_GLIBCXX_DEBUG: yes
             OS: ubuntu-22.04
             CC: gcc
@@ -145,7 +144,7 @@ jobs:
             OS: ubuntu-22.04
 
           - BUILD_TYPE: Debug
-            WITH_LLVM: 3.8
+            WITH_LLVM: 5.0
             OS: macos-latest
             CC: clang
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
           - BUILD_TYPE: Debug
             WITH_BFD: yes
             WITH_LLVM: 12
+            WITH_COVERAGE: yes
             CC: clang
             OS: ubuntu-20.04
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,9 +406,9 @@ set(WITH_LLVM no
     CACHE BOOL "Build with LLVM")
 
 if (WITH_LLVM)
-    set(SYMENGINE_LLVM_COMPONENTS asmparser core executionengine instcombine mcjit native nativecodegen scalaropts vectorize support transformutils)
+    set(SYMENGINE_LLVM_COMPONENTS asmparser core executionengine instcombine mcjit native nativecodegen scalaropts vectorize support transformutils passes)
     find_package(LLVM REQUIRED ${SYMENGINE_LLVM_COMPONENTS})
-    set(LLVM_MINIMUM_REQUIRED_VERSION "3.8")
+    set(LLVM_MINIMUM_REQUIRED_VERSION "4.0")
     if (LLVM_PACKAGE_VERSION LESS ${LLVM_MINIMUM_REQUIRED_VERSION})
 	    message(FATAL_ERROR "LLVM version found ${LLVM_PACKAGE_VERSION} is too old.
                              Require at least ${LLVM_MINIMUM_REQUIRED_VERSION}")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ install:
 - if [%COMPILER%]==[MSVC15] if [%BUILD_TYPE%]==[Debug] set "conda_pkgs=symengine/label/debug::mpir=3.0.0"
 - if [%COMPILER%]==[MSVC15] if [%WITH_MPFR%]==[yes] set "conda_pkgs=%conda_pkgs% conda-forge::mpfr=3.1.5"
 - if [%COMPILER%]==[MSVC15] if [%WITH_MPC%]==[yes] set "conda_pkgs=%conda_pkgs% conda-forge::mpc=1.0.3"
-- if [%COMPILER%]==[MSVC15] if [%WITH_LLVM%]==[yes] set "conda_pkgs=%conda_pkgs% conda-forge::llvmdev=3.9"
+- if [%COMPILER%]==[MSVC15] if [%WITH_LLVM%]==[yes] set "conda_pkgs=%conda_pkgs% conda-forge::llvmdev=4.0"
 - if [%COMPILER%]==[MSVC15] conda create --yes -n myenv %conda_pkgs%
 - if [%COMPILER%]==[MSVC15] call activate myenv
 - if [%COMPILER%]==[MSVC15] if [%LIB_TYPE%]==[lib] rm %CONDA_PREFIX%\Library\lib\gmp.lib

--- a/benchmarks/visitor_init.cpp
+++ b/benchmarks/visitor_init.cpp
@@ -17,5 +17,4 @@ static void Init(benchmark::State &state)
 }
 
 SYMENGINE_BENCHMARK_VISITORS(Init);
-
 BENCHMARK_MAIN();

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -18,10 +18,6 @@ class ExecutionEngine;
 class MemoryBufferRef;
 class LLVMContext;
 class Pass;
-namespace legacy
-{
-class FunctionPassManager;
-}
 } // namespace llvm
 
 namespace SymEngine
@@ -39,7 +35,7 @@ protected:
     llvm::Value *result_;
     std::shared_ptr<llvm::LLVMContext> context;
     std::shared_ptr<llvm::ExecutionEngine> executionengine;
-    std::shared_ptr<llvm::legacy::FunctionPassManager> fpm;
+
     intptr_t func;
 
     // Following are invalid after the init call.
@@ -53,15 +49,8 @@ public:
     llvm::Value *apply(const Basic &b);
     void init(const vec_basic &x, const Basic &b,
               const bool symbolic_cse = false, unsigned opt_level = 3);
-    void init(const vec_basic &x, const Basic &b, const bool symbolic_cse,
-              const std::vector<llvm::Pass *> &passes, unsigned opt_level = 3);
     void init(const vec_basic &inputs, const vec_basic &outputs,
               const bool symbolic_cse = false, unsigned opt_level = 3);
-    void init(const vec_basic &inputs, const vec_basic &outputs,
-              const bool symbolic_cse, const std::vector<llvm::Pass *> &passes,
-              unsigned opt_level = 3);
-
-    static std::vector<llvm::Pass *> create_default_passes(int optlevel);
 
     // Helper functions
     void set_double(double d);

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -17,7 +17,6 @@ class Function;
 class ExecutionEngine;
 class MemoryBufferRef;
 class LLVMContext;
-class Pass;
 } // namespace llvm
 
 namespace SymEngine

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -523,8 +523,7 @@ TEST_CASE("Check that our default LLVM passes give correct results",
     v.init({x, y, z}, *r);
     LLVMDoubleVisitor v2;
     for (int opt_level = 0; opt_level < 4; ++opt_level) {
-        v2.init({x, y, z}, *r, false,
-                LLVMDoubleVisitor::create_default_passes(opt_level), opt_level);
+        v2.init({x, y, z}, *r, false, opt_level);
         d = v.call({0.4, 2.0, 3.0});
         d2 = v2.call({0.4, 2.0, 3.0});
         // Check for 12 digits with doubles


### PR DESCRIPTION
motivation: https://llvm.org/docs/NewPassManager.html#status-of-the-new-and-legacy-pass-managers

- use `PassBuilder` default `-O0`, `-O1`, ... passes instead of manually specifying passes
- remove `LLVMVisitor::init()` overloads with explicit list of passes
- add `passes` to SYMENGINE_LLVM_COMPONENTS in CMakeLists
- increase minimum required llvm version to 4.0
- remove llvm from USE_GLIBCXX_DEBUG ci job
  - using debug libstdc++ changes the ABI: https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode_using.html
  - but llvm library is not compiled against debug libstdc++
  - new pass manager passes a vector between debug and non-debug translation units -> crash