### PR TITLE
Fix Unicode printer dropping leading minus on first term

### DIFF
--- a/symengine/printers/unicode.cpp
+++ b/symengine/printers/unicode.cpp
@@ -437,7 +437,14 @@ void UnicodePrinter::bvisit(const Add &x)
                 box.add_right(t);
             }
         } else {
-            box.add_right(t);
+            if (minus) {
+                StringBox op("- ");
+                box.add_right(op);
+                box.add_right(t);
+                minus = false;
+            } else {
+                box.add_right(t);
+            }
             first = false;
         }
     }

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -1080,6 +1080,20 @@ TEST_CASE("test_unicode()", "[unicode]")
     // https://github.com/symengine/symengine/issues/2029
     s = unicode(*mul(mul(x, x), y));
     CHECK(s == U8(" 2  \nx \u22C5y"));
+
+    // https://github.com/symengine/symengine/issues/2131
+    s = unicode(*add(mul(integer(-1), parse("sin(x)")), parse("cos(x)")));
+    CHECK(s.find("- ") != std::string::npos);
+
+    s = unicode(*add(mul(integer(-1), x), integer(1)));
+    CHECK(s == U8("1 - x"));
+
+    s = unicode(*add(mul(integer(-2), x), parse("cos(x)")));
+    CHECK(s.find("- ") != std::string::npos);
+
+    s = unicode(*add(mul(integer(-1), parse("sin(x)")),
+                     mul(integer(-1), parse("cos(x)"))));
+    CHECK(s.find("- ") == 0);
 }
 
 TEST_CASE("test_stringbox()", "[stringbox]")


### PR DESCRIPTION
When the first term of an Add expression had a negative coefficient, the minus sign was silently dropped.
For example, -sin(x)+cos(x) printed as sin(x)+cos(x).

Closes #2131