### PR TITLE
Add metalcode printer

### DIFF
--- a/.github/workflows/build_doxygen.yml
+++ b/.github/workflows/build_doxygen.yml
@@ -9,12 +9,12 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
           fetch-depth: 0
       - name: Cache conda
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         env:
           CACHE_NUMBER: 0
         with:
@@ -23,14 +23,14 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('doxygendoc.yml') }}
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('doxygendoc.yml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: doxygendoc
           environment-file: ./binder/doxygendoc.yml
@@ -47,7 +47,7 @@ jobs:
           cd ../../
       - name: Deploy Docs
         if: ${{ github.ref == 'refs/heads/master' && github.repository == 'Symengine/symengine' }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,20 +166,24 @@ jobs:
 
           - BUILD_TYPE: Debug
             WITH_LLVM: 5.0
+            BUILD_METAL_TESTS: yes
             OS: macos-14
             CC: clang
 
           - BUILD_TYPE: Release
             WITH_LLVM: 5.0
+            BUILD_METAL_TESTS: yes
             OS: macos-14
             CC: clang
 
           - BUILD_TYPE: Debug
+            BUILD_METAL_TESTS: yes
             OS: macos-14
             CC: gcc
             WITH_SYMENGINE_RCP: yes
 
           - BUILD_TYPE: Release
+            BUILD_METAL_TESTS: yes
             OS: macos-14
             CC: gcc
 
@@ -280,13 +284,14 @@ jobs:
       CXX: ${{ matrix.CXX }}
       WITH_UNITY_BUILD: ${{ matrix.WITH_UNITY_BUILD }}
       WITH_COVERAGE: ${{ matrix.WITH_COVERAGE }}
+      BUILD_METAL_TESTS: ${{ matrix.BUILD_METAL_TESTS }}
       BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
       WITH_SANITIZE: ${{ matrix.WITH_SANITIZE }}
       WITH_MPC: ${{ matrix.WITH_MPC }}
       BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}
       NO_RTTI: ${{ matrix.NO_RTTI }}
       MSYS_ENV: ${{ matrix.MSYS_ENV }}
-      OPTIONS: ${{ matrix.BUILD_TYPE }}-${{ matrix.OS }}-${{ matrix.CC }}-${{ matrix.USE_GLIBCXX_DEBUG }}-${{ matrix.WITH_MPFR }}-${{ matrix.WITH_LLVM }}-${{ matrix.WITH_BENCHMARKS }}-${{ matrix.WITH_BENCHMARKS_GOOGLE }}-${{ matrix.WITH_SYMENGINE_RCP }}-${{ matrix.TEST_IN_TREE }}-${{ matrix.WITH_SYMENGINE_THREAD_SAFE }}-${{ matrix.WITH_PRIMESIEVE }}-${{ matrix.INTEGER_CLASS }}-${{ matrix.WITH_ARB }}-${{ matrix.WITH_PIRANHA }}-${{ matrix.WITH_BFD }}-${{ matrix.WITH_FLINT }}-${{ matrix.WITH_ECM }}-${{ matrix.WITH_LATEST_GCC }}-${{ matrix.WITH_FLINT_DEV }}-${{ matrix.WITH_UNITY_BUILD }}-${{ matrix.WITH_COVERAGE }}-${{ matrix.WITH_SANITIZE }}-${{ matrix.WITH_MPC }}-${{ matrix.BUILD_SHARED_LIBS }}-${{ matrix.NO_RTTI }}-${{ matrix.MSYS_ENV }}
+      OPTIONS: ${{ matrix.BUILD_TYPE }}-${{ matrix.OS }}-${{ matrix.CC }}-${{ matrix.USE_GLIBCXX_DEBUG }}-${{ matrix.WITH_MPFR }}-${{ matrix.WITH_LLVM }}-${{ matrix.WITH_BENCHMARKS }}-${{ matrix.WITH_BENCHMARKS_GOOGLE }}-${{ matrix.WITH_SYMENGINE_RCP }}-${{ matrix.TEST_IN_TREE }}-${{ matrix.WITH_SYMENGINE_THREAD_SAFE }}-${{ matrix.WITH_PRIMESIEVE }}-${{ matrix.INTEGER_CLASS }}-${{ matrix.WITH_ARB }}-${{ matrix.WITH_PIRANHA }}-${{ matrix.WITH_BFD }}-${{ matrix.WITH_FLINT }}-${{ matrix.WITH_ECM }}-${{ matrix.WITH_LATEST_GCC }}-${{ matrix.WITH_FLINT_DEV }}-${{ matrix.WITH_UNITY_BUILD }}-${{ matrix.WITH_COVERAGE }}-${{ matrix.BUILD_METAL_TESTS }}-${{ matrix.WITH_SANITIZE }}-${{ matrix.WITH_MPC }}-${{ matrix.BUILD_SHARED_LIBS }}-${{ matrix.NO_RTTI }}-${{ matrix.MSYS_ENV }}
       CCACHE_DIR: 'D:\a\_temp\msys\msys64\home\runneradmin\.ccache'
 
     steps:
@@ -312,14 +317,14 @@ jobs:
         conda-remove-defaults: "true"
 
     - name: Cache ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ github.job }}-${{ env.OPTIONS }}-${{ runner.os }}-${{ github.sha }}
         restore-keys: ccache-${{ github.job }}-${{ env.OPTIONS }}-${{ runner.os }}-
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 2
 
@@ -336,7 +341,7 @@ jobs:
   matchpycpp:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: conda-incubator/setup-miniconda@v3
         with:
           channels: conda-forge
@@ -347,7 +352,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: pip install "clang-format==11.1.0.2" && ./bin/run_clang_format.sh
 
   check:

--- a/.github/workflows/test_tutorials.yml
+++ b/.github/workflows/test_tutorials.yml
@@ -6,7 +6,7 @@ jobs:
   test_tutorials:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Run tutorials
         run: |
           source bin/install_deps.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,6 +490,8 @@ set(BUILD_TESTS yes
     CACHE BOOL "Build SymEngine tests")
 set(BUILD_CUDA_TESTS no
     CACHE BOOL "Build CUDA integration tests for the CUDA printer")
