### PR TITLE
CMake: Bump minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.13)
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)


### PR DESCRIPTION
avoids the deprecation message stating that cmake<3.10 is deprecated

3.13 is still pretty old (2018) part of debian 10