### PR TITLE
Fix Gitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ information. Third party code packaged are licensed under BSD 3-clause license
 
 SymEngine mailinglist: http://groups.google.com/group/symengine
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sympy/symengine?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/symengine/symengine?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Installation
 


### PR DESCRIPTION
The Gitter link points to sympy/symengine room which doesn’t seem to exist, so I changed it to symengine/symengine.