### PR TITLE
Conditionally include ciso646 on c++std<=17

### DIFF
--- a/symengine/prime_sieve.cpp
+++ b/symengine/prime_sieve.cpp
@@ -1,5 +1,9 @@
 #include <symengine/prime_sieve.h>
+#if __cplusplus <= 201703L
 #include <ciso646>
+#else
+#include <version>
+#endif
 #include <cmath>
 #include <valarray>
 #include <algorithm>

--- a/symengine/symengine_rcp.h
+++ b/symengine/symengine_rcp.h
@@ -5,7 +5,11 @@
 #include <cstddef>
 #include <stdexcept>
 #include <string>
+#if __cplusplus <= 201703L
 #include <ciso646>
+#else
+#include <version>
+#endif
 
 #include <symengine/symengine_config.h>
 #include <symengine/symengine_assert.h>


### PR DESCRIPTION
Starting with [gcc 15](https://github.com/gcc-mirror/gcc/blob/36c20fee22d40c6d25f52e929b42f5eab62cb1eb/libstdc%2B%2B-v3/include/c_global/ciso646#L49), a warning is emitted when including ciso646 with cppstd>=20. This becomes an error with -Werror.

The warning emitted by gcc recommends to include the <version> header instead. This commit does the for cppstd>17.

