### PR TITLE
Updated basic_free_stack to check if basic variable was stack allocated before freeing

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -128,11 +128,6 @@ void basic_new_stack(basic s)
 
 void basic_free_stack(basic s)
 {
-    s->m.~RCP();
-}
-
-void basic_free_stack_if_not_null(basic s)
-{
     if (s != nullptr) {
         s->m.~RCP();
     }

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -128,6 +128,12 @@ void basic_new_stack(basic s)
 
 void basic_free_stack(basic s)
 {
+    SYMENGINE_ASSERT(s != nullptr);
+    s->m.~RCP();
+}
+
+void basic_free_stack_if_not_null(basic s)
+{
     if (s != nullptr) {
         s->m.~RCP();
     }

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -131,6 +131,13 @@ void basic_free_stack(basic s)
     s->m.~RCP();
 }
 
+void basic_free_stack_if_not_null(basic s)
+{
+    if (s != nullptr) {
+        s->m.~RCP();
+    }
+}
+
 basic_struct *basic_new_heap()
 {
     return new CRCPBasic();

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -100,6 +100,8 @@ typedef basic_struct basic[1];
 void basic_new_stack(basic s);
 //! Free the C++ class wrapped by s.
 void basic_free_stack(basic s);
+//! Free the C++ class wrapped by s only if s is stack allocated.
+void basic_free_stack_if_not_null(basic s);
 
 // Use these two functions to allocate and free 'basic' on a heap. The pointer
 // can then be used in all the other methods below (i.e. the methods that

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -98,7 +98,7 @@ typedef basic_struct basic[1];
 // 'basic' type, this function initializes an RCP<const Basic> on the stack
 // allocated variable. The 's' variable must be freed using basic_free_stack()
 void basic_new_stack(basic s);
-//! Free the C++ class wrapped by s only if s is stack allocated.
+//! Free the C++ class wrapped by s; does nothing if `s` is `nullptr`
 void basic_free_stack(basic s);
 
 // Use these two functions to allocate and free 'basic' on a heap. The pointer

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -98,10 +98,8 @@ typedef basic_struct basic[1];
 // 'basic' type, this function initializes an RCP<const Basic> on the stack
 // allocated variable. The 's' variable must be freed using basic_free_stack()
 void basic_new_stack(basic s);
-//! Free the C++ class wrapped by s.
-void basic_free_stack(basic s);
 //! Free the C++ class wrapped by s only if s is stack allocated.
-void basic_free_stack_if_not_null(basic s);
+void basic_free_stack(basic s);
 
 // Use these two functions to allocate and free 'basic' on a heap. The pointer
 // can then be used in all the other methods below (i.e. the methods that

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -98,8 +98,10 @@ typedef basic_struct basic[1];
 // 'basic' type, this function initializes an RCP<const Basic> on the stack
 // allocated variable. The 's' variable must be freed using basic_free_stack()
 void basic_new_stack(basic s);
-//! Free the C++ class wrapped by s; does nothing if `s` is `nullptr`
+//! Free the C++ class wrapped by s.
 void basic_free_stack(basic s);
+//! Free the C++ class wrapped by s; does nothing if `s` is `nullptr`
+void basic_free_stack_if_not_null(basic s);
 
 // Use these two functions to allocate and free 'basic' on a heap. The pointer
 // can then be used in all the other methods below (i.e. the methods that


### PR DESCRIPTION
This is a function which frees the basic variable only if it has been allocated. The use case comes from [here](https://github.com/lcompilers/lpython/issues/2614#issuecomment-2009981787)