### PR TITLE
Do not drop LLVM includes when linking against static build thereof

### DIFF
--- a/cmake/SymEngineConfig.cmake.in
+++ b/cmake/SymEngineConfig.cmake.in
@@ -92,8 +92,6 @@ if (NOT "${SYMENGINE_LLVM_COMPONENTS}" STREQUAL "")
         llvm_expand_dependencies(llvm_libs ${llvm_libs_direct})
     endif()
     set(SYMENGINE_LIBRARIES ${SYMENGINE_LIBRARIES} ${llvm_libs})
-else()
-    set(SYMENGINE_LLVM_INCLUDE_DIRS)
 endif()
 
 if (TARGET gmp)


### PR DESCRIPTION
I should preface this PR with that I'm not 100% certain this is the correct fix.

### Background
This is not needed by SymEngine itself, but when linking a 3rd party library against symengine, we have a fully fledged llvm compiler in there. But in order for the third party library to be able to use it, it needs to be able to include the llvm headers matching the version symengine was built against.


### Rationale
My rationale for this change is rather weak: it helps my particular use case, and I can't see how it can hurt to keep the include path around here. But maybe I'm missing something, we went through the hassle of explicitly clearing this in `else` clause, which indicates that I might be missing something here.