### PR TITLE
Fix Eq() to evaluate numerically equal int/float expressions

### DIFF
--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -1,4 +1,6 @@
 #include <symengine/logic.h>
+#include <symengine/add.h>
+#include <symengine/basic.h>
 
 namespace SymEngine
 {
@@ -655,6 +657,10 @@ RCP<const Boolean> Eq(const RCP<const Basic> &lhs, const RCP<const Basic> &rhs)
         if ((is_a_Number(*lhs) and is_a_Number(*rhs))
             or (is_a<BooleanAtom>(*lhs) and is_a<BooleanAtom>(*rhs)))
             return boolean(false);
+        RCP<const Basic> diff = expand(sub(lhs, rhs));
+        if (is_number_and_zero(*diff)) {
+            return boolean(true);
+        }
         if (lhs->__cmp__(*rhs) == 1)
             return make_rcp<const Equality>(rhs, lhs);
         return make_rcp<Equality>(lhs, rhs);

--- a/symengine/tests/basic/test_relationals.cpp
+++ b/symengine/tests/basic/test_relationals.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <symengine/logic.h>
 #include <symengine/add.h>
+#include <symengine/mul.h>
 #include <symengine/real_double.h>
 #include <symengine/complex_double.h>
 
@@ -23,6 +24,7 @@ using SymEngine::Le;
 using SymEngine::logical_not;
 using SymEngine::Lt;
 using SymEngine::make_rcp;
+using SymEngine::mul;
 using SymEngine::Nan;
 using SymEngine::Ne;
 using SymEngine::NegInf;
@@ -146,6 +148,12 @@ TEST_CASE("Eq", "[Relationals]")
     CHECK(eq(*Eq(a, b), *boolTrue));
     CHECK(eq(*Eq(sub(b, y), x), *boolTrue));
     CHECK(eq(*Eq(add(x, real_double(0.0)), x), *boolTrue));
+
+    CHECK(eq(*Eq(mul(mul(integer(2), x), y), mul(mul(real_double(2.0), x), y)),
+             *boolTrue));
+    CHECK(eq(*Eq(mul(x, y), mul(real_double(1.0), mul(x, y))), *boolTrue));
+    CHECK(eq(*Eq(add(add(x, y), integer(2)), add(add(x, y), real_double(2.0))),
+             *boolTrue));
 }
 
 TEST_CASE("Infinity", "[Relationals]")


### PR DESCRIPTION
Eq() now tries expand(sub(lhs, rhs)) to check if the result is zero when structural equality fails. This makes Eq(2*x*y, 2.0*x*y), Eq(x*y, 1.0*x*y), and Eq(x+y+2, x+y+2.0) return True, matching SymPy behavior.

Closes #1340