### PR TITLE
Fixed failing tests when `long` is 32-bit #2107

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,23 +214,23 @@ jobs:
     
           - MSYSTEM: MINGW64
             ARCH: x86_64
-            OS: windows-2019
+            OS: windows-latest
             BUILD_TYPE: Release
 
           - MSYSTEM: MINGW64
             ARCH: x86_64
-            OS: windows-2019
+            OS: windows-latest
             BUILD_TYPE: Debug
 
           - MSYSTEM: MINGW32
             ARCH: i686
-            OS: windows-2019
+            OS: windows-latest
             BUILD_TYPE: Release
             WITH_MPFR: yes
 
           - MSYSTEM: MINGW32
             ARCH: i686
-            OS: windows-2019
+            OS: windows-latest
             BUILD_TYPE: Debug
             WITH_MPFR: yes
             WITH_MPC: yes

--- a/symengine/tests/basic/test_integer_class.cpp
+++ b/symengine/tests/basic/test_integer_class.cpp
@@ -810,30 +810,52 @@ TEST_CASE("misc: integer_class", "[integer_class]")
     REQUIRE(mp_sign(integer_class(0)) == 0);
 
     // mp_get_ui
-    REQUIRE(mp_get_ui(integer_class("-18446744073709551616")) == 0u);
-    REQUIRE(mp_get_ui(integer_class("-18446744073709551615"))
-            == 18446744073709551615u);
-    REQUIRE(mp_get_ui(integer_class("-9223372036854775809"))
-            == 9223372036854775809u);
-    REQUIRE(mp_get_ui(integer_class("-9223372036854775808"))
-            == 9223372036854775808u);
+    if (sizeof(long) == 8) {
+        REQUIRE(mp_get_ui(integer_class("-18446744073709551616")) == 0u);
+        REQUIRE(mp_get_ui(integer_class("-18446744073709551615"))
+                == 18446744073709551615u);
+        REQUIRE(mp_get_ui(integer_class("-9223372036854775809"))
+                == 9223372036854775809u);
+        REQUIRE(mp_get_ui(integer_class("-9223372036854775808"))
+                == 9223372036854775808u);
+    }
+    else if (sizeof(long) == 4) {
+        REQUIRE(mp_get_ui(integer_class("-4294967296")) == 0u);
+        REQUIRE(mp_get_ui(integer_class("-4294967295")) == 4294967295u);
+        REQUIRE(mp_get_ui(integer_class("-2147483649")) == 2147483649u);
+        REQUIRE(mp_get_ui(integer_class("-2147483648")) == 2147483648u);
+    }
+
     REQUIRE(mp_get_ui(integer_class("-2")) == 2u);
     REQUIRE(mp_get_ui(integer_class("-1")) == 1u);
     REQUIRE(mp_get_ui(integer_class("0")) == 0u);
     REQUIRE(mp_get_ui(integer_class("1")) == 1u);
     REQUIRE(mp_get_ui(integer_class("2")) == 2u);
-    REQUIRE(mp_get_ui(integer_class("9223372036854775807"))
-            == 9223372036854775807u);
-    REQUIRE(mp_get_ui(integer_class("-9223372036854775807"))
-            == 9223372036854775807u);
-    REQUIRE(mp_get_ui(integer_class("18446744073709551615"))
-            == 18446744073709551615u);
-    REQUIRE(mp_get_ui(integer_class("18446744073709551615"))
-            == 18446744073709551615u);
-    REQUIRE(mp_get_ui(integer_class("18446744073709551616")) == 0u);
+    if (sizeof(long) == 8) {
+        REQUIRE(mp_get_ui(integer_class("9223372036854775807"))
+                == 9223372036854775807u);
+        REQUIRE(mp_get_ui(integer_class("-9223372036854775807"))
+                == 9223372036854775807u);
+        REQUIRE(mp_get_ui(integer_class("18446744073709551615"))
+                == 18446744073709551615u);
+        REQUIRE(mp_get_ui(integer_class("-18446744073709551615"))
+                == 18446744073709551615u);
+        REQUIRE(mp_get_ui(integer_class("18446744073709551616")) == 0u);
+    }
+    else if (sizeof(long) == 4) {
+        REQUIRE(mp_get_ui(integer_class("2147483647")) == 2147483647u);
+        REQUIRE(mp_get_ui(integer_class("-2147483647")) == 2147483647u);
+        REQUIRE(mp_get_ui(integer_class("4294967295")) == 4294967295u);
+        REQUIRE(mp_get_ui(integer_class("-4294967295")) == 4294967295u);
+        REQUIRE(mp_get_ui(integer_class("4294967296")) == 0u);
+    }
 
     // mp_scan1
-    REQUIRE(mp_scan1(LONG_MIN) == 63);
+    if (sizeof(long) == 8) {
+        REQUIRE(mp_scan1(LONG_MIN) == 63);
+    } else if (sizeof(long) == 4) {
+        REQUIRE(mp_scan1(LONG_MIN) == 31);    
+    }
     REQUIRE(mp_scan1(-1024) == 10);
     REQUIRE(mp_scan1(-768) == 8);
     REQUIRE(mp_scan1(-500) == 2);

--- a/symengine/tests/basic/test_integer_class.cpp
+++ b/symengine/tests/basic/test_integer_class.cpp
@@ -818,8 +818,7 @@ TEST_CASE("misc: integer_class", "[integer_class]")
                 == 9223372036854775809u);
         REQUIRE(mp_get_ui(integer_class("-9223372036854775808"))
                 == 9223372036854775808u);
-    }
-    else if (sizeof(long) == 4) {
+    } else if (sizeof(long) == 4) {
         REQUIRE(mp_get_ui(integer_class("-4294967296")) == 0u);
         REQUIRE(mp_get_ui(integer_class("-4294967295")) == 4294967295u);
         REQUIRE(mp_get_ui(integer_class("-2147483649")) == 2147483649u);
@@ -841,8 +840,7 @@ TEST_CASE("misc: integer_class", "[integer_class]")
         REQUIRE(mp_get_ui(integer_class("-18446744073709551615"))
                 == 18446744073709551615u);
         REQUIRE(mp_get_ui(integer_class("18446744073709551616")) == 0u);
-    }
-    else if (sizeof(long) == 4) {
+    } else if (sizeof(long) == 4) {
         REQUIRE(mp_get_ui(integer_class("2147483647")) == 2147483647u);
         REQUIRE(mp_get_ui(integer_class("-2147483647")) == 2147483647u);
         REQUIRE(mp_get_ui(integer_class("4294967295")) == 4294967295u);
@@ -854,7 +852,7 @@ TEST_CASE("misc: integer_class", "[integer_class]")
     if (sizeof(long) == 8) {
         REQUIRE(mp_scan1(LONG_MIN) == 63);
     } else if (sizeof(long) == 4) {
-        REQUIRE(mp_scan1(LONG_MIN) == 31);    
+        REQUIRE(mp_scan1(LONG_MIN) == 31);
     }
     REQUIRE(mp_scan1(-1024) == 10);
     REQUIRE(mp_scan1(-768) == 8);


### PR DESCRIPTION
PS: The original test contains two copies of

```
REQUIRE(mp_get_ui(integer_class("18446744073709551615"))
        == 18446744073709551615u);
```

I changed the second one to "-18446744073709551615" because it feels like the author's original intention :)