### PR TITLE
sets: fix Intersection::contains and Union::contains

### DIFF
--- a/symengine/sets.cpp
+++ b/symengine/sets.cpp
@@ -1265,13 +1265,18 @@ RCP<const Set> Union::set_complement(const RCP<const Set> &o) const
 
 RCP<const Boolean> Union::contains(const RCP<const Basic> &o) const
 {
+    bool has_contains = false;
     for (auto &a : container_) {
         auto contain = a->contains(o);
         if (eq(*contain, *boolTrue)) {
             return boolean(true);
         }
-        if (is_a<Contains>(*contain))
-            throw NotImplementedError("Not implemented");
+        if (is_a<Contains>(*contain)) {
+            has_contains = true;
+        }
+    }
+    if (has_contains) {
+        return make_rcp<Contains>(o, rcp_from_this_cast<const Set>());
     }
     return boolean(false);
 }
@@ -1360,15 +1365,19 @@ RCP<const Set> Intersection::set_complement(const RCP<const Set> &o) const
 
 RCP<const Boolean> Intersection::contains(const RCP<const Basic> &o) const
 {
+    bool has_contains = false;
     for (auto &a : container_) {
         auto contain = a->contains(o);
-        if (eq(*contain, *boolTrue)) {
-            return boolean(true);
+        if (is_a<Contains>(*contain)) {
+            has_contains = true;
+        } else if (eq(*contain, *boolFalse)) {
+            return boolean(false);
         }
-        if (is_a<Contains>(*contain))
-            throw NotImplementedError("Not implemented");
     }
-    return boolean(false);
+    if (has_contains) {
+        return make_rcp<Contains>(o, rcp_from_this_cast<const Set>());
+    }
+    return boolean(true);
 }
 
 RCP<const Set> Intersection::create(const set_set &in) const

--- a/symengine/tests/basic/test_sets.cpp
+++ b/symengine/tests/basic/test_sets.cpp
@@ -29,6 +29,7 @@ using SymEngine::Eq;
 using SymEngine::FiniteSet;
 using SymEngine::finiteset;
 using SymEngine::Gt;
+using SymEngine::I;
 using SymEngine::ImageSet;
 using SymEngine::imageset;
 using SymEngine::Inf;
@@ -37,6 +38,7 @@ using SymEngine::Integer;
 using SymEngine::integer;
 using SymEngine::Integers;
 using SymEngine::integers;
+using SymEngine::Intersection;
 using SymEngine::Interval;
 using SymEngine::interval;
 using SymEngine::is_a;
@@ -1496,4 +1498,53 @@ TEST_CASE("interior : Basic", "[basic]")
     REQUIRE(eq(*interior(*i1), *i2));
     REQUIRE(eq(*interior(*i2), *i2));
     REQUIRE(eq(*interior(*set_union({i1, i3})), *set_union({i2, i4})));
+}
+
+TEST_CASE("Intersection : contains", "[basic]")
+{
+    auto x = symbol("x");
+
+    // Intersection(Reals, {x}) - symbolic element
+    auto s1 = set_intersection({reals(), finiteset({x})});
+    REQUIRE(is_a<Intersection>(*s1));
+    REQUIRE(eq(*s1->contains(x), *make_rcp<Contains>(x, s1)));
+    // Eq(1, x) is undecidable, so Intersection::contains returns Contains
+    REQUIRE(eq(*s1->contains(one), *make_rcp<Contains>(one, s1)));
+
+    // Intersection(Reals, {1+I, 1-I}) simplifies to EmptySet
+    auto s2
+        = set_intersection({reals(), finiteset({add(one, I), sub(one, I)})});
+    REQUIRE(eq(*s2, *emptyset()));
+    REQUIRE(eq(*s2->contains(one), *boolFalse));
+
+    // Intersection of finite sets
+    auto s3
+        = set_intersection({finiteset({one, integer(2), integer(3)}),
+                            finiteset({integer(2), integer(3), integer(4)})});
+    REQUIRE(eq(*s3->contains(one), *boolFalse));
+    REQUIRE(eq(*s3->contains(integer(2)), *boolTrue));
+    REQUIRE(eq(*s3->contains(integer(3)), *boolTrue));
+    REQUIRE(eq(*s3->contains(integer(5)), *boolFalse));
+
+    // Intersection(Reals, Integers) simplifies to Integers
+    auto s4 = set_intersection({reals(), integers()});
+    REQUIRE(eq(*s4->contains(one), *boolTrue));
+    REQUIRE(eq(*s4->contains(x), *make_rcp<Contains>(x, s4)));
+}
+
+TEST_CASE("Union : contains", "[basic]")
+{
+    auto x = symbol("x");
+
+    // Union of finite sets
+    auto u1 = set_union(
+        {finiteset({one, integer(2)}), finiteset({integer(3), integer(4)})});
+    REQUIRE(eq(*u1->contains(one), *boolTrue));
+    REQUIRE(eq(*u1->contains(integer(3)), *boolTrue));
+    REQUIRE(eq(*u1->contains(integer(5)), *boolFalse));
+
+    // Union(Reals, {x}) - x is in the finite set, not in Reals
+    auto u2 = set_union({reals(), finiteset({x})});
+    REQUIRE(eq(*u2->contains(one), *boolTrue));
+    REQUIRE(eq(*u2->contains(x), *boolTrue));
 }


### PR DESCRIPTION
Intersection::contains had two bugs:
- Returned true if ANY component set contained the element (union semantics) instead of requiring ALL component sets (intersection semantics)
- Threw NotImplementedError when a sub-set returned a Contains expression

Union::contains also threw NotImplementedError in the same case.

Both now return a symbolic Contains expression when containment cannot be decided, instead of throwing.