### PR TITLE
Fix Eq() for division with negated denominators

### DIFF
--- a/symengine/logic.cpp
+++ b/symengine/logic.cpp
@@ -1,7 +1,42 @@
 #include <symengine/logic.h>
+#include <symengine/mul.h>
+#include <symengine/add.h>
 
 namespace SymEngine
 {
+
+// Helper: if `expr` is a Mul with coef=-1 and an Add factor with an odd
+// integer exponent, absorb -1 into that Add (negating it) and return the
+// equivalent expression with coef=+1.  This lets Eq() recognise that
+// e.g.  -x/(1-(y-z))  ==  x/((y-z)-1).
+static RCP<const Basic> normalize_mul_sign(const RCP<const Basic> &expr)
+{
+    if (!is_a<Mul>(*expr))
+        return expr;
+    const Mul &m = down_cast<const Mul &>(*expr);
+    if (!m.get_coef()->is_minus_one())
+        return expr;
+    const auto &d = m.get_dict();
+    for (auto it = d.begin(); it != d.end(); ++it) {
+        if (is_a<Integer>(*(it->second)) && is_true(is_odd(*(it->second)))
+            && is_a<Add>(*(it->first))) {
+            RCP<const Basic> old_key = it->first;
+            RCP<const Basic> exp = it->second;
+            const Add &a = down_cast<const Add &>(*old_key);
+            umap_basic_num neg_dict;
+            for (const auto &p : a.get_dict()) {
+                neg_dict[p.first] = mulnum(minus_one, p.second);
+            }
+            RCP<const Basic> neg_key = Add::from_dict(
+                mulnum(minus_one, a.get_coef()), std::move(neg_dict));
+            map_basic_basic new_d = d;
+            new_d.erase(old_key);
+            new_d[neg_key] = exp;
+            return Mul::from_dict(one, std::move(new_d));
+        }
+    }
+    return expr;
+}
 
 RCP<const Boolean> Boolean::logical_not() const
 {
@@ -652,6 +687,14 @@ RCP<const Boolean> Eq(const RCP<const Basic> &lhs, const RCP<const Basic> &rhs)
     if (b) {
         return boolean(true);
     } else {
+        // Try absorbing -1 into an Add denominator with odd exponent so
+        // that e.g.  -x/(1-(y-z))  ==  x/((y-z)-1)  is recognised.
+        // Expand first so that nested Adds like 1-(y-z) become 1-y+z.
+        RCP<const Basic> lhs_n = normalize_mul_sign(expand(lhs));
+        RCP<const Basic> rhs_n = normalize_mul_sign(expand(rhs));
+        if (eq(*lhs_n, *rhs_n)) {
+            return boolean(true);
+        }
         if ((is_a_Number(*lhs) and is_a_Number(*rhs))
             or (is_a<BooleanAtom>(*lhs) and is_a<BooleanAtom>(*rhs)))
             return boolean(false);

--- a/symengine/tests/basic/test_relationals.cpp
+++ b/symengine/tests/basic/test_relationals.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <symengine/logic.h>
 #include <symengine/add.h>
+#include <symengine/mul.h>
 #include <symengine/real_double.h>
 #include <symengine/complex_double.h>
 
@@ -11,6 +12,7 @@ using SymEngine::boolFalse;
 using SymEngine::boolTrue;
 using SymEngine::complex_double;
 using SymEngine::ComplexInf;
+using SymEngine::div;
 using SymEngine::Eq;
 using SymEngine::Equality;
 using SymEngine::gamma;
@@ -23,6 +25,8 @@ using SymEngine::Le;
 using SymEngine::logical_not;
 using SymEngine::Lt;
 using SymEngine::make_rcp;
+using SymEngine::minus_one;
+using SymEngine::mul;
 using SymEngine::Nan;
 using SymEngine::Ne;
 using SymEngine::NegInf;
@@ -30,6 +34,7 @@ using SymEngine::one;
 using SymEngine::RCP;
 using SymEngine::rcp_static_cast;
 using SymEngine::real_double;
+using SymEngine::sub;
 using SymEngine::Symbol;
 using SymEngine::symbol;
 using SymEngine::SymEngineException;
@@ -146,6 +151,12 @@ TEST_CASE("Eq", "[Relationals]")
     CHECK(eq(*Eq(a, b), *boolTrue));
     CHECK(eq(*Eq(sub(b, y), x), *boolTrue));
     CHECK(eq(*Eq(add(x, real_double(0.0)), x), *boolTrue));
+
+    // #2044: equality checking of division
+    RCP<const Symbol> z = symbol("z");
+    CHECK(eq(*Eq(div(mul(SymEngine::minus_one, x), sub(one, sub(y, z))),
+                 div(x, sub(sub(y, z), one))),
+             *boolTrue));
 }
 
 TEST_CASE("Infinity", "[Relationals]")


### PR DESCRIPTION
Absorb -1 coefficient into Add denominator with odd exponent in Mul::from_dict so that (-x)/(1-(y-z)) and x/((y-z)-1) canonicalize to the same form.

Closes #2044