### PR TITLE
Fix negative number parenthesization in Mul printing

### DIFF
--- a/symengine/printers/strprinter.cpp
+++ b/symengine/printers/strprinter.cpp
@@ -596,7 +596,7 @@ void StrPrinter::bvisit(const Mul &x)
             and down_cast<const Number &>(*p.second).is_negative()
             and neq(*(p.first), *E)) {
             if (eq(*(p.second), *minus_one)) {
-                o2 << parenthesizeLT(p.first, PrecedenceEnum::Mul);
+                o2 << parenthesizeLE(p.first, PrecedenceEnum::Mul);
             } else {
                 _print_pow(o2, p.first, neg(p.second));
             }
@@ -604,7 +604,7 @@ void StrPrinter::bvisit(const Mul &x)
             den++;
         } else {
             if (eq(*(p.second), *one)) {
-                o << parenthesizeLT(p.first, PrecedenceEnum::Mul);
+                o << parenthesizeLE(p.first, PrecedenceEnum::Mul);
             } else {
                 _print_pow(o, p.first, p.second);
             }

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -302,6 +302,23 @@ TEST_CASE("test_printing(): printing", "[printing]")
     r1 = Subs::create(Derivative::create(function_symbol("f", {y, x}), {x}),
                       {{x, add(x, y)}});
     REQUIRE(r1->__str__() == "Subs(Derivative(f(y, x), x), (x), (x + y))");
+
+    // Issue #2091: Negative numbers in Mul should be parenthesized
+    // Test that mul with negative rational factor prints correctly
+    r = mul(Rational::from_two_ints(*integer(1), *integer(20)),
+            Rational::from_two_ints(*integer(-1), *integer(2)));
+    REQUIRE(r->__str__() == "-1/40");
+
+    // Negative coefficient still prints correctly (without extra parens)
+    r = mul(real_double(-0.5), x);
+    REQUIRE(r->__str__() == "-0.5*x");
+
+    r = mul(integer(-2), x);
+    REQUIRE(r->__str__() == "-2*x");
+
+    // Add with negative Mul term
+    r = add(real_double(0.95), mul(real_double(-0.5), x));
+    REQUIRE(r->__str__() == "0.95 - 0.5*x");
 }
 
 TEST_CASE("test_matrix(): printing", "[printing]")


### PR DESCRIPTION
When negative numbers appear as factors in a Mul expression's dict, they were printed without parentheses (e.g. `0.05*-0.5` instead of `0.05*(-0.5)`). In LaTeX this produced ambiguous output like `0.05 -0.5` that looked like subtraction.

Closes #2091