### PR TITLE
Support all standard values of CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,12 @@ if (NOT CMAKE_BUILD_TYPE)
         CACHE STRING "Build type (Debug, Release)" FORCE)
 endif ()
 if (NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR
-        CMAKE_BUILD_TYPE STREQUAL "Release"))
+         CMAKE_BUILD_TYPE STREQUAL "Release" OR
+         CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR
+         CMAKE_BUILD_TYPE STREQUAL "MinSizeRel"))
     message("${CMAKE_BUILD_TYPE}")
-    message(FATAL_ERROR "CMAKE_BUILD_TYPE must be one of: Debug, Release (current value: '${CMAKE_BUILD_TYPE}')")
+    message(FATAL_ERROR
+            "CMAKE_BUILD_TYPE must be one of: Debug, Release, RelWithDebInfo, MinSizeRel (current value: '${CMAKE_BUILD_TYPE}')")
 endif ()
 
 set(BUILD_FOR_DISTRIBUTION no
@@ -140,7 +143,7 @@ endif()
 try_compile(HAVE_SYMENGINE_STD_TO_STRING "${CMAKE_CURRENT_BINARY_DIR}/cxx" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/checkstdtostring.cpp"
 	CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_CXX_FLAGS}")
 
-if ((CMAKE_CXX_COMPILER_ID MATCHES Clang) AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
+if ((CMAKE_CXX_COMPILER_ID MATCHES Clang) AND (NOT CMAKE_BUILD_TYPE STREQUAL "Debug"))
     try_compile(CHECK_CLANG "${CMAKE_CURRENT_BINARY_DIR}/cxx" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/checkclang.cpp")
     if (NOT ${CHECK_CLANG})
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__extern_always_inline=inline" )

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Here are all the `CMake` options that you can use to configure the build, with
 their default values are indicated below:
 
     cmake -DCMAKE_INSTALL_PREFIX:PATH="/usr/local" \  # Installation prefix
-        -DCMAKE_BUILD_TYPE:STRING="Release" \         # Type of build, one of: Debug or Release
+        -DCMAKE_BUILD_TYPE:STRING="Release" \         # Type of build, one of: Debug, Release, RelWithDebInfo, MinSizeRel
         -DWITH_BFD:BOOL=OFF \                         # Install with BFD library (requires binutils-dev)s
         -DWITH_SYMENGINE_ASSERT:BOOL=OFF \            # Test all SYMENGINE_ASSERT statements in the code
         -DWITH_SYMENGINE_RCP:BOOL=ON \                # Use our faster special implementation of RCP


### PR DESCRIPTION
Add support for the two remaining standard values of `CMAKE_BUILD_TYPE`: `RelWithDebInfo` and `MinSizeRel`.  This is particularly needed for Gentoo packaging that uses the most versatile `RelWithDebInfo` build variant for all packages.  See:
https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html