### PR TITLE
CI: use symengine_rcp for thread safe tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           - BUILD_TYPE: Debug
             WITH_BFD: yes
             WITH_SYMENGINE_THREAD_SAFE: yes
+            WITH_SYMENGINE_RCP: yes
             OS: ubuntu-22.04
             CC: gcc
 


### PR DESCRIPTION
The version of Teuchos::RCP we are vendoring is not thread safe in its debug configuration. That has been fixed upstream, but updating Teuchos is non-trivial. xref: gh-2114

To avoid [false positives](https://github.com/symengine/symengine/pull/2127#issuecomment-3389435439) in tests involving multi-threading, I suggest we use our own RCP pointer type for those configurations.