### PR TITLE
series: Replace Poly /= Coeff with Poly = Poly / Coeff

### DIFF
--- a/symengine/series.h
+++ b/symengine/series.h
@@ -232,7 +232,7 @@ public:
             throw SymEngineException(
                 "reversion of series with zero term of degree one");
         Poly r(var);
-        r /= a;
+        r = r / a;
         for (unsigned int i = 2; i < prec; i++) {
             Poly sp = Series::subs(s, var, r, i + 1);
             r -= Series::pow(var, i, i + 1) * Series::find_cf(sp, var, i) / a;


### PR DESCRIPTION
fmpq_poly_wrapper (FLINT polynomial type) does not define operator/=, which causes error C2676 on MSVC. GCC silently decomposes r /= a into r = r / a, but MSVC requires the compound assignment operator to exist.