+set(BUILD_METAL_TESTS no
+    CACHE BOOL "Build Metal integration tests for the Metal printer")
 
 # Teuchos
 set(WITH_SYMENGINE_TEUCHOS no

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ their default values are indicated below:
                                                         the vendored copy
         -DBUILD_TESTS:BOOL=ON \                       # Build with tests
         -DBUILD_CUDA_TESTS:BOOL=OFF \                 # Build with cuda tests (requires cuda and an nvidia GPU)
+        -DBUILD_METAL_TESTS:BOOL=OFF \                # Build with metal tests (requires macOS, Metal, and metal-cpp headers)
         -DBUILD_BENCHMARKS:BOOL=ON \                  # Build with benchmarks
         -DBUILD_BENCHMARKS_GOOGLE:BOOL=OFF \          # Build with Google Benchmark benchmarks
         -DINTEGER_CLASS:STRING=gmp \                  # Choose storage type for Integer. one of gmp, gmpxx,

--- a/bin/install_deps.sh
+++ b/bin/install_deps.sh
@@ -143,6 +143,15 @@ else
 
 fi
 
+if [[ "${RUNNER_OS}" == "macOS" ]] && [[ "${BUILD_METAL_TESTS}" == "yes" ]]; then
+  METALCPP_ARCHIVE_URL="https://developer.apple.com/metal/cpp/files/metal-cpp_macOS14.2_iOS17.2.zip"
+  METALCPP_ARCHIVE_PATH="/tmp/metal-cpp.zip"
+  export METALCPP_ROOT="/tmp/metal-cpp"
+  rm -rf "${METALCPP_ROOT}" "${METALCPP_ARCHIVE_PATH}"
+  curl -L "${METALCPP_ARCHIVE_URL}" -o "${METALCPP_ARCHIVE_PATH}"
+  unzip -q "${METALCPP_ARCHIVE_PATH}" -d /tmp
+fi
+
 export CXX="ccache ${CXX}"
 export CC="ccache ${CC}"
 export CCACHE_SLOPPINESS="pch_defines,time_macros"

--- a/bin/test_symengine.sh
+++ b/bin/test_symengine.sh
@@ -154,6 +154,12 @@ fi
 if [[ "${WITH_COVERAGE}" != "" ]]; then
     cmake_line="$cmake_line -DWITH_COVERAGE=${WITH_COVERAGE}"
 fi
+if [[ "${BUILD_METAL_TESTS}" != "" ]]; then
+    cmake_line="$cmake_line -DBUILD_METAL_TESTS=${BUILD_METAL_TESTS}"
+fi
+if [[ "${METALCPP_ROOT}" != "" ]]; then
+    cmake_line="$cmake_line -DMETALCPP_ROOT=${METALCPP_ROOT}"
+fi
 if [[ "${WITH_UNITY_BUILD}" != "" ]]; then
     cmake_line="$cmake_line -DCMAKE_UNITY_BUILD=${WITH_UNITY_BUILD}"
 fi

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -73,6 +73,7 @@ using SymEngine::jscode;
 using SymEngine::julia_str;
 using SymEngine::latex;
 using SymEngine::mathml;
+using SymEngine::metalcode;
 using SymEngine::mp_get_si;
 using SymEngine::mp_get_ui;
 using SymEngine::numeric_cast;
@@ -707,7 +708,9 @@ IMPLEMENT_TWO_ARG_FUNC(polygamma)
     {                                                                          \
         std::string str;                                                       \
         try {                                                                  \
-            str = func(*s->m, to_code_printer_precision(settings));            \
+            str = settings == nullptr                                          \
+                      ? func(*s->m)                                            \
+                      : func(*s->m, to_code_printer_precision(settings));      \
         } catch (SymEngineException & e) {                                     \
             return nullptr;                                                    \
         } catch (...) {                                                        \
@@ -725,8 +728,10 @@ IMPLEMENT_STR_CONVERSION(str_latex, latex)
 IMPLEMENT_STR_CONVERSION(str_jscode, jscode)
 IMPLEMENT_STR_CONVERSION(str_ccode, ccode)
 IMPLEMENT_STR_CONVERSION(str_cudacode, cudacode)
+IMPLEMENT_STR_CONVERSION(str_metalcode, metalcode)
 IMPLEMENT_STR_CONVERSION_SETTINGS(str_ccode_settings, ccode)
 IMPLEMENT_STR_CONVERSION_SETTINGS(str_cudacode_settings, cudacode)
+IMPLEMENT_STR_CONVERSION_SETTINGS(str_metalcode_settings, metalcode)
 
 BasicCodePrinterSettings *basic_code_printer_settings_new()
 {

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -33,10 +33,11 @@ extern "C" {
 
 typedef symengine_exceptions_t CWRAPPER_OUTPUT_TYPE;
 
-//! Precision for code printers (ccode, cudacode)
+//! Precision for code printers (ccode, cudacode, metalcode)
 typedef enum {
     SYMENGINE_DOUBLE = 0,
     SYMENGINE_FLOAT = 1,
+    SYMENGINE_HALF = 2,
 } BasicCodePrinterPrecision;
 //! Code printer settings object
 typedef struct BasicCodePrinterSettings BasicCodePrinterSettings;
@@ -412,6 +413,11 @@ char *basic_str_cudacode(const basic s);
 //! Printing CUDA code with optional settings; NULL uses defaults
 char *basic_str_cudacode_settings(const basic s,
                                   const BasicCodePrinterSettings *settings);
+//! Printing Metal code
+char *basic_str_metalcode(const basic s);
+//! Printing Metal code with optional settings; NULL uses float defaults
+char *basic_str_metalcode_settings(const basic s,
+                                   const BasicCodePrinterSettings *settings);
 //! Printing JavaScript code
 char *basic_str_jscode(const basic s);
 //! Frees the string s

--- a/symengine/printers.h
+++ b/symengine/printers.h
@@ -8,7 +8,11 @@
 
 namespace SymEngine
 {
-enum class CodePrinterPrecision : std::uint32_t { Double = 0, Float = 1 };
+enum class CodePrinterPrecision : std::uint32_t {
+    Double = 0,
+    Float = 1,
+    Half = 2
+};
 
 std::string str(const Basic &x);
 std::string str(const DenseMatrix &x);
@@ -27,6 +31,8 @@ std::string ccode(const Basic &x, CodePrinterPrecision precision
                                   = CodePrinterPrecision::Double);
 std::string cudacode(const Basic &x, CodePrinterPrecision precision
                                      = CodePrinterPrecision::Double);
+std::string metalcode(const Basic &x, CodePrinterPrecision precision
+                                      = CodePrinterPrecision::Float);
 std::string c89code(const Basic &x);
 std::string c99code(const Basic &x);
 std::string jscode(const Basic &x);

--- a/symengine/printers/codegen.cpp
+++ b/symengine/printers/codegen.cpp
@@ -8,9 +8,18 @@ namespace SymEngine
 namespace
 {
 
-std::string print_float_literal(double d)
+const char *print_precision_suffix(CodePrinterPrecision precision)
 {
-    return print_double(d) + "f";
+    switch (precision) {
+        case CodePrinterPrecision::Double:
+            return "";
+        case CodePrinterPrecision::Float:
+            return "f";
+        case CodePrinterPrecision::Half:
+            return "h";
+        default:
+            throw SymEngineException("Unknown code printer precision");
+    }
 }
 
 CodePrinterPrecision
@@ -19,6 +28,7 @@ normalize_code_printer_precision(CodePrinterPrecision precision)
     switch (precision) {
         case CodePrinterPrecision::Double:
         case CodePrinterPrecision::Float:
+        case CodePrinterPrecision::Half:
             return precision;
         default:
             throw SymEngineException("Unknown code printer precision");
@@ -34,10 +44,7 @@ CodePrinter::CodePrinter(CodePrinterPrecision precision)
 
 std::string CodePrinter::print_scalar_literal(double d) const
 {
-    if (precision_ == CodePrinterPrecision::Float) {
-        return print_float_literal(d);
-    }
-    return print_double(d);
+    return print_double(d) + print_precision_suffix(precision_);
 }
 
 std::string CodePrinter::print_math_function(const std::string &name) const
@@ -126,7 +133,7 @@ void CodePrinter::bvisit(const BooleanAtom &x)
 }
 void CodePrinter::bvisit(const Integer &x)
 {
-    if (precision_ == CodePrinterPrecision::Float) {
+    if (precision_ != CodePrinterPrecision::Double) {
         str_ = print_scalar_literal(mp_get_d(x.as_integer_class()));
     } else {
         StrPrinter::bvisit(x);
@@ -277,12 +284,12 @@ void CodePrinter::bvisit(const Min &x)
 void CodePrinter::bvisit(const Constant &x)
 {
     if (eq(x, *E)) {
-        str_ = precision_ == CodePrinterPrecision::Float
+        str_ = precision_ != CodePrinterPrecision::Double
                    ? print_math_function("exp") + "("
                          + print_scalar_literal(1.0) + ")"
                    : "exp(1)";
     } else if (eq(x, *pi)) {
-        str_ = precision_ == CodePrinterPrecision::Float
+        str_ = precision_ != CodePrinterPrecision::Double
                    ? print_math_function("acos") + "("
                          + print_scalar_literal(-1.0) + ")"
                    : "acos(-1)";
@@ -364,7 +371,7 @@ void CodePrinter::bvisit(const Function &x)
 
 void CodePrinter::bvisit(const RealDouble &x)
 {
-    if (precision_ == CodePrinterPrecision::Float) {
+    if (precision_ != CodePrinterPrecision::Double) {
         str_ = print_scalar_literal(x.i);
     } else {
         StrPrinter::bvisit(x);
@@ -375,8 +382,8 @@ void CodePrinter::bvisit(const RealDouble &x)
 void CodePrinter::bvisit(const RealMPFR &x)
 {
     StrPrinter::bvisit(x);
-    if (precision_ == CodePrinterPrecision::Float) {
-        str_ += "f";
+    if (precision_ != CodePrinterPrecision::Double) {
+        str_ += print_precision_suffix(precision_);
     }
 }
 #endif
@@ -384,6 +391,10 @@ void CodePrinter::bvisit(const RealMPFR &x)
 C89CodePrinter::C89CodePrinter(CodePrinterPrecision precision)
     : BaseVisitor<C89CodePrinter, CodePrinter>(precision)
 {
+    if (precision_ == CodePrinterPrecision::Half) {
+        throw SymEngineException(
+            "C-family code printers do not support half precision");
+    }
 }
 
 void C89CodePrinter::bvisit(const Infty &x)
@@ -495,6 +506,135 @@ void CudaCodePrinter::bvisit(const Infty &x)
         throw SymEngineException("Not supported");
 }
 
+MetalCodePrinter::MetalCodePrinter(CodePrinterPrecision precision)
+    : BaseVisitor<MetalCodePrinter, CodePrinter>(precision)
+{
+    if (precision_ == CodePrinterPrecision::Double) {
+        throw SymEngineException(
+            "Metal code printer currently only supports float and half "
+            "precision");
+    }
+}
+
+void MetalCodePrinter::bvisit(const Constant &x)
+{
+    if (eq(x, *E)) {
+        str_ = "exp(" + print_scalar_literal(1.0) + ")";
+    } else if (eq(x, *pi)) {
+        str_ = "acos(" + print_scalar_literal(-1.0) + ")";
+    } else {
+        str_ = x.get_name();
+    }
+}
+
+void MetalCodePrinter::bvisit(const NaN &x)
+{
+    if (precision_ == CodePrinterPrecision::Half) {
+        str_ = "half(NAN)";
+    } else {
+        str_ = "NAN";
+    }
+}
+
+void MetalCodePrinter::bvisit(const Infty &x)
+{
+    if (x.is_negative_infinity()) {
+        str_ = precision_ == CodePrinterPrecision::Half ? "-HUGE_VALH"
+                                                        : "-INFINITY";
+    } else if (x.is_positive_infinity()) {
+        str_ = precision_ == CodePrinterPrecision::Half ? "HUGE_VALH"
+                                                        : "INFINITY";
+    } else {
+        throw SymEngineException("Not supported");
+    }
+}
+
+void MetalCodePrinter::bvisit(const Abs &x)
+{
+    std::ostringstream s;
+    s << "fabs(" << apply(x.get_arg()) << ")";
+    str_ = s.str();
+}
+
+void MetalCodePrinter::bvisit(const Ceiling &x)
+{
+    std::ostringstream s;
+    s << "ceil(" << apply(x.get_arg()) << ")";
+    str_ = s.str();
+}
+
+void MetalCodePrinter::bvisit(const Truncate &x)
+{
+    std::ostringstream s;
+    s << "trunc(" << apply(x.get_arg()) << ")";
+    str_ = s.str();
+}
+
+void MetalCodePrinter::bvisit(const Max &x)
+{
+    std::ostringstream s;
+    const auto &args = x.get_args();
+    switch (args.size()) {
+        case 0:
+        case 1:
+            throw SymEngineException("Impossible");
+        case 2:
+            s << "fmax(" << apply(args[0]) << ", " << apply(args[1]) << ")";
+            break;
+        default: {
+            vec_basic inner_args(args.begin() + 1, args.end());
+            auto inner = max(inner_args);
+            s << "fmax(" << apply(args[0]) << ", " << apply(inner) << ")";
+            break;
+        }
+    }
+    str_ = s.str();
+}
+
+void MetalCodePrinter::bvisit(const Min &x)
+{
+    std::ostringstream s;
+    const auto &args = x.get_args();
+    switch (args.size()) {
+        case 0:
+        case 1:
+            throw SymEngineException("Impossible");
+        case 2:
+            s << "fmin(" << apply(args[0]) << ", " << apply(args[1]) << ")";
+            break;
+        default: {
+            vec_basic inner_args(args.begin() + 1, args.end());
+            auto inner = min(inner_args);
+            s << "fmin(" << apply(args[0]) << ", " << apply(inner) << ")";
+            break;
+        }
+    }
+    str_ = s.str();
+}
+
+void MetalCodePrinter::bvisit(const Function &x)
+{
+    static const std::vector<std::string> names_ = init_str_printer_names();
+    std::ostringstream o;
+    o << names_[x.get_type_code()];
+    vec_basic vec = x.get_args();
+    o << parenthesize(apply(vec));
+    str_ = o.str();
+}
+
+void MetalCodePrinter::_print_pow(std::ostringstream &o,
+                                  const RCP<const Basic> &a,
+                                  const RCP<const Basic> &b)
+{
+    if (eq(*a, *E)) {
+        o << "exp(" << apply(b) << ")";
+    } else if (eq(*b, *rational(1, 2))) {
+        o << "sqrt(" << apply(a) << ")";
+    } else {
+        o << "pow(" << apply(a) << ", " << apply(b) << ")";
+    }
+}
+
 void JSCodePrinter::bvisit(const Constant &x)
 {
     if (eq(x, *E)) {
@@ -568,6 +708,12 @@ std::string ccode(const Basic &x, CodePrinterPrecision precision)
 std::string cudacode(const Basic &x, CodePrinterPrecision precision)
 {
     CudaCodePrinter p(precision);
+    return p.apply(x);
+}
+
+std::string metalcode(const Basic &x, CodePrinterPrecision precision)
+{
+    MetalCodePrinter p(precision);
     return p.apply(x);
 }
 

--- a/symengine/printers/codegen.cpp
+++ b/symengine/printers/codegen.cpp
@@ -62,13 +62,24 @@ std::string CodePrinter::print_binary_reduction(const vec_basic &args,
         throw SymEngineException("Impossible");
     }
 
-    std::string result = apply(args.back());
-    for (auto it = args.rbegin() + 1; it != args.rend(); ++it) {
-        std::ostringstream s;
-        s << func_name << "(" << apply(*it) << ", " << result << ")";
-        result = s.str();
+    return print_binary_reduction_impl(args.begin(), args.end(), func_name);
+}
+
+std::string
+CodePrinter::print_binary_reduction_impl(vec_basic::const_iterator begin,
+                                         vec_basic::const_iterator end,
+                                         const std::string &func_name)
+{
+    const auto size = static_cast<std::size_t>(std::distance(begin, end));
+    if (size == 1) {
+        return apply(*begin);
     }
-    return result;
+
+    const auto mid = begin + size / 2;
+    std::ostringstream s;
+    s << func_name << "(" << print_binary_reduction_impl(begin, mid, func_name)
+      << ", " << print_binary_reduction_impl(mid, end, func_name) << ")";
+    return s.str();
 }
 
 void CodePrinter::bvisit(const Basic &x)

--- a/symengine/printers/codegen.cpp
+++ b/symengine/printers/codegen.cpp
@@ -55,6 +55,22 @@ std::string CodePrinter::print_math_function(const std::string &name) const
     return name;
 }
 
+std::string CodePrinter::print_binary_reduction(const vec_basic &args,
+                                                const std::string &func_name)
+{
+    if (args.size() < 2) {
+        throw SymEngineException("Impossible");
+    }
+
+    std::string result = apply(args.back());
+    for (auto it = args.rbegin() + 1; it != args.rend(); ++it) {
+        std::ostringstream s;
+        s << func_name << "(" << apply(*it) << ", " << result << ")";
+        result = s.str();
+    }
+    return result;
+}
+
 void CodePrinter::bvisit(const Basic &x)
 {
     throw SymEngineException("Not supported");
@@ -239,47 +255,11 @@ void CodePrinter::bvisit(const Truncate &x)
 }
 void CodePrinter::bvisit(const Max &x)
 {
-    std::ostringstream s;
-    const auto &args = x.get_args();
-    switch (args.size()) {
-        case 0:
-        case 1:
-            throw SymEngineException("Impossible");
-        case 2:
-            s << print_math_function("fmax") << "(" << apply(args[0]) << ", "
-              << apply(args[1]) << ")";
-            break;
-        default: {
-            vec_basic inner_args(args.begin() + 1, args.end());
-            auto inner = max(inner_args);
-            s << print_math_function("fmax") << "(" << apply(args[0]) << ", "
-              << apply(inner) << ")";
-            break;
-        }
-    }
-    str_ = s.str();
+    str_ = print_binary_reduction(x.get_args(), print_math_function("fmax"));
 }
 void CodePrinter::bvisit(const Min &x)
 {
-    std::ostringstream s;
-    const auto &args = x.get_args();
-    switch (args.size()) {
-        case 0:
-        case 1:
-            throw SymEngineException("Impossible");
-        case 2:
-            s << print_math_function("fmin") << "(" << apply(args[0]) << ", "
-              << apply(args[1]) << ")";
-            break;
-        default: {
-            vec_basic inner_args(args.begin() + 1, args.end());
-            auto inner = min(inner_args);
-            s << print_math_function("fmin") << "(" << apply(args[0]) << ", "
-              << apply(inner) << ")";
-            break;
-        }
-    }
-    str_ = s.str();
+    str_ = print_binary_reduction(x.get_args(), print_math_function("fmin"));
 }
 void CodePrinter::bvisit(const Constant &x)
 {
@@ -572,44 +552,12 @@ void MetalCodePrinter::bvisit(const Truncate &x)
 
 void MetalCodePrinter::bvisit(const Max &x)
 {
-    std::ostringstream s;
-    const auto &args = x.get_args();
-    switch (args.size()) {
-        case 0:
-        case 1:
-            throw SymEngineException("Impossible");
-        case 2:
-            s << "fmax(" << apply(args[0]) << ", " << apply(args[1]) << ")";
-            break;
-        default: {
-            vec_basic inner_args(args.begin() + 1, args.end());
-            auto inner = max(inner_args);
-            s << "fmax(" << apply(args[0]) << ", " << apply(inner) << ")";
-            break;
-        }
-    }
-    str_ = s.str();
+    str_ = print_binary_reduction(x.get_args(), "fmax");
 }
 
 void MetalCodePrinter::bvisit(const Min &x)
 {
-    std::ostringstream s;
-    const auto &args = x.get_args();
-    switch (args.size()) {
-        case 0:
-        case 1:
-            throw SymEngineException("Impossible");
-        case 2:
-            s << "fmin(" << apply(args[0]) << ", " << apply(args[1]) << ")";
-            break;
-        default: {
-            vec_basic inner_args(args.begin() + 1, args.end());
-            auto inner = min(inner_args);
-            s << "fmin(" << apply(args[0]) << ", " << apply(inner) << ")";
-            break;
-        }
-    }
-    str_ = s.str();
+    str_ = print_binary_reduction(x.get_args(), "fmin");
 }
 
 void MetalCodePrinter::bvisit(const Function &x)

--- a/symengine/printers/codegen.h
+++ b/symengine/printers/codegen.h
@@ -107,6 +107,27 @@ public:
     void bvisit(const Infty &x);
 };
 
+class MetalCodePrinter : public BaseVisitor<MetalCodePrinter, CodePrinter>
+{
+public:
+    explicit MetalCodePrinter(CodePrinterPrecision precision
+                              = CodePrinterPrecision::Float);
+    using CodePrinter::apply;
+    using CodePrinter::bvisit;
+    using CodePrinter::str_;
+    void bvisit(const Constant &x);
+    void bvisit(const NaN &x);
+    void bvisit(const Infty &x);
+    void bvisit(const Abs &x);
+    void bvisit(const Ceiling &x);
+    void bvisit(const Truncate &x);
+    void bvisit(const Max &x);
+    void bvisit(const Min &x);
+    void bvisit(const Function &x);
+    void _print_pow(std::ostringstream &o, const RCP<const Basic> &a,
+                    const RCP<const Basic> &b) override;
+};
+
 class JSCodePrinter : public BaseVisitor<JSCodePrinter, CodePrinter>
 {
 public:

--- a/symengine/printers/codegen.h
+++ b/symengine/printers/codegen.h
@@ -63,6 +63,8 @@ protected:
     CodePrinterPrecision precision_;
     std::string print_scalar_literal(double d) const;
     std::string print_math_function(const std::string &name) const;
+    std::string print_binary_reduction(const vec_basic &args,
+                                       const std::string &func_name);
 };
 
 class C89CodePrinter : public BaseVisitor<C89CodePrinter, CodePrinter>

--- a/symengine/printers/codegen.h
+++ b/symengine/printers/codegen.h
@@ -65,6 +65,9 @@ protected:
     std::string print_math_function(const std::string &name) const;
     std::string print_binary_reduction(const vec_basic &args,
                                        const std::string &func_name);
+    std::string print_binary_reduction_impl(vec_basic::const_iterator begin,
+                                            vec_basic::const_iterator end,
+                                            const std::string &func_name);
 };
 
 class C89CodePrinter : public BaseVisitor<C89CodePrinter, CodePrinter>

--- a/symengine/tests/CMakeLists.txt
+++ b/symengine/tests/CMakeLists.txt
@@ -17,3 +17,7 @@ add_subdirectory(finitediff)
 if (BUILD_CUDA_TESTS)
     add_subdirectory(cuda)
 endif()
+
+if (BUILD_METAL_TESTS)
+    add_subdirectory(metal)
+endif()

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -137,6 +137,38 @@ void test_cwrapper()
     SYMENGINE_C_ASSERT(strcmp(s, "expf(sqrtf(123.0f))") == 0);
     basic_str_free(s);
 
+    s = basic_str_metalcode_settings(e, NULL);
+    SYMENGINE_C_ASSERT(strcmp(s, "exp(sqrt(123.0f))") == 0);
+    basic_str_free(s);
+
+    s = basic_str_metalcode(e);
+    SYMENGINE_C_ASSERT(strcmp(s, "exp(sqrt(123.0f))") == 0);
+    basic_str_free(s);
+
+    s = basic_str_metalcode_settings(e, float_settings);
+    SYMENGINE_C_ASSERT(strcmp(s, "exp(sqrt(123.0f))") == 0);
+    basic_str_free(s);
+
+    BasicCodePrinterSettings *half_settings = basic_code_printer_settings_new();
+    basic_code_printer_settings_set_precision(half_settings, SYMENGINE_HALF);
+
+    s = basic_str_ccode_settings(e, half_settings);
+    SYMENGINE_C_ASSERT(s == NULL);
+
+    s = basic_str_cudacode_settings(e, half_settings);
+    SYMENGINE_C_ASSERT(s == NULL);
+
+    s = basic_str_metalcode_settings(e, half_settings);
+    SYMENGINE_C_ASSERT(strcmp(s, "exp(sqrt(123.0h))") == 0);
+    basic_str_free(s);
+
+    BasicCodePrinterSettings *double_settings
+        = basic_code_printer_settings_new();
+    basic_code_printer_settings_set_precision(double_settings,
+                                              SYMENGINE_DOUBLE);
+    s = basic_str_metalcode_settings(e, double_settings);
+    SYMENGINE_C_ASSERT(s == NULL);
+
 #if HAVE_SYMENGINE_RTTI
     unsigned long size = 0;
     basic deserialized;
@@ -229,6 +261,8 @@ void test_cwrapper()
     basic_free_stack(numer);
     basic_free_stack(denom);
     basic_str_free(s);
+    basic_code_printer_settings_free(double_settings);
+    basic_code_printer_settings_free(half_settings);
     basic_code_printer_settings_free(float_settings);
 }
 

--- a/symengine/tests/metal/CMakeLists.txt
+++ b/symengine/tests/metal/CMakeLists.txt
@@ -1,0 +1,28 @@
+project(test_metal)
+
+if (NOT APPLE)
+    message(FATAL_ERROR "BUILD_METAL_TESTS requires macOS")
+endif()
+
+if (NOT METALCPP_ROOT)
+    message(FATAL_ERROR
+            "BUILD_METAL_TESTS requires METALCPP_ROOT to point to the extracted metal-cpp headers")
+endif()
+
+find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
+find_library(METAL_FRAMEWORK Metal REQUIRED)
+find_library(QUARTZCORE_FRAMEWORK QuartzCore REQUIRED)
+
+add_executable(test_metalcode_runtime
+               test_metalcode_runtime.cpp)
+target_compile_features(test_metalcode_runtime PRIVATE cxx_std_17)
+target_include_directories(test_metalcode_runtime PRIVATE
+                           ${METALCPP_ROOT})
+target_link_libraries(test_metalcode_runtime PRIVATE
+                      symengine
+                      catch
+                      ${FOUNDATION_FRAMEWORK}
+                      ${METAL_FRAMEWORK}
+                      ${QUARTZCORE_FRAMEWORK})
+
+add_test(NAME test_metalcode_runtime COMMAND $<TARGET_FILE:test_metalcode_runtime>)

--- a/symengine/tests/metal/test_metalcode_runtime.cpp
+++ b/symengine/tests/metal/test_metalcode_runtime.cpp
@@ -1,0 +1,327 @@
+#include "catch.hpp"
+
+#define NS_PRIVATE_IMPLEMENTATION
+#define CA_PRIVATE_IMPLEMENTATION
+#define MTL_PRIVATE_IMPLEMENTATION
+#include <Foundation/Foundation.hpp>
+#include <Metal/Metal.hpp>
+#include <QuartzCore/QuartzCore.hpp>
+
+#include <cmath>
+#include <ostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <symengine/add.h>
+#include <symengine/constants.h>
+#include <symengine/functions.h>
+#include <symengine/lambda_double.h>
+#include <symengine/logic.h>
+#include <symengine/pow.h>
+#include <symengine/printers.h>
+#include <symengine/sets.h>
+
+using SymEngine::add;
+using SymEngine::Basic;
+using SymEngine::boolFalse;
+using SymEngine::boolTrue;
+using SymEngine::cbrt;
+using SymEngine::CodePrinterPrecision;
+using SymEngine::contains;
+using SymEngine::E;
+using SymEngine::Ge;
+using SymEngine::Gt;
+using SymEngine::Inf;
+using SymEngine::integer;
+using SymEngine::interval;
+using SymEngine::LambdaRealDoubleVisitor;
+using SymEngine::logical_and;
+using SymEngine::logical_not;
+using SymEngine::logical_or;
+using SymEngine::logical_xor;
+using SymEngine::Lt;
+using SymEngine::max;
+using SymEngine::metalcode;
+using SymEngine::mul;
+using SymEngine::Nan;
+using SymEngine::NegInf;
+using SymEngine::pi;
+using SymEngine::piecewise;
+using SymEngine::pow;
+using SymEngine::RCP;
+using SymEngine::sign;
+using SymEngine::sqrt;
+using SymEngine::symbol;
+using SymEngine::unevaluated_expr;
+using SymEngine::vec_basic;
+
+namespace
+{
+
+std::ostream &operator<<(std::ostream &os, const NS::Error *error)
+{
+    if (error == nullptr) {
+        os << "unknown Metal error";
+        return os;
+    }
+
+    const NS::String *description = error->localizedDescription();
+    if (description == nullptr || description->utf8String() == nullptr) {
+        os << "unknown Metal error";
+        return os;
+    }
+
+    os << description->utf8String();
+    return os;
+}
+
+struct TestInput {
+    double x;
+    double y;
+    double z;
+};
+
+struct RuntimeCase {
+    std::string name;
+    RCP<const Basic> expr;
+};
+
+struct KernelPayload {
+    float x;
+    float y;
+    float z;
+    float out;
+};
+
+struct DeviceKernel {
+    MTL::Device *device = nullptr;
+    MTL::ComputePipelineState *pipeline = nullptr;
+    MTL::CommandQueue *queue = nullptr;
+};
+
+constexpr double kFloatRelativeTolerance = 1e-6;
+constexpr double kHalfRelativeTolerance = 1e-3;
+
+std::string build_kernel_source(const std::string &metal_code,
+                                CodePrinterPrecision precision)
+{
+    std::ostringstream source;
+    source << "#include <metal_stdlib>\n";
+    source << "using namespace metal;\n";
+    source << "\n";
+    source << "struct KernelPayload {\n";
+    source << "    float x;\n";
+    source << "    float y;\n";
+    source << "    float z;\n";
+    source << "    float out;\n";
+    source << "};\n";
+    source << "\n";
+    source
+        << "kernel void evaluate(device KernelPayload *data [[buffer(0)]])\n";
+    source << "{\n";
+    if (precision == CodePrinterPrecision::Float) {
+        source << "    const float x = data[0].x;\n";
+        source << "    const float y = data[0].y;\n";
+        source << "    const float z = data[0].z;\n";
+        source << "    data[0].out = " << metal_code << ";\n";
+    } else if (precision == CodePrinterPrecision::Half) {
+        source << "    const half x = half(data[0].x);\n";
+        source << "    const half y = half(data[0].y);\n";
+        source << "    const half z = half(data[0].z);\n";
+        source << "    data[0].out = float(" << metal_code << ");\n";
+    } else {
+        throw std::runtime_error("Unsupported Metal runtime precision");
+    }
+    source << "}\n";
+    return source.str();
+}
+
+DeviceKernel compile_kernel(MTL::Device *device, const std::string &metal_code,
+                            CodePrinterPrecision precision)
+{
+    NS::AutoreleasePool *pool = NS::AutoreleasePool::alloc()->init();
+    const std::string source = build_kernel_source(metal_code, precision);
+    NS::Error *error = nullptr;
+    MTL::Library *library = device->newLibrary(
+        NS::String::string(source.c_str(), NS::UTF8StringEncoding), nullptr,
+        &error);
+    INFO(error);
+    REQUIRE(library != nullptr);
+
+    MTL::Function *function = library->newFunction(
+        NS::String::string("evaluate", NS::UTF8StringEncoding));
+    REQUIRE(function != nullptr);
+
+    error = nullptr;
+    DeviceKernel kernel;
+    kernel.device = device;
+    kernel.pipeline = device->newComputePipelineState(function, &error);
+    INFO(error);
+    REQUIRE(kernel.pipeline != nullptr);
+    kernel.queue = device->newCommandQueue();
+    REQUIRE(kernel.queue != nullptr);
+
+    function->release();
+    library->release();
+    pool->release();
+    return kernel;
+}
+
+void unload_kernel(DeviceKernel &kernel)
+{
+    kernel.pipeline->release();
+    kernel.queue->release();
+}
+
+double evaluate_on_device(const DeviceKernel &kernel, const TestInput &input)
+{
+    NS::AutoreleasePool *pool = NS::AutoreleasePool::alloc()->init();
+    MTL::Buffer *buffer = kernel.device->newBuffer(
+        sizeof(KernelPayload), MTL::ResourceStorageModeShared);
+    REQUIRE(buffer != nullptr);
+
+    auto *payload = static_cast<KernelPayload *>(buffer->contents());
+    payload->x = static_cast<float>(input.x);
+    payload->y = static_cast<float>(input.y);
+    payload->z = static_cast<float>(input.z);
+    payload->out = 0.0f;
+
+    MTL::CommandBuffer *command_buffer = kernel.queue->commandBuffer();
+    REQUIRE(command_buffer != nullptr);
+    MTL::ComputeCommandEncoder *encoder
+        = command_buffer->computeCommandEncoder();
+    REQUIRE(encoder != nullptr);
+
+    encoder->setComputePipelineState(kernel.pipeline);
+    encoder->setBuffer(buffer, 0, 0);
+    const MTL::Size grid_size = {1, 1, 1};
+    const MTL::Size threadgroup_size = {1, 1, 1};
+    encoder->dispatchThreadgroups(grid_size, threadgroup_size);
+    encoder->endEncoding();
+    command_buffer->commit();
+    command_buffer->waitUntilCompleted();
+
+    const double out = static_cast<double>(payload->out);
+    buffer->release();
+    pool->release();
+    return out;
+}
+
+double evaluate_on_host(const vec_basic &symbols, const Basic &expr,
+                        const TestInput &input)
+{
+    LambdaRealDoubleVisitor visitor;
+    visitor.init(symbols, expr);
+    return visitor.call({input.x, input.y, input.z});
+}
+
+void require_codegen_match(const Basic &expr, const vec_basic &symbols,
+                           const DeviceKernel &kernel,
+                           CodePrinterPrecision precision,
+                           const TestInput &input)
+{
+    const double host_value = evaluate_on_host(symbols, expr, input);
+    const double device_value = evaluate_on_device(kernel, input);
+
+    if (std::isnan(host_value) || std::isnan(device_value)) {
+        REQUIRE(std::isnan(host_value));
+        REQUIRE(std::isnan(device_value));
+        return;
+    }
+    if (std::isinf(host_value) || std::isinf(device_value)) {
+        REQUIRE(std::isinf(host_value));
+        REQUIRE(std::isinf(device_value));
+        REQUIRE(std::signbit(host_value) == std::signbit(device_value));
+        return;
+    }
+
+    const double scale = std::fmax(
+        1.0, std::fmax(std::fabs(host_value), std::fabs(device_value)));
+    const double tolerance = precision == CodePrinterPrecision::Half
+                                 ? kHalfRelativeTolerance
+                                 : kFloatRelativeTolerance;
+    REQUIRE(std::fabs(device_value - host_value) <= tolerance * scale);
+}
+
+} // namespace
+
+TEST_CASE("Metal code matches Lambda visitor", "[metal][metalcode]")
+{
+    NS::AutoreleasePool *pool = NS::AutoreleasePool::alloc()->init();
+    MTL::Device *device = MTL::CreateSystemDefaultDevice();
+    REQUIRE(device != nullptr);
+
+    auto x = symbol("x");
+    auto y = symbol("y");
+    auto z = symbol("z");
+    auto sign_expr = sign(add(x, mul(integer(-1), z)));
+
+    vec_basic symbols = {x, y, z};
+
+    auto arithmetic = add(add(add(add(x, mul(x, y)), pow(x, y)), cbrt(x)),
+                          sqrt(integer(2)));
+    auto relational_expr = add(add(boolTrue, boolFalse),
+                               add(SymEngine::Eq(x, integer(3)),
+                                   add(SymEngine::Ne(y, integer(1)),
+                                       add(SymEngine::Le(y, z), Lt(x, z)))));
+    auto logical_expr
+        = add(logical_and({Lt(x, integer(6)), Gt(x, integer(5))}),
+              add(logical_or({Lt(x, integer(2)), Gt(z, integer(5))}),
+                  add(logical_xor({Lt(x, integer(2)), Gt(z, integer(5))}),
+                      logical_not(logical_xor(
+                          {Lt(x, integer(2)), Gt(z, integer(5))})))));
+    auto piecewise_expr = piecewise(
+        {{x, contains(x, interval(NegInf, integer(2), true, false))},
+         {y, contains(x, interval(integer(2), integer(5), true, false))},
+         {add(x, y), boolTrue}});
+
+    std::vector<RuntimeCase> cases = {
+        {"arithmetic", arithmetic},
+        {"integer base power", pow(integer(2), x)},
+        {"abs", SymEngine::abs(x)},
+        {"sin", SymEngine::sin(x)},
+        {"atan2", SymEngine::atan2(x, z)},
+        {"exp", SymEngine::exp(y)},
+        {"log", SymEngine::log(add(x, integer(2)))},
+        {"max", max({x, y, z})},
+        {"min", SymEngine::min({x, y, z})},
+        {"piecewise", piecewise_expr},
+        {"constant E", E},
+        {"constant pi", pi},
+        {"positive infinity", Inf},
+        {"nan", Nan},
+        {"booleans and relationals", relational_expr},
+        {"logical operators", logical_expr},
+        {"sign", sign_expr},
+        {"unevaluated expr", unevaluated_expr(add(x, y))},
+    };
+
+    const std::vector<double> x_values = {1.2, 3.0, 7.0};
+    const std::vector<double> y_values = {0.2, 0.5, 0.8};
+    const std::vector<double> z_values = {1.2, 3.0, 7.0};
+    for (const auto precision :
+         {CodePrinterPrecision::Float, CodePrinterPrecision::Half}) {
+        for (const auto &runtime_case : cases) {
+            const char *precision_name
+                = precision == CodePrinterPrecision::Float ? "float" : "half";
+            INFO(runtime_case.name);
+            INFO(precision_name);
+            DeviceKernel kernel = compile_kernel(
+                device, metalcode(*runtime_case.expr, precision), precision);
+            for (double x_value : x_values) {
+                for (double y_value : y_values) {
+                    for (double z_value : z_values) {
+                        require_codegen_match(*runtime_case.expr, symbols,
+                                              kernel, precision,
+                                              {x_value, y_value, z_value});
+                    }
+                }
+            }
+            unload_kernel(kernel);
+        }
+    }
+
+    pool->release();
+}

--- a/symengine/tests/printing/test_ccode.cpp
+++ b/symengine/tests/printing/test_ccode.cpp
@@ -164,9 +164,9 @@ TEST_CASE("Metal code generation", "[metalcode]")
     REQUIRE(metalcode(*max({x, y, z})) == "fmax(x, fmax(y, z))");
     REQUIRE(metalcode(*min({x, y, z})) == "fmin(x, fmin(y, z))");
     REQUIRE(metalcode(*max({a, b, c, x, y, z}))
-            == "fmax(a, fmax(b, fmax(c, fmax(x, fmax(y, z)))))");
+            == "fmax(fmax(a, fmax(b, c)), fmax(x, fmax(y, z)))");
     REQUIRE(metalcode(*min({a, b, c, x, y, z}))
-            == "fmin(a, fmin(b, fmin(c, fmin(x, fmin(y, z)))))");
+            == "fmin(fmin(a, fmin(b, c)), fmin(x, fmin(y, z)))");
     REQUIRE(metalcode(*piecewise_expr)
             == "((x <= 2.0f) ? (\n   x\n)\n: ((x > 2.0f && x <= 5.0f) ? (\n   "
                "y\n)\n: (\n   x + y\n)))");
@@ -388,12 +388,12 @@ TEST_CASE("Functions", "[ccode][cudacode]")
     REQUIRE(cudacode(*p, CodePrinterPrecision::Float)
             == "fmaxf(x, fmaxf(y, z))");
     p = max({a, b, c, x, y, z});
-    REQUIRE(ccode(*p) == "fmax(a, fmax(b, fmax(c, fmax(x, fmax(y, z)))))");
+    REQUIRE(ccode(*p) == "fmax(fmax(a, fmax(b, c)), fmax(x, fmax(y, z)))");
     REQUIRE(ccode(*p, CodePrinterPrecision::Float)
-            == "fmaxf(a, fmaxf(b, fmaxf(c, fmaxf(x, fmaxf(y, z)))))");
-    REQUIRE(cudacode(*p) == "fmax(a, fmax(b, fmax(c, fmax(x, fmax(y, z)))))");
+            == "fmaxf(fmaxf(a, fmaxf(b, c)), fmaxf(x, fmaxf(y, z)))");
+    REQUIRE(cudacode(*p) == "fmax(fmax(a, fmax(b, c)), fmax(x, fmax(y, z)))");
     REQUIRE(cudacode(*p, CodePrinterPrecision::Float)
-            == "fmaxf(a, fmaxf(b, fmaxf(c, fmaxf(x, fmaxf(y, z)))))");
+            == "fmaxf(fmaxf(a, fmaxf(b, c)), fmaxf(x, fmaxf(y, z)))");
     p = min({x, y, z});
     REQUIRE(ccode(*p) == "fmin(x, fmin(y, z))");
     REQUIRE(ccode(*p, CodePrinterPrecision::Float) == "fminf(x, fminf(y, z))");
@@ -401,12 +401,12 @@ TEST_CASE("Functions", "[ccode][cudacode]")
     REQUIRE(cudacode(*p, CodePrinterPrecision::Float)
             == "fminf(x, fminf(y, z))");
     p = min({a, b, c, x, y, z});
-    REQUIRE(ccode(*p) == "fmin(a, fmin(b, fmin(c, fmin(x, fmin(y, z)))))");
+    REQUIRE(ccode(*p) == "fmin(fmin(a, fmin(b, c)), fmin(x, fmin(y, z)))");
     REQUIRE(ccode(*p, CodePrinterPrecision::Float)
-            == "fminf(a, fminf(b, fminf(c, fminf(x, fminf(y, z)))))");
-    REQUIRE(cudacode(*p) == "fmin(a, fmin(b, fmin(c, fmin(x, fmin(y, z)))))");
+            == "fminf(fminf(a, fminf(b, c)), fminf(x, fminf(y, z)))");
+    REQUIRE(cudacode(*p) == "fmin(fmin(a, fmin(b, c)), fmin(x, fmin(y, z)))");
     REQUIRE(cudacode(*p, CodePrinterPrecision::Float)
-            == "fminf(a, fminf(b, fminf(c, fminf(x, fminf(y, z)))))");
+            == "fminf(fminf(a, fminf(b, c)), fminf(x, fminf(y, z)))");
 }
 
 TEST_CASE("Configurable precision", "[ccode][cudacode]")

--- a/symengine/tests/printing/test_ccode.cpp
+++ b/symengine/tests/printing/test_ccode.cpp
@@ -52,6 +52,8 @@ using SymEngine::logical_not;
 using SymEngine::logical_xor;
 using SymEngine::Lt;
 using SymEngine::max;
+using SymEngine::metalcode;
+using SymEngine::MetalCodePrinter;
 using SymEngine::min;
 using SymEngine::Nan;
 using SymEngine::Ne;
@@ -107,6 +109,66 @@ TEST_CASE("CUDA-code printers", "[CudaCodePrinter]")
     REQUIRE(cuda_float.apply(E) == "expf(1.0f)");
     REQUIRE(cuda_float.apply(pi) == "acosf(-1.0f)");
     REQUIRE(cuda_float.apply(Nan) == "CUDART_NAN_F");
+}
+
+TEST_CASE("Metal-code printers", "[MetalCodePrinter]")
+{
+    MetalCodePrinter metal;
+    MetalCodePrinter metal_half(CodePrinterPrecision::Half);
+
+    REQUIRE(metal.apply(Inf) == "INFINITY");
+    REQUIRE(metal.apply(E) == "exp(1.0f)");
+    REQUIRE(metal.apply(pi) == "acos(-1.0f)");
+    REQUIRE(metal.apply(Nan) == "NAN");
+    REQUIRE(metal_half.apply(Inf) == "HUGE_VALH");
+    REQUIRE(metal_half.apply(E) == "exp(1.0h)");
+    REQUIRE(metal_half.apply(pi) == "acos(-1.0h)");
+    REQUIRE(metal_half.apply(Nan) == "half(NAN)");
+    REQUIRE_THROWS_AS(MetalCodePrinter(CodePrinterPrecision::Double),
+                      SymEngine::SymEngineException);
+}
+
+TEST_CASE("Metal code generation", "[metalcode]")
+{
+    auto x = symbol("x");
+    auto y = symbol("y");
+    auto z = symbol("z");
+    auto piecewise_expr = piecewise(
+        {{x, contains(x, interval(NegInf, integer(2), true, false))},
+         {y, contains(x, interval(integer(2), integer(5), true, false))},
+         {add(x, y), boolTrue}});
+
+    REQUIRE(metalcode(*boolTrue) == "1.0f");
+    REQUIRE(metalcode(*add(add(add(add(x, mul(x, y)), mul(x, x)), pow(x, y)),
+                           sqrt(integer(2))))
+            == "x + x*y + sqrt(2.0f) + pow(x, 2.0f) + pow(x, y)");
+    REQUIRE(metalcode(*rational(1, 3)) == "1.0f/3.0f");
+    REQUIRE(metalcode(*boolTrue, CodePrinterPrecision::Half) == "1.0h");
+    REQUIRE(metalcode(*add(add(add(add(x, mul(x, y)), mul(x, x)), pow(x, y)),
+                           sqrt(integer(2))),
+                      CodePrinterPrecision::Half)
+            == "x + x*y + sqrt(2.0h) + pow(x, 2.0h) + pow(x, y)");
+    REQUIRE(metalcode(*rational(1, 3), CodePrinterPrecision::Half)
+            == "1.0h/3.0h");
+    REQUIRE(metalcode(*function_symbol("f", pow(integer(2), x)))
+            == "f(pow(2.0f, x))");
+    REQUIRE(metalcode(*function_symbol("f", pow(integer(2), x)),
+                      CodePrinterPrecision::Half)
+            == "f(pow(2.0h, x))");
+    REQUIRE(metalcode(*abs(x)) == "fabs(x)");
+    REQUIRE(metalcode(*sin(x)) == "sin(x)");
+    REQUIRE(metalcode(*atan2(x, y)) == "atan2(x, y)");
+    REQUIRE(metalcode(*max({x, y, z})) == "fmax(x, fmax(y, z))");
+    REQUIRE(metalcode(*min({x, y, z})) == "fmin(x, fmin(y, z))");
+    REQUIRE(metalcode(*piecewise_expr)
+            == "((x <= 2.0f) ? (\n   x\n)\n: ((x > 2.0f && x <= 5.0f) ? (\n   "
+               "y\n)\n: (\n   x + y\n)))");
+    REQUIRE_THROWS_AS(metalcode(*x, CodePrinterPrecision::Double),
+                      SymEngine::SymEngineException);
+    REQUIRE_THROWS_AS(ccode(*x, CodePrinterPrecision::Half),
+                      SymEngine::SymEngineException);
+    REQUIRE_THROWS_AS(cudacode(*x, CodePrinterPrecision::Half),
+                      SymEngine::SymEngineException);
 }
 
 TEST_CASE("Codegen boolean support", "[ccode][cudacode]")

--- a/symengine/tests/printing/test_ccode.cpp
+++ b/symengine/tests/printing/test_ccode.cpp
@@ -133,6 +133,9 @@ TEST_CASE("Metal code generation", "[metalcode]")
     auto x = symbol("x");
     auto y = symbol("y");
     auto z = symbol("z");
+    auto a = symbol("a");
+    auto b = symbol("b");
+    auto c = symbol("c");
     auto piecewise_expr = piecewise(
         {{x, contains(x, interval(NegInf, integer(2), true, false))},
          {y, contains(x, interval(integer(2), integer(5), true, false))},
@@ -160,6 +163,10 @@ TEST_CASE("Metal code generation", "[metalcode]")
     REQUIRE(metalcode(*atan2(x, y)) == "atan2(x, y)");
     REQUIRE(metalcode(*max({x, y, z})) == "fmax(x, fmax(y, z))");
     REQUIRE(metalcode(*min({x, y, z})) == "fmin(x, fmin(y, z))");
+    REQUIRE(metalcode(*max({a, b, c, x, y, z}))
+            == "fmax(a, fmax(b, fmax(c, fmax(x, fmax(y, z)))))");
+    REQUIRE(metalcode(*min({a, b, c, x, y, z}))
+            == "fmin(a, fmin(b, fmin(c, fmin(x, fmin(y, z)))))");
     REQUIRE(metalcode(*piecewise_expr)
             == "((x <= 2.0f) ? (\n   x\n)\n: ((x > 2.0f && x <= 5.0f) ? (\n   "
                "y\n)\n: (\n   x + y\n)))");
@@ -223,6 +230,9 @@ TEST_CASE("Dummy", "[CodePrinter]")
 }
 TEST_CASE("Arithmetic", "[ccode][cudacode]")
 {
+    auto a = symbol("a");
+    auto b = symbol("b");
+    auto c = symbol("c");
     auto x = symbol("x");
     auto y = symbol("y");
     auto p = add(add(add(add(x, mul(x, y)), pow(x, y)), mul(x, x)),
@@ -252,6 +262,9 @@ TEST_CASE("Rational", "[ccode][cudacode]")
 
 TEST_CASE("Functions", "[ccode][cudacode]")
 {
+    auto a = symbol("a");
+    auto b = symbol("b");
+    auto c = symbol("c");
     auto x = symbol("x");
     auto y = symbol("y");
     auto z = symbol("z");
@@ -374,12 +387,26 @@ TEST_CASE("Functions", "[ccode][cudacode]")
     REQUIRE(cudacode(*p) == "fmax(x, fmax(y, z))");
     REQUIRE(cudacode(*p, CodePrinterPrecision::Float)
             == "fmaxf(x, fmaxf(y, z))");
+    p = max({a, b, c, x, y, z});
+    REQUIRE(ccode(*p) == "fmax(a, fmax(b, fmax(c, fmax(x, fmax(y, z)))))");
+    REQUIRE(ccode(*p, CodePrinterPrecision::Float)
+            == "fmaxf(a, fmaxf(b, fmaxf(c, fmaxf(x, fmaxf(y, z)))))");
+    REQUIRE(cudacode(*p) == "fmax(a, fmax(b, fmax(c, fmax(x, fmax(y, z)))))");
+    REQUIRE(cudacode(*p, CodePrinterPrecision::Float)
+            == "fmaxf(a, fmaxf(b, fmaxf(c, fmaxf(x, fmaxf(y, z)))))");
     p = min({x, y, z});
     REQUIRE(ccode(*p) == "fmin(x, fmin(y, z))");
     REQUIRE(ccode(*p, CodePrinterPrecision::Float) == "fminf(x, fminf(y, z))");
     REQUIRE(cudacode(*p) == "fmin(x, fmin(y, z))");
     REQUIRE(cudacode(*p, CodePrinterPrecision::Float)
             == "fminf(x, fminf(y, z))");
+    p = min({a, b, c, x, y, z});
+    REQUIRE(ccode(*p) == "fmin(a, fmin(b, fmin(c, fmin(x, fmin(y, z)))))");
+    REQUIRE(ccode(*p, CodePrinterPrecision::Float)
+            == "fminf(a, fminf(b, fminf(c, fminf(x, fminf(y, z)))))");
+    REQUIRE(cudacode(*p) == "fmin(a, fmin(b, fmin(c, fmin(x, fmin(y, z)))))");
+    REQUIRE(cudacode(*p, CodePrinterPrecision::Float)
+            == "fminf(a, fminf(b, fminf(c, fminf(x, fminf(y, z)))))");
 }
 
 TEST_CASE("Configurable precision", "[ccode][cudacode]")


### PR DESCRIPTION
- equivalent of cudacoda printer using metal for mac gpus
- key differences versus cudacode:
  - supported precision in metal is float or half
    - default precision for metalcode is float
    - unlike cuda metal does not support double precision
  - some intrinsics are not supported by metal
    - erf/erfc
    - tgamma/lgamma
- add optional metal runtime tests
   - requires a mac and metal-cpp headers to compile
   - compiles and runs the generated metal code on the gpu
   - checks it numerically matches lambda_double within the expected precision
   - add this to the mac CI jobs
- bump github actions versions in CI