### PR TITLE
Check that INTEGER_CLASS=boostmp is not used with FLINT, ARB or MPFR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,12 @@ if (WITH_VIRTUAL_TYPEID)
     set(WITH_SYMENGINE_VIRTUAL_TYPEID True)
 endif()
 
+if (SYMENGINE_INTEGER_CLASS STREQUAL "BOOSTMP")
+    if (WITH_FLINT OR WITH_ARB OR WITH_MPFR)
+        message(FATAL_ERROR "INTEGER_CLASS=boostmp cannot be used with FLINT, ARB or MPFR")
+    endif()
+endif()
+
 # Parser
 set(WITH_GENERATE_PARSER no CACHE BOOL "Generate parser files")
 if (WITH_GENERATE_PARSER)


### PR DESCRIPTION
See https://github.com/symengine/symengine/issues/1969#issuecomment-1679076896

Fixes https://github.com/symengine/symengine/issues/1969 and https://github.com/symengine/symengine/issues/1970