### PR TITLE
llvm: Fix build with 22.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,9 @@ jobs:
           - BUILD_TYPE: Release
             OS: ubuntu-24.04
             CC: clang
-            # WITH_LLVM="LATEST" (llvm 22) fails: llvm_double.cpp:58:13: error: variable 'GetDeclaration' with type 'const auto &'
-            # has incompatible initializer of type '<overloaded function type>'
-            # const auto &GetDeclaration = llvm::Intrinsic::getOrInsertDeclaration;
-            WITH_LLVM: 21
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble main'
-            EXTRA_APT_PACKAGES: llvm
+            WITH_LLVM: 22
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main'
+            EXTRA_APT_PACKAGES: llvm-22
 
           ## In-tree builds (we just check a few configurations to make sure they work):
           # Debug build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,7 @@ set(WITH_LLVM no
 if (WITH_LLVM)
     set(SYMENGINE_LLVM_COMPONENTS asmparser core executionengine instcombine mcjit native nativecodegen scalaropts vectorize support transformutils passes)
     find_package(LLVM REQUIRED ${SYMENGINE_LLVM_COMPONENTS})
-    set(LLVM_MINIMUM_REQUIRED_VERSION "4.0")
+    set(LLVM_MINIMUM_REQUIRED_VERSION "5.0")
     if (LLVM_PACKAGE_VERSION LESS ${LLVM_MINIMUM_REQUIRED_VERSION})
 	    message(FATAL_ERROR "LLVM version found ${LLVM_PACKAGE_VERSION} is too old.
                              Require at least ${LLVM_MINIMUM_REQUIRED_VERSION}")

--- a/cmake/SymEngineConfig.cmake.in
+++ b/cmake/SymEngineConfig.cmake.in
@@ -22,7 +22,7 @@
 
 # An example project would be,
 #
-# cmake_minimum_required(VERSION 2.8)
+# cmake_minimum_required(VERSION 3.18)
 # find_package(symengine CONFIG)
 # set(CMAKE_CXX_FLAGS_RELEASE ${SYMENGINE_CXX_FLAGS_RELEASE})
 #
@@ -31,17 +31,9 @@
 # target_link_libraries(example ${SYMENGINE_LIBRARIES})
 #
 
-# We are compatible with 2.8.12, but also updated to support policies
+# We are compatible with 3.18, but also updated to support policies
 # in 4.0.0
-cmake_minimum_required(VERSION 2.8.12...4.0.0)
-
-if (POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
-if (POLICY CMP0057)
-  cmake_policy(SET CMP0057 NEW) # needed for llvm >= 16
-endif ()
+cmake_minimum_required(VERSION 3.18...4.0.0)
 
 include(CMakeFindDependencyMacro)
 


### PR DESCRIPTION
Also bumps llvm>=5 requirement to cleanup code (CI still tests 5.x on macos)

/cc @bjodah 