### PR TITLE
CMake: Set INSTALL_CMAKE_DIR as STRING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,7 +612,7 @@ else()
     set(DEF_INSTALL_CMAKE_DIR lib/cmake/symengine)
     set(DEF_INSTALL_CMAKE_DIR_REL ../../..)
 endif()
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
+set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE STRING
     "Installation directory for CMake files")
 
 if (TARGET teuchos)


### PR DESCRIPTION
else cmake sets it as absolute in cache but it should be kept relative for the install command