### PR TITLE
Add parser support for truncate

### DIFF
--- a/symengine/parser/parser.cpp
+++ b/symengine/parser/parser.cpp
@@ -102,6 +102,7 @@ init_parser_single_arg_functions()
             {"dirichlet_eta", dirichlet_eta},
             {"floor", floor},
             {"ceiling", ceiling},
+            {"truncate", truncate},
             {"ln", (single_arg_func)log},
             {"log", (single_arg_func)log},
             {"zeta", (single_arg_func)zeta},

--- a/symengine/parser/parser_old.cpp
+++ b/symengine/parser/parser_old.cpp
@@ -115,6 +115,7 @@ private:
             {"loggamma", loggamma},
             {"lambertw", lambertw},
             {"dirichlet_eta", dirichlet_eta},
+            {"truncate", truncate},
             {"ln", single_casted_log},
             {"log", single_casted_log},
             {"zeta", single_casted_zeta}};

--- a/symengine/parser/sbml/sbml_parser.cpp
+++ b/symengine/parser/sbml/sbml_parser.cpp
@@ -132,6 +132,7 @@ init_sbml_parser_single_arg_functions()
                      {"floor", floor},
                      {"ceil", ceiling},
                      {"ceiling", ceiling},
+                     {"truncate", truncate},
                      {"ln", (single_arg_func)log},
                      {"log", log10},
                      {"log10", log10},

--- a/symengine/tests/basic/test_parser.cpp
+++ b/symengine/tests/basic/test_parser.cpp
@@ -49,6 +49,7 @@ using SymEngine::NegInf;
 using SymEngine::Number;
 using SymEngine::one;
 using SymEngine::parse;
+using SymEngine::parse_old;
 using SymEngine::ParseError;
 using SymEngine::pi;
 using SymEngine::piecewise;
@@ -60,6 +61,7 @@ using SymEngine::real_double;
 using SymEngine::RealDouble;
 using SymEngine::Symbol;
 using SymEngine::symbol;
+using SymEngine::truncate;
 using SymEngine::UIntPoly;
 using SymEngine::zero;
 
@@ -325,6 +327,23 @@ TEST_CASE("Parsing: functions", "[parser]")
     s = "floor(x) + ceiling(y)";
     res = parse(s);
     REQUIRE(eq(*res, *add(floor(x), ceiling(y))));
+    REQUIRE(eq(*res, *parse(res->__str__())));
+
+    s = "truncate(5.2)";
+    res = parse(s);
+    REQUIRE(eq(*res, *integer(5)));
+    REQUIRE(eq(*res, *parse(res->__str__())));
+
+    s = "truncate(x)";
+    res = parse(s);
+    REQUIRE(is_a<SymEngine::Truncate>(*res));
+    REQUIRE(eq(*res, *truncate(x)));
+    REQUIRE(eq(*res, *parse(res->__str__())));
+
+    s = "truncate(x + y)";
+    res = parse(s);
+    REQUIRE(is_a<SymEngine::Truncate>(*res));
+    REQUIRE(eq(*res, *truncate(add(x, y))));
     REQUIRE(eq(*res, *parse(res->__str__())));
 
     s = "beta(x, y)";
@@ -972,6 +991,15 @@ TEST_CASE("Parsing: errors", "[parser]")
 
     s = "And(x, y)";
     CHECK_THROWS_AS(parse(s), ParseError);
+}
+
+TEST_CASE("Parsing: parse_old handles truncate", "[parser]")
+{
+    RCP<const Basic> x = symbol("x");
+    auto res = parse_old("truncate(x)");
+
+    REQUIRE(is_a<SymEngine::Truncate>(*res));
+    REQUIRE(eq(*res, *truncate(x)));
 }
 
 TEST_CASE("Parsing: bison stack reallocation", "[parser]")

--- a/symengine/tests/basic/test_sbml_parser.cpp
+++ b/symengine/tests/basic/test_sbml_parser.cpp
@@ -57,6 +57,7 @@ using SymEngine::RealDouble;
 using SymEngine::sbml;
 using SymEngine::Symbol;
 using SymEngine::symbol;
+using SymEngine::truncate;
 using SymEngine::vec_basic;
 using SymEngine::zero;
 
@@ -406,6 +407,12 @@ TEST_CASE("Parsing: functions", "[sbml_parser]")
     s = "floor(x)";
     res = parse_sbml(s);
     REQUIRE(eq(*res, *floor(x)));
+    REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
+
+    s = "truncate(x)";
+    res = parse_sbml(s);
+    REQUIRE(is_a<SymEngine::Truncate>(*res));
+    REQUIRE(eq(*res, *truncate(x)));
     REQUIRE(eq(*res, *parse_sbml(sbml(*res))));
 
     s = "csc(x)";

--- a/symengine/tests/eval/test_lambda_double.cpp
+++ b/symengine/tests/eval/test_lambda_double.cpp
@@ -343,6 +343,15 @@ TEST_CASE("Evaluate functions", "[lambda_gamma]")
         std::make_tuple(abs(x), -1.112111321, 1.112111321),
         std::make_tuple(erf(x), 1.1, 0.88020506957408169),
         std::make_tuple(erfc(x), 2.1, 0.00297946665633298),
+        std::make_tuple(floor(x), 1.7, 1.0),
+        std::make_tuple(floor(x), -1.5, -2.0),
+        std::make_tuple(floor(x), 5.0, 5.0),
+        std::make_tuple(ceiling(x), 1.2, 2.0),
+        std::make_tuple(ceiling(x), -1.5, -1.0),
+        std::make_tuple(ceiling(x), 5.0, 5.0),
+        std::make_tuple(truncate(x), 2.7, 2.0),
+        std::make_tuple(truncate(x), -1.5, -1.0),
+        std::make_tuple(truncate(x), 5.0, 5.0),
     };
 
     for (unsigned i = 0; i < testvec.size(); i++) {
@@ -371,6 +380,32 @@ TEST_CASE("Evaluate functions", "[lambda_gamma]")
 }
 
 #ifdef HAVE_SYMENGINE_LLVM
+TEST_CASE("Evaluate rounding functions with LLVM", "[llvm_double]")
+{
+    auto x = symbol("x");
+
+    struct Case {
+        RCP<const Basic> expr;
+        double input;
+        double expected;
+    };
+
+    const std::vector<Case> cases = {
+        {floor(x), 1.7, 1.0},     {floor(x), -1.5, -2.0},
+        {floor(x), 5.0, 5.0},     {ceiling(x), 1.2, 2.0},
+        {ceiling(x), -1.5, -1.0}, {ceiling(x), 5.0, 5.0},
+        {truncate(x), 2.7, 2.0},  {truncate(x), -1.5, -1.0},
+        {truncate(x), 5.0, 5.0},
+    };
+
+    for (const auto &test_case : cases) {
+        LLVMDoubleVisitor llvm_double;
+        llvm_double.init({x}, *test_case.expr);
+        REQUIRE(llvm_double.call({test_case.input})
+                == Approx(test_case.expected));
+    }
+}
+
 TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
 {
 


### PR DESCRIPTION
Add native parsing of the `truncate(...)` syntax to all parsers.

`parse(SymEngine::truncate(x)->__str__())` now returns `SymEngine::Truncate` as one would expect from round-tripping.
Previously, parsing `"truncate(x)"` was resulting in an anonymous `FunctionSymbol("truncate", arg)`