### PR TITLE
Fix bug in transpose of ImmutableDenseMatrix

### DIFF
--- a/symengine/matrices/transpose.cpp
+++ b/symengine/matrices/transpose.cpp
@@ -80,7 +80,7 @@ public:
 
         for (size_t i = 0; i < x.nrows(); i++)
             for (size_t j = 0; j < x.ncols(); j++)
-                t[j * x.ncols() + i] = x.get(i, j);
+                t[j * x.nrows() + i] = x.get(i, j);
 
         transpose_
             = make_rcp<const ImmutableDenseMatrix>(x.ncols(), x.nrows(), t);

--- a/symengine/tests/matrix/test_matrixexpr.cpp
+++ b/symengine/tests/matrix/test_matrixexpr.cpp
@@ -305,13 +305,19 @@ TEST_CASE("Test Transpose", "[Transpose]")
     auto D1 = diagonal_matrix({integer(2), integer(23)});
     REQUIRE(eq(*transpose(D1), *D1));
 
-    auto A1 = immutable_dense_matrix(2, 3,
+    auto A1 = immutable_dense_matrix(
+        2, 2, {integer(2), integer(23), integer(5), integer(9)});
+    auto A1T = immutable_dense_matrix(
+        2, 2, {integer(2), integer(5), integer(23), integer(9)});
+    REQUIRE(eq(*transpose(A1), *A1T));
+
+    auto A2 = immutable_dense_matrix(2, 3,
                                      {integer(2), integer(23), integer(5),
                                       integer(9), integer(7), integer(4)});
-    auto A1T = immutable_dense_matrix(3, 2,
+    auto A2T = immutable_dense_matrix(3, 2,
                                       {integer(2), integer(9), integer(23),
                                        integer(7), integer(5), integer(4)});
-    REQUIRE(eq(*transpose(A1), *A1T));
+    REQUIRE(eq(*transpose(A2), *A2T));
 
     REQUIRE(is_a<Transpose>(*AT));
     REQUIRE(eq(*down_cast<const Transpose &>(*AT).get_arg(), *A));

--- a/symengine/tests/matrix/test_matrixexpr.cpp
+++ b/symengine/tests/matrix/test_matrixexpr.cpp
@@ -305,10 +305,12 @@ TEST_CASE("Test Transpose", "[Transpose]")
     auto D1 = diagonal_matrix({integer(2), integer(23)});
     REQUIRE(eq(*transpose(D1), *D1));
 
-    auto A1 = immutable_dense_matrix(
-        2, 2, {integer(2), integer(23), integer(5), integer(9)});
-    auto A1T = immutable_dense_matrix(
-        2, 2, {integer(2), integer(5), integer(23), integer(9)});
+    auto A1 = immutable_dense_matrix(2, 3,
+                                     {integer(2), integer(23), integer(5),
+                                      integer(9), integer(7), integer(4)});
+    auto A1T = immutable_dense_matrix(3, 2,
+                                      {integer(2), integer(9), integer(23),
+                                       integer(7), integer(5), integer(4)});
     REQUIRE(eq(*transpose(A1), *A1T));
 
     REQUIRE(is_a<Transpose>(*AT));


### PR DESCRIPTION
Hi, this tiny PR fixes #2032. I replaced `ncols` with `nrows` as suggested in the issue and updated the corresponding test so that it now checks the transpose of a rectangular matrix rather than a square one.