### PR TITLE
Increase minimum cmake version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 2.8.12...4.0.0)
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/cmake/SymEngineConfig.cmake.in
+++ b/cmake/SymEngineConfig.cmake.in
@@ -31,7 +31,7 @@
 # target_link_libraries(example ${SYMENGINE_LIBRARIES})
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/cmake/SymEngineConfig.cmake.in
+++ b/cmake/SymEngineConfig.cmake.in
@@ -31,7 +31,9 @@
 # target_link_libraries(example ${SYMENGINE_LIBRARIES})
 #
 
-cmake_minimum_required(VERSION 3.5)
+# We are compatible with 2.8.12, but also updated to support policies
+# in 4.0.0
+cmake_minimum_required(VERSION 2.8.12...4.0.0)
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)


### PR DESCRIPTION
With cmake 4.0.0, having a minimum cmake version below 3.5 causes an error. This will affect any projects that depend on symengine and use the latest version of cmake.