### PR TITLE
Fix boost-cpp version in build script

### DIFF
--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -83,7 +83,7 @@ if [[ "${WITH_BENCHMARKS_GOOGLE}" == "yes" ]]; then
 fi
 
 if [[ "${WITH_PIRANHA}" == "yes" ]]; then
-    conda_pkgs="$conda_pkgs piranha=0.11 cmake=3.24.3 'boost-cpp<1.79.0'"
+    conda_pkgs="$conda_pkgs piranha=0.11 cmake=3.24.3 boost-cpp=1.78.0"
 fi
 
 if [[ "${WITH_PRIMESIEVE}" == "yes" ]]; then


### PR DESCRIPTION
This hopefully fixes the interpolation issue in the failing CI runs