### PR TITLE
Fix unicode printer segfault

### DIFF
--- a/symengine/printers/stringbox.cpp
+++ b/symengine/printers/stringbox.cpp
@@ -67,7 +67,7 @@ void StringBox::add_right(StringBox &other)
         smaller->lines_.insert(smaller->lines_.begin(), pad);
     }
     if (odd == 1) {
-        smaller->lines_.insert(lines_.begin(), pad);
+        smaller->lines_.insert(smaller->lines_.begin(), pad);
     }
     for (unsigned i = 0; i < lines_.size(); i++) {
         lines_[i].append(other.lines_[i]);

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -1069,6 +1069,10 @@ TEST_CASE("test_unicode()", "[unicode]")
 
     s = unicode(*tuple({}));
     CHECK(s == U8("()"));
+
+    // https://github.com/symengine/symengine/issues/2029
+    s = unicode(*mul(mul(x, x), y));
+    CHECK(s == U8(" 2  \nx \u22C5y"));
 }
 
 TEST_CASE("test_stringbox()", "[stringbox]")


### PR DESCRIPTION
Turns out `x^2 y` is enough to reproduce #2029 which occurred when padding an odd number of characters in `StringBox::add_right`