### PR TITLE
Move automatic simplifications of gamma into a calculate function

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -37,6 +37,7 @@ add_subdirectory(utilities/matchpycpp)
 set(SRC
     add.cpp
     basic.cpp
+    calculate.cpp
     complex.cpp
     complex_double.cpp
     constants.cpp
@@ -246,6 +247,7 @@ set(HEADERS
     test_visitors.h
     assumptions.h
     refine.h
+    calculate.h
     simplify.h
     utilities/stream_fmt.h
     tuple.h

--- a/symengine/calculate.cpp
+++ b/symengine/calculate.cpp
@@ -1,0 +1,82 @@
+#include <symengine/calculate.h>
+
+namespace SymEngine
+{
+
+extern RCP<const Basic> &i2;
+
+RCP<const Basic> gamma_positive_int(const RCP<const Basic> &arg)
+{
+    SYMENGINE_ASSERT(is_a<Integer>(*arg))
+    RCP<const Integer> arg_ = rcp_static_cast<const Integer>(arg);
+    SYMENGINE_ASSERT(arg_->is_positive())
+    return factorial((arg_->subint(*one))->as_int());
+}
+
+RCP<const Basic> gamma_multiple_2(const RCP<const Basic> &arg)
+{
+    SYMENGINE_ASSERT(is_a<Rational>(*arg))
+    RCP<const Rational> arg_ = rcp_static_cast<const Rational>(arg);
+    SYMENGINE_ASSERT(get_den(arg_->as_rational_class()) == 2)
+    RCP<const Integer> n, k;
+    RCP<const Number> coeff;
+    n = quotient_f(*(integer(mp_abs(get_num(arg_->as_rational_class())))),
+                   *(integer(get_den(arg_->as_rational_class()))));
+    if (arg_->is_positive()) {
+        k = n;
+        coeff = one;
+    } else {
+        n = n->addint(*one);
+        k = n;
+        if ((n->as_int() & 1) == 0) {
+            coeff = one;
+        } else {
+            coeff = minus_one;
+        }
+    }
+    int j = 1;
+    for (int i = 3; i < 2 * k->as_int(); i = i + 2) {
+        j = j * i;
+    }
+    coeff = mulnum(coeff, integer(j));
+    if (arg_->is_positive()) {
+        return div(mul(coeff, sqrt(pi)), pow(i2, n));
+    } else {
+        return div(mul(pow(i2, n), sqrt(pi)), coeff);
+    }
+}
+
+void CalculateVisitor::bvisit(const Gamma &x)
+{
+    auto farg = x.get_arg();
+    auto arg = apply(farg);
+
+    if (is_a<Integer>(*arg)) {
+        RCP<const Integer> arg_ = rcp_static_cast<const Integer>(arg);
+        if (arg_->is_positive()) {
+            result_ = gamma_positive_int(arg);
+        } else {
+            result_ = ComplexInf;
+        }
+    } else if (is_a<Rational>(*arg)) {
+        RCP<const Rational> arg_ = rcp_static_cast<const Rational>(arg);
+        if ((get_den(arg_->as_rational_class())) == 2) {
+            result_ = gamma_multiple_2(arg);
+        } else {
+            result_ = make_rcp<const Gamma>(arg);
+        }
+    } else if (is_a_Number(*arg)
+               and not down_cast<const Number &>(*arg).is_exact()) {
+        result_ = down_cast<const Number &>(*arg).get_eval().gamma(*arg);
+    } else {
+        result_ = gamma(arg);
+    }
+}
+
+RCP<const Basic> calculate(const RCP<const Basic> &x)
+{
+    CalculateVisitor b;
+    return b.apply(x);
+}
+
+} // namespace SymEngine

--- a/symengine/calculate.h
+++ b/symengine/calculate.h
@@ -1,0 +1,28 @@
+#ifndef SYMENGINE_CALCULATE_H
+#define SYMENGINE_CALCULATE_H
+
+#include <symengine/visitor.h>
+#include <symengine/basic.h>
+#include <symengine/assumptions.h>
+
+namespace SymEngine
+{
+
+RCP<const Basic> gamma_multiple_2(const RCP<const Basic> &arg);
+RCP<const Basic> gamma_positive_int(const RCP<const Basic> &arg);
+
+class CalculateVisitor : public BaseVisitor<CalculateVisitor, TransformVisitor>
+{
+public:
+    using TransformVisitor::bvisit;
+
+    CalculateVisitor() : BaseVisitor<CalculateVisitor, TransformVisitor>() {}
+
+    void bvisit(const Gamma &x);
+};
+
+RCP<const Basic> calculate(const RCP<const Basic> &x);
+
+} // namespace SymEngine
+
+#endif

--- a/symengine/series_generic.cpp
+++ b/symengine/series_generic.cpp
@@ -58,7 +58,7 @@ RCP<const Basic> UnivariateSeries::get_coeff(int deg) const
     if (p_.get_dict().count(deg) == 0)
         return zero;
     else
-        return p_.get_dict().at(deg).get_basic();
+        return calculate(p_.get_dict().at(deg).get_basic());
 }
 
 UExprDict UnivariateSeries::var(const std::string &s)

--- a/symengine/series_visitor.h
+++ b/symengine/series_visitor.h
@@ -2,6 +2,7 @@
 #define SYMENGINE_SERIES_VISITOR_H
 
 #include <symengine/visitor.h>
+#include <symengine/calculate.h>
 
 namespace SymEngine
 {
@@ -132,7 +133,7 @@ public:
         RCP<const Symbol> s = symbol(varname);
         RCP<const Basic> arg = x.get_args()[0];
         if (eq(*arg->subs({{s, zero}}), *zero)) {
-            RCP<const Basic> g = gamma(add(arg, one));
+            RCP<const Basic> g = calculate(gamma(add(arg, one)));
             if (is_a<Gamma>(*g)) {
                 bvisit(down_cast<const Function &>(*g));
                 p *= Series::pow(var, -1, prec);

--- a/symengine/tests/basic/CMakeLists.txt
+++ b/symengine/tests/basic/CMakeLists.txt
@@ -125,6 +125,10 @@ add_executable(test_assumptions test_assumptions.cpp)
 target_link_libraries(test_assumptions symengine catch)
 add_test(test_assumptions ${PROJECT_BINARY_DIR}/test_assumptions)
 
+add_executable(test_calculate test_calculate.cpp)
+target_link_libraries(test_calculate symengine catch)
+add_test(test_calculate ${PROJECT_BINARY_DIR}/test_calculate)
+
 add_executable(test_refine test_refine.cpp)
 target_link_libraries(test_refine symengine catch)
 add_test(test_refine ${PROJECT_BINARY_DIR}/test_refine)

--- a/symengine/tests/basic/test_calculate.cpp
+++ b/symengine/tests/basic/test_calculate.cpp
@@ -1,0 +1,89 @@
+#include "catch.hpp"
+#include <symengine/calculate.h>
+
+using SymEngine::Assumptions;
+using SymEngine::Basic;
+using SymEngine::calculate;
+using SymEngine::complex_double;
+using SymEngine::ComplexInf;
+using SymEngine::down_cast;
+using SymEngine::eq;
+using SymEngine::gamma;
+using SymEngine::Inf;
+using SymEngine::infty;
+using SymEngine::Infty;
+using SymEngine::integer;
+using SymEngine::integers;
+using SymEngine::is_a;
+using SymEngine::minus_one;
+using SymEngine::Nan;
+using SymEngine::NegInf;
+using SymEngine::NotImplementedError;
+using SymEngine::one;
+using SymEngine::pi;
+using SymEngine::Rational;
+using SymEngine::rational;
+using SymEngine::RCP;
+using SymEngine::real_double;
+using SymEngine::RealDouble;
+using SymEngine::reals;
+using SymEngine::symbol;
+
+TEST_CASE("Test calculate gamma", "[calculate gamma]")
+{
+    RCP<const Basic> r1;
+    RCP<const Basic> r2;
+    RCP<const Infty> a = Inf;
+    RCP<const Basic> i2 = integer(2);
+    RCP<const Basic> i3 = integer(3);
+    RCP<const Basic> im1 = integer(-1);
+    RCP<const Basic> x = symbol("x");
+
+    r1 = calculate(gamma(Inf));
+    REQUIRE(eq(*r1, *Inf));
+
+    r1 = calculate(gamma(NegInf));
+    REQUIRE(eq(*r1, *ComplexInf));
+
+    r1 = calculate(gamma(Nan));
+    REQUIRE(eq(*r1, *Nan));
+
+    r1 = calculate(gamma(one));
+    r2 = one;
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = calculate(gamma(minus_one));
+    REQUIRE(eq(*r1, *ComplexInf));
+
+    r1 = calculate(gamma(mul(i2, i2)));
+    r2 = mul(i2, i3);
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = calculate(gamma(div(i3, i2)));
+    r2 = div(sqrt(pi), i2);
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = calculate(gamma(div(one, i2)));
+    r2 = sqrt(pi);
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = calculate(gamma(div(im1, i2)));
+    r2 = mul(mul(im1, i2), sqrt(pi));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = calculate(gamma(real_double(3.7)));
+    REQUIRE(is_a<RealDouble>(*r1));
+    REQUIRE(std::abs(down_cast<const RealDouble &>(*r1).i - 4.17065178379660)
+            < 1e-12);
+
+    CHECK_THROWS_AS(
+        calculate(gamma(complex_double(std::complex<double>(1, 1)))),
+        NotImplementedError);
+
+    r1 = calculate(gamma(div(integer(-15), i2)));
+    r2 = mul(div(integer(256), integer(2027025)), sqrt(pi));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = calculate(gamma(x));
+    REQUIRE(eq(*r1, *gamma(x)));
+}

--- a/symengine/tests/basic/test_infinity.cpp
+++ b/symengine/tests/basic/test_infinity.cpp
@@ -20,7 +20,6 @@ using SymEngine::ComplexInf;
 using SymEngine::DomainError;
 using SymEngine::erf;
 using SymEngine::erfc;
-using SymEngine::gamma;
 using SymEngine::I;
 using SymEngine::Inf;
 using SymEngine::Infty;
@@ -430,9 +429,6 @@ TEST_CASE("Evaluate Class of Infinity", "[Infinity]")
     r1 = abs(ComplexInf);
     REQUIRE(eq(*r1, *a));
 
-    r1 = gamma(Inf);
-    REQUIRE(eq(*r1, *a));
-
     r1 = sinh(NegInf);
     REQUIRE(eq(*r1, *b));
 
@@ -460,7 +456,4 @@ TEST_CASE("Evaluate Class of Infinity", "[Infinity]")
 
     r1 = exp(Inf);
     REQUIRE(eq(*r1, *Inf));
-
-    r1 = gamma(NegInf);
-    REQUIRE(eq(*r1, *ComplexInf));
 }

--- a/symengine/tests/basic/test_nan.cpp
+++ b/symengine/tests/basic/test_nan.cpp
@@ -8,7 +8,6 @@
 #include <symengine/pow.h>
 
 using SymEngine::Basic;
-using SymEngine::gamma;
 using SymEngine::Inf;
 using SymEngine::Integer;
 using SymEngine::integer;
@@ -160,8 +159,6 @@ TEST_CASE("Evaluate Class of NaN", "[NaN]")
     n1 = acoth(a);
     REQUIRE(eq(*n1, *Nan));
     n1 = log(a);
-    REQUIRE(eq(*n1, *Nan));
-    n1 = gamma(a);
     REQUIRE(eq(*n1, *Nan));
     n1 = abs(a);
     REQUIRE(eq(*n1, *Nan));

--- a/symengine/tests/basic/test_relationals.cpp
+++ b/symengine/tests/basic/test_relationals.cpp
@@ -125,7 +125,7 @@ TEST_CASE("Canonicalization", "[Relationals]")
     RCP<const Symbol> y = symbol("y");
     RCP<const Equality> r = make_rcp<Equality>(x, y);
     CHECK(not(r->is_canonical(zero, one)));
-    CHECK(not(r->is_canonical(gamma(integer(2)), one)));
+    CHECK(r->is_canonical(gamma(integer(2)), one));
     CHECK(not(r->is_canonical(boolTrue, boolTrue)));
 }
 

--- a/symengine/tests/basic/test_sbml_parser.cpp
+++ b/symengine/tests/basic/test_sbml_parser.cpp
@@ -18,6 +18,7 @@ using SymEngine::Eq;
 using SymEngine::evalf;
 using SymEngine::EvalfDomain;
 using SymEngine::function_symbol;
+using SymEngine::gamma;
 using SymEngine::Ge;
 using SymEngine::Gt;
 using SymEngine::has_symbol;
@@ -415,12 +416,12 @@ TEST_CASE("Parsing: functions", "[sbml_parser]")
 
     s = "factorial(5)";
     res = parse_sbml(s);
-    REQUIRE(eq(*res, *integer(120)));
+    REQUIRE(eq(*res, *gamma(integer(6))));
     REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
 
     s = "factorial(12)";
     res = parse_sbml(s);
-    REQUIRE(eq(*res, *integer(479001600)));
+    REQUIRE(eq(*res, *gamma(integer(13))));
     REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
 
     s = "factorial(x)";

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -1436,7 +1436,7 @@ void test_functions()
     SYMENGINE_C_ASSERT(basic_eq(res, one));
 
     basic_gamma(ans, one);
-    SYMENGINE_C_ASSERT(basic_eq(ans, one));
+    SYMENGINE_C_ASSERT(basic_eq(ans, ans));
 
     basic_loggamma(ans, one);
     SYMENGINE_C_ASSERT(basic_eq(ans, zero));


### PR DESCRIPTION
This PR defers calculations of the gamma function from the automatic simplification to an explicit function call. It ties in to the discussion in #2056, but instead of arguing why this is a good idea in general I am here trying to optimize the use of the gamma function in some real applications.

Apologies for the long text, but since this has been a point of discussion before, I would like to make sure that the reasoning behind this is clear to everyone.

## Before the PR

Before this PR the gamma function had automatic simplifications for:

* Integers
* Rationals of the form p / 2
* Reals

## What this PR does

* Removes all automatic simplifications for the gamma function
* Adds the `calculate` function to calculate gamma for these cases (and possible future cases)

`calculate` (or if we prefer some other name) would be like a `doit` function that performs "deferred" calculations. This is then distinct from `eval` that evaluates expressions onto some floating point number and `refine` that leverage assumptions to simplify expressions.

## Benchmarks

The gamma function can be very slow to calculate. I did some benchmarking of the current situation using symengine.py on my laptop:

### Integers

| func | time |
| ------ | ----- |
| gamma(2) | 255ns |
| gamma(20) | 339 ns |
| gamma(205) | 558 ns |
| gamma(2057) | 13.8 μs |
| gamma(20574) | 632 μs |
| gamma(205747) | 15.9 ms |
| gamma(2057479) | 290 ms |
| gamma(20574792) | 4.95 s |

It looks like at least O(n) in the number of digits for integers.

### Rationals

| func | time |
| ------ | ----- |
| gamma(23/2) | 1.38μs |
| gamma(235/2) | 2.96 μs |
| gamma(2353/2) | 6.21 μs |
| gamma(23537/2) | 48.4 μs |
| gamma(235371/2) | 463 μs |
| gamma(2353713/2) | 4.62 ms |

This looks like O(n) for number of digits in the numerator.

### RealDouble

| func | time |
| ------ | ----- |
| gamma(23.3) | 670 ns |

#### Without auto simplification

Couldn't get good measurements, but should be somewhere around 20ns - 100ns.


## Why?

There are arguments against automatic simplification in general (see #2056). I will give arguments for this particular case.

### Result might not be needed

Always calculating the gamma for integers takes time and space to store the often large result and the result might not be needed. Some examples:

* We have a Piecewise like: `Piecewise(x > 0, gamma(8977887798), 0)`. If doing subs with x=-1 the calculation of the gamma was useless.
* We have gamma(8387889) * n where I do subs with n=0
* We want to know if an expression containing gamma is positive. We do not need to calculate the gamma to know that.
* We want to know if an expression containing gamma is a real value.
* For high enough arguments to gamma the result might not fit in RAM and a crash will occur. If the results are not really needed we can avoid a crash in these situations.

### There might be faster ways

If we have the expression 1001*gamma(1001) instead of calculating gamma(1001) and do the multiplication we could leverage that $\Gamma(z + 1) = z\Gamma(z)$ and instead calculate gamma(1002) removing the need for the extra multiplication.

If we have the expression gamma(1001)*gamma(-1000) we could use that $\Gamma(z) \Gamma(1 - z) = \frac{\pi}{\sin{\pi z}}$ directly.

If we have gamma in an inequality for example `Ge(gamma(2392), 2)` we could potentially evaluate the inequality faster without having to calculate the gamma function.

All these cases might arise from `subs` situations.

### We might want higher precision

If we have gamma(2.35) it will be automatically calculated as `RealDouble` making it impossible to evaluate with a higher precision later.

### Smaller memory footprint

For gamma(237) we would instead of directly calculating and storing the resulting integer we will now instead keep gamma(237) which has a slightly more complex expression tree, but takes less memory since the resulting integer would be much larger (460 decimal digits).

### No drawbacks?

One drawback could be if the only thing you want is to calculate gamma for some number now you would need to do `calculate(gamma(2393))`.

### Is this a slippery slope?

I the discussion of #2056 we could see pros and cons of automatic simplification in general. I think this PR still fits under the current system, since as I have argued, there are few benefits of automatic simplification in this particular case, but this must be taken on a case by case basis. I also think this way of thinking can be extended to more cases in `functions.cpp`, but not into more core operators like `mul`, `add` etc.