### PR TITLE
Fix serialization of Rational/Complex

### DIFF
--- a/symengine/serialize-cereal.h
+++ b/symengine/serialize-cereal.h
@@ -43,6 +43,12 @@ public:
         if (not first_seen) {
             return;
         }
+        // Keep a reference to every serialized object for the lifetime of the
+        // archive, as some are temporary objects (e.g. Rational::get_num).
+        // Without this a temp object can be freed and its address
+        // then re-used by another temp object, which is then incorrectly
+        // serialized as the previous object seen at this address.
+        _keep_alive.push_back(ptr);
         TypeID type_code = ptr->get_type_code();
         save_typeid(*this, type_code);
         switch (type_code) {
@@ -60,6 +66,7 @@ public:
 
 private:
     std::set<uintptr_t> _addresses;
+    std::vector<RCP<const Basic>> _keep_alive;
     //! Overload the rtti function to enable dynamic_cast
     void rtti(){};
 };

--- a/symengine/tests/basic/test_serialize-cereal.cpp
+++ b/symengine/tests/basic/test_serialize-cereal.cpp
@@ -48,9 +48,12 @@ template <typename T>
 void check_string_serialization_roundtrip(RCP<const T> basic1)
 {
     RCP<const Basic> basic2 = loads<T>(dumps<T>(basic1));
+    CAPTURE(*basic1);
+    CAPTURE(*basic2);
     REQUIRE(eq(*basic1, *basic2));
 
     RCP<const Basic> basic3 = loads<Basic>(dumps<Basic>(basic1));
+    CAPTURE(*basic3);
     REQUIRE(eq(*basic1, *basic3));
 }
 
@@ -83,6 +86,15 @@ TEST_CASE("Test serialization using cereal", "[serialize-cereal]")
     check_string_serialization_roundtrip(
         real_mpfr(mpfr_class("0.35", 100, 10)));
 #endif
+    // Rational
+    check_string_serialization_roundtrip(
+        se::parse("x**3/6 + x**9/135 + x**15/600"));
+    // Complex
+    check_string_serialization_roundtrip(
+        se::parse("(1 + 2*I)*x**2 + (3 + 4*I)*x**8 + (5 + 6*I)*x**14"));
+    // Rational and Complex
+    check_string_serialization_roundtrip(
+        se::parse("sin(x)**3/6 + (2 + 3*I)*cos(y)/135 + log(x)/(600*sin(z))"));
 }
 
 TEST_CASE("Test serialization exception", "[serialize-cereal]")


### PR DESCRIPTION
- keep a reference to all objects being serialized during serialization
  - some methods return temporary objects, e.g. `Rational::get_num`
  - if a reference to these objects is not kept, their address can be re-used by another temporary object
  - serialization checks for objects already serialized based on raw address
  - so if two different temporary objects have the same address, the second one will be serialized as the first one
  - e.g. `(1/6)*x**3 + (1/600)*x**15` -> `(1/600)*x**3 + (1/600)*x**15`
- add test cases for rational & complex expressions which (often) fail without this change
  - this reproduces https://github.com/symengine/symengine.py/issues/514
  - they only fail if an address is reused, but this seems to happen most of the time for these expressions (at least in CI)