### PR TITLE
Fix compiler warnings when using clang

### DIFF
--- a/symengine/matrix.h
+++ b/symengine/matrix.h
@@ -120,7 +120,7 @@ public:
     DenseMatrix &operator=(const DenseMatrix &other) = default;
     // type_code
     const static MatrixTypeID type_code_id = SYMENGINE_DENSE_MATRIX;
-    virtual MatrixTypeID get_type_code() const
+    virtual MatrixTypeID get_type_code() const override
     {
         return SYMENGINE_DENSE_MATRIX;
     }
@@ -370,7 +370,7 @@ public:
     CSRMatrix &operator=(CSRMatrix &&other);
     CSRMatrix(const CSRMatrix &) = default;
     const static MatrixTypeID type_code_id = SYMENGINE_CSR_MATRIX;
-    virtual MatrixTypeID get_type_code() const
+    virtual MatrixTypeID get_type_code() const override
     {
         return SYMENGINE_CSR_MATRIX;
     }

--- a/symengine/mp_class.h
+++ b/symengine/mp_class.h
@@ -74,12 +74,12 @@ typedef mpq_class rational_class;
 inline namespace literals
 {
 //! Literal for creating multiple precision integers
-inline integer_class operator"" _z(const char *str)
+inline integer_class operator""_z(const char *str)
 {
     return integer_class(str);
 }
 
-inline rational_class operator"" _q(const char *str)
+inline rational_class operator""_q(const char *str)
 {
     return rational_class(integer_class(str));
 }


### PR DESCRIPTION
<details>
<summary>This should fix some compiler warnings that I'm seeing</summary>

```
/work/external/symengine/symengine/mp_class.h:77:33: warning: identifier '_z' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   77 | inline integer_class operator"" _z(const char *str)
      |                      ~~~~~~~~~~~^~
      |                      operator""_z
/work/external/symengine/symengine/mp_class.h:82:34: warning: identifier '_q' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   82 | inline rational_class operator"" _q(const char *str)
      |                       ~~~~~~~~~~~^~
      |                       operator""_q
In file included from /work/external/symengine/symengine/tests/ntheory/test_diophantine.cpp:3:
In file included from /work/external/symengine/symengine/diophantine.h:10:
/work/external/symengine/symengine/matrix.h:123:26: warning: 'get_type_code' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  123 |     virtual MatrixTypeID get_type_code() const
      |                          ^
/work/external/symengine/symengine/matrix.h:21:26: note: overridden virtual function is here
   21 |     virtual MatrixTypeID get_type_code() const = 0;
      |                          ^
/work/external/symengine/symengine/matrix.h:373:26: warning: 'get_type_code' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  373 |     virtual MatrixTypeID get_type_code() const
      |                          ^
/work/external/symengine/symengine/matrix.h:21:26: note: overridden virtual function is here
   21 |     virtual MatrixTypeID get_type_code() const = 0;
      |                          ^
4 warnings generated.
[ 80%] Linking CXX executable test_diophantine
In file included from /work/external/symengine/symengine/tests/ntheory/test_ntheory.cpp:4:
In file included from /work/external/symengine/symengine/ntheory.h:10:
In file included from /work/external/symengine/symengine/integer.h:10:
In file included from /work/external/symengine/symengine/number.h:10:
In file included from /work/external/symengine/symengine/basic.h:37:
In file included from /work/external/symengine/symengine/dict.h:9:
/work/external/symengine/symengine/mp_class.h:77:33: warning: identifier '_z' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   77 | inline integer_class operator"" _z(const char *str)
      |                      ~~~~~~~~~~~^~
      |                      operator""_z
/work/external/symengine/symengine/mp_class.h:82:34: warning: identifier '_q' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   82 | inline rational_class operator"" _q(const char *str)
      |                       ~~~~~~~~~~~^~
      |                       operator""_q
```

</details>