### PR TITLE
Minor fix for SBML printing of piecewise function

### DIFF
--- a/symengine/printers/sbml.cpp
+++ b/symengine/printers/sbml.cpp
@@ -100,8 +100,10 @@ void SbmlPrinter::bvisit(const Piecewise &x)
     s << "piecewise(";
     while (it != vec.end()) {
         s << apply((*it).first);
-        s << ", ";
-        s << apply((*it).second);
+        if (!(it + 1 == vec.end() && eq(*(*it).second, *boolTrue))) {
+            s << ", ";
+            s << apply((*it).second);
+        }
         ++it;
         if (it != vec.end()) {
             s << ", ";

--- a/symengine/tests/basic/test_sbml_parser.cpp
+++ b/symengine/tests/basic/test_sbml_parser.cpp
@@ -460,8 +460,11 @@ TEST_CASE("Parsing: functions", "[sbml_parser]")
 
     s = "piecewise(x, x>0, 0)";
     res = parse_sbml(s);
+    s = sbml(*res);
     REQUIRE(eq(*res, *piecewise({{x, Gt(x, zero)}, {zero, boolTrue}})));
-    REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
+    REQUIRE(eq(*res, *parse_sbml(s)));
+    // check that printing doesn't add a "true" condition to the final 0 piece
+    REQUIRE(s.substr(s.size() - 2) == "0)");
 
     s = "piecewise(x, x>0, -x, x<=0)";
     res = parse_sbml(s);
@@ -471,10 +474,12 @@ TEST_CASE("Parsing: functions", "[sbml_parser]")
 
     s = "piecewise(x, x>0, -2*x, x<0, 6)";
     res = parse_sbml(s);
+    s = sbml(*res);
     REQUIRE(eq(*res, *piecewise({{x, Gt(x, zero)},
                                  {mul(integer(-2), x), Lt(x, zero)},
                                  {integer(6), boolTrue}})));
-    REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
+    REQUIRE(eq(*res, *parse_sbml(s)));
+    REQUIRE(s.substr(s.size() - 2) == "6)");
 
     s = "power(x, y)";
     res = parse_sbml(s);


### PR DESCRIPTION
- If the last piece condition is `true` then don't explicitly print this condition
- This doesn't change symengine behaviour (other than sbml printing)
  - Both forms are equivalent for the symengine sbml parser
- But it improves compatibility of the generated sbml string with the libSBML library
  - libSBML parser returns `NaN` if multiple explicit piece conditions evaluate to `true`
