### PR TITLE
Fix is_nth_residue returning false positives for negative values

### DIFF
--- a/symengine/ntheory.cpp
+++ b/symengine/ntheory.cpp
@@ -1592,10 +1592,13 @@ i.e a % mod in set([i**n % mod for i in range(mod)]).
     prime_factor_multiplicities(prime_mul, *mod2);
     bool ret_val;
 
+    integer_class a_mod = a.as_integer_class();
+    mp_fdiv_r(a_mod, a_mod, _mod);
+
     for (const auto &it : prime_mul) {
-        ret_val = _is_nthroot_mod_prime_power(
-            a.as_integer_class(), n.as_integer_class(),
-            it.first->as_integer_class(), it.second);
+        ret_val = _is_nthroot_mod_prime_power(a_mod, n.as_integer_class(),
+                                              it.first->as_integer_class(),
+                                              it.second);
         if (not ret_val)
             return false;
     }

--- a/symengine/tests/ntheory/test_ntheory.cpp
+++ b/symengine/tests/ntheory/test_ntheory.cpp
@@ -858,6 +858,10 @@ TEST_CASE("test_is_nth_residue(): ntheory", "[ntheory]")
     REQUIRE(is_nth_residue(*i32, *i10, *zero) == false);
     REQUIRE(is_nth_residue(*i32, *i10, *i1) == true);
     REQUIRE(is_nth_residue(*i32, *i10, *im1) == true);
+
+    // Test for issue #2136: is_nth_residue returns false positives for negative
+    // values
+    REQUIRE(is_nth_residue(*im1, *i2, *i4) == false);
 }
 
 TEST_CASE("test_mobius(): ntheory", "[ntheory]")


### PR DESCRIPTION
Normalize `a` modulo `mod` using `mp_fdiv_r` before passing it to `_is_nthroot_mod_prime_power` in `is_nth_residue`. This ensures negative values are properly reduced to their canonical residue class, so equivalent residues produce the same result.

Closes #2136