### PR TITLE
Fix atan2 incorrect evaluation for symbolic expressions

### DIFF
--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -565,6 +565,13 @@ RCP<const Basic> sign(const RCP<const Basic> &arg)
         return mul(s,
                    make_rcp<const Sign>(Mul::from_dict(one, std::move(dict))));
     }
+    if (is_a<Pow>(*arg)) {
+        RCP<const Pow> pow_arg = rcp_static_cast<const Pow>(arg);
+        RCP<const Basic> s = sign(pow_arg->get_base());
+        if (not is_a<Sign>(*s) and not eq(*s, *pow_arg->get_base())) {
+            return sign(pow(s, pow_arg->get_exp()));
+        }
+    }
     return make_rcp<const Sign>(arg);
 }
 
@@ -1595,8 +1602,14 @@ ATan2::ATan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
 bool ATan2::is_canonical(const RCP<const Basic> &num,
                          const RCP<const Basic> &den) const
 {
-    if (eq(*num, *zero) or eq(*num, *den) or eq(*num, *mul(minus_one, den)))
+    if (eq(*num, *den) or eq(*num, *mul(minus_one, den)))
         return false;
+    if (eq(*num, *zero)) {
+        return not(is_a_Number(*den) or eq(*den, *zero));
+    }
+    if (eq(*den, *zero)) {
+        return not is_a_Number(*num);
+    }
     RCP<const Basic> index;
     bool b = inverse_lookup(inverse_tct(), div(num, den), outArg(index));
     if (b)
@@ -1614,6 +1627,9 @@ RCP<const Basic> ATan2::create(const RCP<const Basic> &a,
 RCP<const Basic> atan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
 {
     if (eq(*num, *zero)) {
+        if (eq(*den, *zero)) {
+            return Nan;
+        }
         if (is_a_Number(*den)) {
             RCP<const Number> den_new = rcp_static_cast<const Number>(den);
             if (den_new->is_negative())
@@ -1624,6 +1640,7 @@ RCP<const Basic> atan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
                 return Nan;
             }
         }
+        return make_rcp<const ATan2>(num, den);
     } else if (eq(*den, *zero)) {
         if (is_a_Number(*num)) {
             RCP<const Number> num_new = rcp_static_cast<const Number>(num);
@@ -1632,36 +1649,17 @@ RCP<const Basic> atan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
             else
                 return div(pi, i2);
         }
+        return make_rcp<const ATan2>(num, den);
     }
     RCP<const Basic> index;
     bool b = inverse_lookup(inverse_tct(), div(num, den), outArg(index));
     if (b) {
-        // Ideally the answer should depend on the signs of `num` and `den`
-        // Currently is_positive() and is_negative() is not implemented for
-        // types other than `Number`
-        // Hence this will give exact answers in case when num and den are
-        // numbers in SymEngine sense and when num and den are positive.
-        // for the remaining cases in which we just return the value from
-        // the lookup table.
-        // TODO: update once is_positive() and is_negative() is implemented
-        // in `Basic`
-        if (is_a_Number(*den) and is_a_Number(*num)) {
-            RCP<const Number> den_new = rcp_static_cast<const Number>(den);
-            RCP<const Number> num_new = rcp_static_cast<const Number>(num);
-
-            if (den_new->is_positive()) {
-                return div(pi, index);
-            } else if (den_new->is_negative()) {
-                if (num_new->is_negative()) {
-                    return sub(div(pi, index), pi);
-                } else {
-                    return add(div(pi, index), pi);
-                }
-            } else {
-                return div(pi, index);
-            }
+        SYMENGINE_ASSERT(is_a_Number(*index));
+        RCP<const Number> index_num = rcp_static_cast<const Number>(index);
+        if (index_num->is_positive()) {
+            return add(div(pi, index), mul(div(pi, i2), sub(sign(den), one)));
         } else {
-            return div(pi, index);
+            return sub(div(pi, index), mul(div(pi, i2), sub(sign(den), one)));
         }
     } else {
         return make_rcp<const ATan2>(num, den);

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -2227,7 +2227,7 @@ TEST_CASE("Atan2: functions", "[functions]")
     REQUIRE(eq(*r1, *r2));
 
     r1 = atan2(add(one, sqrt(i2)), im1);
-    r2 = div(mul(pi, i3), integer(-8));
+    r2 = div(mul(pi, i5), integer(8));
     REQUIRE(eq(*r1, *r2));
 
     r1 = atan2(sub(sqrt(i2), one), i1);
@@ -2239,7 +2239,7 @@ TEST_CASE("Atan2: functions", "[functions]")
     REQUIRE(eq(*r1, *r2));
 
     r1 = atan2(sqrt(add(i5, mul(i2, sqrt(i5)))), im1);
-    r2 = div(mul(pi, im2), i5);
+    r2 = div(mul(pi, i3), i5);
     REQUIRE(eq(*r1, *r2));
 
     r1 = atan2(y, x)->diff(x);
@@ -2270,6 +2270,16 @@ TEST_CASE("Atan2: functions", "[functions]")
     r2 = mul(div(pi, i2), minus_one);
     REQUIRE(eq(*r1, *r2));
 
+    r1 = atan2(x, x);
+    r2 = add(div(pi, integer(4)), mul(div(pi, i2), sub(sign(x), one)));
+    REQUIRE(eq(*r1, *r2));
+
+    r1 = atan2(zero, x);
+    REQUIRE(unified_eq(r1->get_args(), {zero, x}));
+
+    r1 = atan2(x, zero);
+    REQUIRE(unified_eq(r1->get_args(), {x, zero}));
+
     RCP<const ATan2> r4 = make_rcp<ATan2>(i2, i3);
     REQUIRE(not(r4->is_canonical(zero, i2)));
     REQUIRE(not(r4->is_canonical(zero, zero)));
@@ -2277,6 +2287,8 @@ TEST_CASE("Atan2: functions", "[functions]")
     REQUIRE(not(r4->is_canonical(i2, neg(i2))));
     REQUIRE(r4->is_canonical(i2, i3));
     REQUIRE(not(r4->is_canonical(one, sqrt(i3))));
+    REQUIRE(r4->is_canonical(zero, x));
+    REQUIRE(r4->is_canonical(x, zero));
 }
 
 TEST_CASE("Lambertw: functions", "[functions]")


### PR DESCRIPTION
atan2(a,a) now returns pi/4 + pi/2*(sign(a)-1) instead of always pi/4. atan2(0,x) and atan2(x,0) with symbolic args remain unevaluated. Uses sign(den) for quadrant adjustment in the inverse lookup path.

Closes #1806