### PR TITLE
Added support for sign function in the cwrapper

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -643,6 +643,7 @@ IMPLEMENT_ONE_ARG_FUNC(exp)
 IMPLEMENT_ONE_ARG_FUNC(log)
 IMPLEMENT_ONE_ARG_FUNC(floor)
 IMPLEMENT_ONE_ARG_FUNC(ceiling)
+IMPLEMENT_ONE_ARG_FUNC(sign)
 
 #define IMPLEMENT_TWO_ARG_FUNC(func)                                           \
     CWRAPPER_OUTPUT_TYPE basic_##func(basic s, const basic a, const basic b)   \

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -352,6 +352,8 @@ CWRAPPER_OUTPUT_TYPE basic_log(basic s, const basic a);
 CWRAPPER_OUTPUT_TYPE basic_floor(basic s, const basic a);
 //! Assigns s = ceiling(a).
 CWRAPPER_OUTPUT_TYPE basic_ceiling(basic s, const basic a);
+//! Assigns s = sign(a).
+CWRAPPER_OUTPUT_TYPE basic_sign(basic s, const basic a);
 
 //! Assigns s = atan2(a, b).
 CWRAPPER_OUTPUT_TYPE basic_atan2(basic s, const basic a, const basic b);

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1437,6 +1437,11 @@ void test_functions()
     basic_mul_vec(ans, vec);
     SYMENGINE_C_ASSERT(basic_eq(ans, twenty_four));
 
+    basic_sign(ans, zero);
+    SYMENGINE_C_ASSERT(basic_eq(ans, zero));
+    basic_sign(ans, pi);
+    SYMENGINE_C_ASSERT(basic_eq(ans, one));
+
     basic_free_stack(ans);
     basic_free_stack(res);
     basic_free_stack(pi);


### PR DESCRIPTION
I saw that we didn't have a function `basic_sign` in the cwrapper and hence thought of it adding it.