### PR TITLE
CMake: disable hidden visibility in static builds

### DIFF
--- a/symengine/CMakeLists.txt
+++ b/symengine/CMakeLists.txt
@@ -287,7 +287,7 @@ add_library(symengine ${SRC})
 set_target_properties (symengine PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 include(CMakeDependentOption)
-cmake_dependent_option(WITH_VISIBILITY_HIDDEN "Build shared libraries with hidden visibility for private functions" ON "NOT WITH_PIRANHA" OFF)
+cmake_dependent_option(WITH_VISIBILITY_HIDDEN "Build shared libraries with hidden visibility for private functions" ON "BUILD_SHARED_LIBS AND NOT WITH_PIRANHA" OFF)
 
 if (WITH_VISIBILITY_HIDDEN)
     set_target_properties(symengine PROPERTIES


### PR DESCRIPTION
WITH_VISIBILITY_HIDDEN applies to static libraries despite being documented for shared libraries. This hides SymEngine template instantiations required by downstream serialization-hook overloads. As a result, symengine.py cannot apply PySymbol's save_basic/load_basic overrides, and pickle round-trips discard Python Symbol subclasses.

Enable the option only when BUILD_SHARED_LIBS is enabled. Shared builds retain hidden visibility.