### PR TITLE
Exposing the `has_symbol` function through cwrapper.h

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -30,6 +30,7 @@ using SymEngine::DenseMatrix;
 using SymEngine::down_cast;
 using SymEngine::function_symbol;
 using SymEngine::FunctionSymbol;
+using SymEngine::has_symbol;
 using SymEngine::Integer;
 using SymEngine::integer_class;
 using SymEngine::LambdaRealDoubleVisitor;
@@ -278,6 +279,12 @@ int number_is_complex(const basic s)
 {
     SYMENGINE_ASSERT(is_a_Number(*(s->m)));
     return (int)((down_cast<const Number &>(*(s->m))).is_complex());
+}
+
+int expression_has_symbol(const basic e, const basic s)
+{
+    //Should have a check for s being a symbol
+    return (int)(has_symbol(*(e->m), *(s->m)));
 }
 
 CWRAPPER_OUTPUT_TYPE integer_set_si(basic s, long i)

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -281,7 +281,7 @@ int number_is_complex(const basic s)
     return (int)((down_cast<const Number &>(*(s->m))).is_complex());
 }
 
-int expression_has_symbol(const basic e, const basic s)
+int basic_has_symbol(const basic e, const basic s)
 {
     //Should have a check for s being a symbol
     return (int)(has_symbol(*(e->m), *(s->m)));

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -283,7 +283,6 @@ int number_is_complex(const basic s)
 
 int basic_has_symbol(const basic e, const basic s)
 {
-    //Should have a check for s being a symbol
     return (int)(has_symbol(*(e->m), *(s->m)));
 }
 

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -168,6 +168,9 @@ int number_is_positive(const basic s);
 //! Returns 1 if s is complex; 0 otherwise
 int number_is_complex(const basic s);
 
+//! Returns 1 if `e` contains the symbol `s`; 0 otherwise
+int expression_has_symbol(const basic e, const basic s);
+
 //! Assign to s, a long.
 CWRAPPER_OUTPUT_TYPE integer_set_si(basic s, long i);
 //! Assign to s, a ulong.

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -169,7 +169,7 @@ int number_is_positive(const basic s);
 int number_is_complex(const basic s);
 
 //! Returns 1 if `e` contains the symbol `s`; 0 otherwise
-int expression_has_symbol(const basic e, const basic s);
+int basic_has_symbol(const basic e, const basic s);
 
 //! Assign to s, a long.
 CWRAPPER_OUTPUT_TYPE integer_set_si(basic s, long i);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -55,9 +55,21 @@ void test_cwrapper()
     basic_str_free(s);
 
     integer_set_ui(e, 456);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, x) == 0);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, y) == 0);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, z) == 0);
     basic_add(e, e, x);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, x) == 1);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, y) == 0);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, z) == 0);
     basic_mul(e, e, y);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, x) == 1);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, y) == 1);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, z) == 0);
     basic_div(e, e, z);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, x) == 1);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, y) == 1);
+    SYMENGINE_C_ASSERT(basic_has_symbol(e, z) == 1);
     s = basic_str(e);
     SYMENGINE_C_ASSERT(strcmp(s, "y*(456 + x)/z") == 0);
     basic_str_free(s);


### PR DESCRIPTION
This is a try to expose the `has_symbol` function through the cwrapper so that I could be used in my work for LPython to implement symbolic algorithms as a part of ASR (https://github.com/lcompilers/lpython/pull/2336)