### PR TITLE
avoid requiring too strict boost version

### DIFF
--- a/bin/install_deps.sh
+++ b/bin/install_deps.sh
@@ -74,7 +74,7 @@ else
 
   conda_pkgs="$conda_pkgs ccache"
   if [[ "${INTEGER_CLASS}" == "boostmp" ]]; then
-      conda_pkgs="$conda_pkgs boost=1.80.0"
+      conda_pkgs="$conda_pkgs boost>=1.80.0"
       if [[ "$MSYSTEM" == "" ]]; then
         export CXXFLAGS="-Wno-error=cpp"  # boost-1.80 pragma-warns about 1.82 req. c++14
       fi


### PR DESCRIPTION
should help with CI run in symengine.py
see https://github.com/symengine/symengine.py/pull/482