### PR TITLE
Fix bug in llvm visitor logical_not implementation

### DIFF
--- a/.github/workflows/build_doxygen.yml
+++ b/.github/workflows/build_doxygen.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: doxygendoc
           environment-file: ./binder/doxygendoc.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
       if: matrix.MSYS_ENV == ''
       run: echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
 
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: conda-incubator/setup-miniconda@v4
       if: matrix.MSYS_ENV == ''
       with:
         activate-environment: symengine
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           channels: conda-forge
           environment-file: symengine/utilities/matchpycpp/environment.yml

--- a/symengine/llvm_double.cpp
+++ b/symengine/llvm_double.cpp
@@ -722,7 +722,11 @@ SYMENGINE_LOGIC_FUNCTION(Xor, CreateXor);
 
 void LLVMVisitor::bvisit(const Not &x)
 {
-    builder->CreateNot(apply(*x.get_arg()));
+    set_double(0.0);
+    llvm::Value *zero_val = result_;
+    llvm::Value *value = builder->CreateFCmpONE(apply(*x.get_arg()), zero_val);
+    result_ = builder->CreateUIToFP(builder->CreateNot(value),
+                                    get_float_type(&mod->getContext()));
 }
 
 #define SYMENGINE_RELATIONAL_FUNCTION(Class, method)                           \

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -51,6 +51,7 @@ using SymEngine::Eq;
 using SymEngine::evalf;
 using SymEngine::floor;
 using SymEngine::gamma;
+using SymEngine::Gt;
 using SymEngine::Inf;
 using SymEngine::integer;
 using SymEngine::LambdaComplexDoubleVisitor;
@@ -59,6 +60,7 @@ using SymEngine::Le;
 using SymEngine::log;
 using SymEngine::loggamma;
 using SymEngine::logical_and;
+using SymEngine::logical_not;
 using SymEngine::logical_xor;
 using SymEngine::Lt;
 using SymEngine::map_basic_basic;
@@ -192,6 +194,30 @@ TEST_CASE("Evaluate logical xor with llvm visitors", "[llvm_double]")
                                  static_cast<float>(test_case.y)})
                 == Approx(test_case.expected));
     }
+}
+
+TEST_CASE("Evaluate logical not with llvm visitors", "[llvm_double]")
+{
+    auto x = symbol("x");
+    auto expr
+        = logical_not(logical_xor({Gt(x, integer(2)), Lt(x, integer(4))}));
+
+    LambdaRealDoubleVisitor lambda;
+    lambda.init({x}, *expr);
+
+    LLVMDoubleVisitor llvm_double;
+    llvm_double.init({x}, *expr);
+
+    LLVMFloatVisitor llvm_float;
+    llvm_float.init({x}, *expr);
+
+    REQUIRE(lambda.call({1.0}) == Approx(0.0));
+    REQUIRE(llvm_double.call({1.0}) == Approx(0.0));
+    REQUIRE(llvm_float.call({1.0f}) == Approx(0.0));
+
+    REQUIRE(lambda.call({3.0}) == Approx(1.0));
+    REQUIRE(llvm_double.call({3.0}) == Approx(1.0));
+    REQUIRE(llvm_float.call({3.0f}) == Approx(1.0));
 }
 #endif
 


### PR DESCRIPTION
- not operation was applied directly to float input, and output was not assigned to result
- added a failing test for the issue: https://github.com/lkeegan/symengine/actions/runs/24895479444/job/72898970327#step:8:1815
- fix with same pattern as for other logical operations
  - convert input to bool
  - apply not
  - convert to float