### PR TITLE
Improve CI maintainability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: Build and test symengine
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   build:
     runs-on: ${{ matrix.OS }}
@@ -106,19 +111,19 @@ jobs:
 
           # Release build (recent LLVM + clang)
           - BUILD_TYPE: Release
-            OS: ubuntu-20.04
+            OS: ubuntu-24.04
             CC: clang-18
             CXX: clang++-18
             WITH_LLVM: 18
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main'
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main'
             EXTRA_APT_PACKAGES: clang-18 llvm-18
 
           # Release build (latest pre-release of LLVM)
           - BUILD_TYPE: Release
-            OS: ubuntu-20.04
+            OS: ubuntu-24.04
             CC: clang
             WITH_LLVM: "LATEST"
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal main'
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble main'
             EXTRA_APT_PACKAGES: llvm
 
           ## In-tree builds (we just check a few configurations to make sure they work):
@@ -299,3 +304,13 @@ jobs:
       if: matrix.MSYSTEM == ''
       run: |
         source bin/test_symengine_unix.sh
+
+  check:
+    if: always()
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,6 @@
 name: Build and test symengine
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
+
 jobs:
   build:
     runs-on: ${{ matrix.OS }}


### PR DESCRIPTION
- Add a job named `check`
  - uses `re-actors/alls-green` action to pass if all build ci jobs passed and fail otherwise
  - this can then be the only "required" ci job and list of "required" jobs doesn't need further updating in the future
- Reduce CI duplication, only run CI on pull requests or pushes to master branch
  - previously PRs to the master branch would run every job twice, one for the branch, on for the PR
- Use ubuntu 24.04 for jobs using recent llvm