### PR TITLE
Add Conan 2 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SymEngine mailinglist: http://groups.google.com/group/symengine
 
 ### Conan package manager
 
-    conan install symengine/<version>@
+    conan install --requires="symengine/[*]"
 
 ### Building from source
 


### PR DESCRIPTION
Hi!

While reviewing your upstream changes for inclusion of the new version in Conan Center Index in https://github.com/conan-io/conan-center-index/pull/24132 I saw that your install instructions were using the old Conan 1.

This new Conan 2 syntax installs the latest version available

Let me know if I should change anything if it fits better your style, thanks!