### PR TITLE
Use `unique_ptr` for `llvm::LLVMContext` and `llvm::ExecutionEngine`

### DIFF
--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -51,6 +51,9 @@ class IRBuilder : public llvm::IRBuilder<>
 {
 };
 
+LLVMVisitor::LLVMVisitor() = default;
+LLVMVisitor::~LLVMVisitor() = default;
+
 llvm::Value *LLVMVisitor::apply(const Basic &b)
 {
     b.accept(*this);
@@ -126,7 +129,7 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
     llvm::InitializeNativeTargetAsmParser();
-    context = std::make_shared<llvm::LLVMContext>();
+    context = make_unique<llvm::LLVMContext>();
     symbols = inputs;
 
     // Create some module to put our function into it.
@@ -260,7 +263,7 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
 
     // Now we create the JIT.
     std::string error;
-    executionengine = std::shared_ptr<llvm::ExecutionEngine>(
+    executionengine = std::unique_ptr<llvm::ExecutionEngine>(
         llvm::EngineBuilder(std::move(module))
             .setEngineKind(llvm::EngineKind::Kind::JIT)
             .setOptLevel(static_cast<llvm::CodeGenOpt::Level>(opt_level))
@@ -301,6 +304,9 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
     symbols.clear();
 }
 
+LLVMDoubleVisitor::LLVMDoubleVisitor() = default;
+LLVMDoubleVisitor::~LLVMDoubleVisitor() = default;
+
 double LLVMDoubleVisitor::call(const std::vector<double> &vec) const
 {
     double ret;
@@ -330,6 +336,9 @@ void LLVMLongDoubleVisitor::call(long double *outs,
 }
 #endif
 
+LLVMFloatVisitor::LLVMFloatVisitor() = default;
+LLVMFloatVisitor::~LLVMFloatVisitor() = default;
+
 float LLVMFloatVisitor::call(const std::vector<float> &vec) const
 {
     float ret;
@@ -354,6 +363,10 @@ void LLVMVisitor::bvisit(const Integer &x)
 }
 
 #ifdef SYMENGINE_HAVE_LLVM_LONG_DOUBLE
+
+LLVMLongDoubleVisitor::LLVMLongDoubleVisitor() = default;
+LLVMLongDoubleVisitor::~LLVMLongDoubleVisitor() = default;
+
 void LLVMLongDoubleVisitor::convert_from_mpfr(const Basic &x)
 {
 #ifndef HAVE_SYMENGINE_MPFR
@@ -937,7 +950,7 @@ void LLVMVisitor::loads(const std::string &s)
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
     llvm::InitializeNativeTargetAsmParser();
-    context = std::make_shared<llvm::LLVMContext>();
+    context = make_unique<llvm::LLVMContext>();
 
     // Create some module to put our function into it.
     std::unique_ptr<llvm::Module> module
@@ -952,7 +965,7 @@ void LLVMVisitor::loads(const std::string &s)
     auto F = get_function_type(context.get());
 
     std::string error;
-    executionengine = std::shared_ptr<llvm::ExecutionEngine>(
+    executionengine = std::unique_ptr<llvm::ExecutionEngine>(
         llvm::EngineBuilder(std::move(module))
             .setEngineKind(llvm::EngineKind::Kind::JIT)
             .setOptLevel(llvm::CodeGenOpt::Level::Aggressive)

--- a/symengine/llvm_double.h
+++ b/symengine/llvm_double.h
@@ -32,8 +32,8 @@ protected:
     std::map<RCP<const Basic>, llvm::Value *, RCPBasicKeyLess>
         replacement_symbol_ptrs;
     llvm::Value *result_;
-    std::shared_ptr<llvm::LLVMContext> context;
-    std::shared_ptr<llvm::ExecutionEngine> executionengine;
+    std::unique_ptr<llvm::LLVMContext> context;
+    std::unique_ptr<llvm::ExecutionEngine> executionengine;
 
     intptr_t func;
 
@@ -45,6 +45,8 @@ protected:
     virtual llvm::Type *get_float_type(llvm::LLVMContext *) = 0;
 
 public:
+    LLVMVisitor();
+    ~LLVMVisitor() override;
     llvm::Value *apply(const Basic &b);
     void init(const vec_basic &x, const Basic &b,
               const bool symbolic_cse = false, unsigned opt_level = 3);
@@ -103,6 +105,8 @@ public:
 class LLVMDoubleVisitor : public LLVMVisitor
 {
 public:
+    LLVMDoubleVisitor();
+    ~LLVMDoubleVisitor() override;
     double call(const std::vector<double> &vec) const;
     void call(double *outs, const double *inps) const;
     llvm::Type *get_float_type(llvm::LLVMContext *) override;
@@ -126,6 +130,8 @@ public:
 class LLVMFloatVisitor : public LLVMVisitor
 {
 public:
+    LLVMFloatVisitor();
+    ~LLVMFloatVisitor() override;
     float call(const std::vector<float> &vec) const;
     void call(float *outs, const float *inps) const;
     llvm::Type *get_float_type(llvm::LLVMContext *) override;
@@ -151,6 +157,8 @@ public:
 class LLVMLongDoubleVisitor : public LLVMVisitor
 {
 public:
+    LLVMLongDoubleVisitor();
+    ~LLVMLongDoubleVisitor() override;
     long double call(const std::vector<long double> &vec) const;
     void call(long double *outs, const long double *inps) const;
     llvm::Type *get_float_type(llvm::LLVMContext *) override;


### PR DESCRIPTION
- this implicity disables the `LLVMVisitor` copy constructors
  - avoids segfault that occured if an initialized `LLVMVisitor` is copy assigned to
  - (segfault itself looks like it may be a bug in LLVM)
- define default constructor/destructor in cpp file to avoid "incomplete type" compilation error
- resolves #1994